### PR TITLE
add data model section in design doc

### DIFF
--- a/doc/design.md
+++ b/doc/design.md
@@ -215,6 +215,45 @@ Returns:
     * tbd
 
 
+Data Model
+----------
+
+#### Record:
+ - cases :: type list[Case]
+
+#### Case:
+ - name
+ - birth_year
+ - case_number
+ - citation_number
+ - date
+ - location
+ - violation_type
+ - current_status
+ - balance_due_in_cents
+ - case_detail_link
+ - charges # type list[Charge]
+
+#### Charge:
+ - name
+ - statute
+ - level
+ - date
+ - disposition :: type list[Disposition]
+ - expungement_result :: type ExpungementResult
+
+#### Disposition:
+ - date
+ - ruling
+
+#### ExpungementResult:
+ - type_eligibility
+ - type_eligibility_reason
+ - time_eligibility
+ - time_eligibility_reason
+ - date_of_eligibility
+
+
 Database Schema
 ---------------
 


### PR DESCRIPTION
This just starts a section for the data objects used by the expungeservice. 

Record doesn't currently exist as an explicit class but implicitly as just a list of cases, so is included here.  

Section is subject to change, but this is a start.