### PR TITLE
Create dependabot config file

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -14,3 +14,9 @@ update_configs:
     default_labels:
     - "frontend"
     - "dependencies"
+
+  - package_manager: "docker"
+    directory: "/src/backend/expungeservice"
+    update_schedule: "daily"
+    default_labels:
+    - "dependencies"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,16 @@
+version: 1
+
+update_configs:
+  - package_manager: "python"
+    directory: "/"
+    update_schedule: "live"
+    default_labels:
+    - "backend"
+    - "dependencies"
+
+  - package_manager: "javascript"
+    directory: "/src/frontend"
+    update_schedule: "live"
+    default_labels:
+    - "frontend"
+    - "dependencies"


### PR DESCRIPTION
This directs dependabot to look for front end javascript dependencies as
well as the backend python dependencies.

@erikjasso @wittejm Are there docker dependencies that need to be maintained as well? If so where are they located?

Fixes #102 