### PR TITLE
Database tables and doc update

### DIFF
--- a/config/postgres/initdb/scripts/create-tables.sql
+++ b/config/postgres/initdb/scripts/create-tables.sql
@@ -15,9 +15,8 @@ CREATE TABLE users (
 CREATE TABLE auth (
     auth_id         UUID NOT NULL,
     hashed_password TEXT NOT NULL,
-    password_salt   TEXT NOT NULL,
-    PRIMARY KEY (auth_id),
-    user_id        UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE
+    user_id        UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    PRIMARY KEY (auth_id)
 );
 
 

--- a/doc/design.md
+++ b/doc/design.md
@@ -274,3 +274,30 @@ Notes:
 
 - Store passwords encrypted
 - Use Postgres features for exporting JSON
+
+Database Functions
+--------------
+Functions that query or update the database will be organized into a single module in the expungeservice.
+
+    create_user(database, email, admin, hashed_password)
+
+Insert a new user into the Users table with the given email string and admin flag, and inserts the password hash into the Auth table and link it with the User uuid. The uuid of each, and the date_created and date_updated are generated within the database.
+
+This pair of inserts is an atomic operation, so if one fails then the other one is cancelled and has no effect.
+Returns None if insert is successful; otherwise throws an informative error.
+
+    get_password_hash(database, email)
+
+Return the password_hash associated with an email. The password hash can then be compared against a password in the calling code. If the user doesn't exist, an informative error is thrown. Otherwise, the function returns the password hash value.
+
+    check_user(database, email)
+
+Check the Users table to see if a user with the given email already exists. Returns boolean. If query fails, throws an error.
+
+    save_stats(database, email, record)
+
+Takes a Record object which has processed by the expungement analyzer. Saves only a limited amount of information. Details tbd, but here are a few examples for tracking app usage and app impact:
+ -  User activity: When a search is performed, log the username and timestamp; but not the search parameters.
+  - Expunged charges: record the individual charges, by their crime level, some eligibility information, and the month that the search was performed.
+     * An inexact timestamp makes it hard to reconstruct a complete record which could then be de-anonymized.
+     * Eligibility information could be kept vague, e.g, only "eligible", "not eligible", "time-eligible", and "undetermined", as opposed to keeping the detailed analysis returned by the expunger.

--- a/doc/design.md
+++ b/doc/design.md
@@ -259,7 +259,9 @@ Database Schema
 
 Tables:
 
-    users (uuid, email, hashed_password, password_salt, admin, date_created, date_modified), uuid primary key
+    users (uuid, email, admin, date_created, date_modified), uuid primary key
+
+    auth (uuid, hashed_password, user_id), uuid primary key
 
     clients (uuid, first_name, last_name, dob, date_created, date_modified), uuid primary key
 
@@ -267,37 +269,10 @@ Tables:
 
     rules (uuid, text)
 
-    analysis (client_id, case_id, result_code, statute, date_eligible, rules[], date_created, date_modified, expunged, date_expunged) 
+    analyses (client_id, case_id, result_code, statute, date_eligible, rules[], date_created, date_modified, expunged, date_expunged)
 
 
 Notes:
 
 - Store passwords encrypted
 - Use Postgres features for exporting JSON
-
-Database Functions
---------------
-Functions that query or update the database will be organized into a single module in the expungeservice.
-
-    create_user(database, email, admin, hashed_password)
-
-Insert a new user into the Users table with the given email string and admin flag, and inserts the password hash into the Auth table and link it with the User uuid. The uuid of each, and the date_created and date_updated are generated within the database.
-
-This pair of inserts is an atomic operation, so if one fails then the other one is cancelled and has no effect.
-Returns None if insert is successful; otherwise throws an informative error.
-
-    get_password_hash(database, email)
-
-Return the password_hash associated with an email. The password hash can then be compared against a password in the calling code. If the user doesn't exist, an informative error is thrown. Otherwise, the function returns the password hash value.
-
-    check_user(database, email)
-
-Check the Users table to see if a user with the given email already exists. Returns boolean. If query fails, throws an error.
-
-    save_stats(database, email, record)
-
-Takes a Record object which has processed by the expungement analyzer. Saves only a limited amount of information. Details tbd, but here are a few examples for tracking app usage and app impact:
- -  User activity: When a search is performed, log the username and timestamp; but not the search parameters.
-  - Expunged charges: record the individual charges, by their crime level, some eligibility information, and the month that the search was performed.
-     * An inexact timestamp makes it hard to reconstruct a complete record which could then be de-anonymized.
-     * Eligibility information could be kept vague, e.g, only "eligible", "not eligible", "time-eligible", and "undetermined", as opposed to keeping the detailed analysis returned by the expunger.

--- a/src/backend/expungeservice/database/user.py
+++ b/src/backend/expungeservice/database/user.py
@@ -1,0 +1,34 @@
+"""
+All database ops on the Users and Auth tables
+"""
+
+
+def create_user(database, email, password_hash, admin):
+    """
+
+    """
+    query = """ INSERT INTO USERS () ( """ 
+
+    database.cursor.execute(""" BEGIN; """)
+
+    """
+    Can 
+    """
+
+def check_user(database, email):
+    """
+    
+    """
+
+    query = """ SELECT """
+
+
+def get_password_hash(database, email):
+    """
+
+    """
+
+def user_is_admin(database, email):
+    """
+    
+    """

--- a/src/backend/tests/database/test_database.py
+++ b/src/backend/tests/database/test_database.py
@@ -1,0 +1,27 @@
+import unittest
+import os
+from expungeservice.database import Database
+from expungeservice.database import user
+
+
+class TestDatabaseOperations(unittest.TestCase):
+
+    def setUp(self):
+
+        password=""
+        #password = os.environ['POSTGRES_PASSWORD']
+
+        self.database = Database(host="localhost", port="5432", 
+            name="record_expunge", username="postgres", 
+            password=password)
+
+    def test_database_connection(self):
+
+        query = 'SELECT * FROM users;'
+        self.database.cursor.execute(query, ())
+        rows = self.database.cursor.fetchall()
+        assert rows or rows == []
+
+    def test_create_user(self):
+
+        d


### PR DESCRIPTION
Password salt is not stored separately in the database because it is encoded as part of the password hash. 
Also just a minor doc update to the database schema to match what is defined in create_tables.sql
