### PR TITLE
remove password salt from auth table; update doc to match sql schema

### DIFF
--- a/config/postgres/initdb/scripts/create-tables.sql
+++ b/config/postgres/initdb/scripts/create-tables.sql
@@ -15,9 +15,8 @@ CREATE TABLE users (
 CREATE TABLE auth (
     auth_id         UUID NOT NULL,
     hashed_password TEXT NOT NULL,
-    password_salt   TEXT NOT NULL,
-    PRIMARY KEY (auth_id),
-    user_id        UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE
+    user_id        UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    PRIMARY KEY (auth_id)
 );
 
 

--- a/doc/design.md
+++ b/doc/design.md
@@ -259,7 +259,9 @@ Database Schema
 
 Tables:
 
-    users (uuid, email, hashed_password, password_salt, admin, date_created, date_modified), uuid primary key
+    users (uuid, email, admin, date_created, date_modified), uuid primary key
+
+    auth (uuid, hashed_password, user_id), uuid primary key
 
     clients (uuid, first_name, last_name, dob, date_created, date_modified), uuid primary key
 
@@ -267,7 +269,7 @@ Tables:
 
     rules (uuid, text)
 
-    analysis (client_id, case_id, result_code, statute, date_eligible, rules[], date_created, date_modified, expunged, date_expunged) 
+    analyses (client_id, case_id, result_code, statute, date_eligible, rules[], date_created, date_modified, expunged, date_expunged)
 
 
 Notes:


### PR DESCRIPTION
Password salt is not stored separately in the database because it is encoded as part of the password hash.
Also just a minor doc update to the database schema to match what is defined in create_tables.sql