### PR TITLE
build and deploy docker stack in Travis-CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+PGHOST=localhost
+PGUSER=postgres
+PGPORT=5432
+PGDATABASE=record_expunge
+POSTGRES_PASSWORD=b30a95e5-246f-44fe-b47e-0aaf5b7a7a7c

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,12 @@ addons:
       - docker-ce
 before_install:
 - docker swarm init
-- cp ./.env.example ./.env
 install:
 - pip install pipenv
 - pipenv install
 - make dev
 before_script:
-- counter=0 ; while ((counter < 10)) && ! pg_isready --host=$PGHOST --port=$PGPORT --dbname=$PGDATABASE ; do sleep 3; let counter=counter+1; done
+- counter=0 ; while ((counter < 20)) && ! pg_isready --host=$PGHOST --port=$PGPORT --dbname=$PGDATABASE ; do sleep 3; let counter=counter+1; done
 script:
 - pipenv run pytest
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,21 @@ language: python
 sudo: required
 dist: xenial
 python: 3.7.0
+services:
+- docker
+addons:
+  apt:
+    packages:
+      - docker-ce
+before_install:
+- docker swarm init
+- cp ./.env.example ./.env
 install:
 - pip install pipenv
 - pipenv install
+- make dev
+before_script:
+- counter=0 ; while ((counter < 10)) && ! pg_isready --host=$PGHOST --port=$PGPORT --dbname=$PGDATABASE ; do sleep 3; let counter=counter+1; done
 script:
 - pipenv run pytest
 notifications:


### PR DESCRIPTION
Expands the .travis.yml to build and deploy the Docker stack before running the pytest battery. 

I'm making this a separate PR even though it's already feature of #160 . But this is pretty simple and standalone, and will be useful to have in the pipeline independent from finalizing the database features in PR #160. 

This is a WIP and partial contribution to issue #165.