### PR TITLE
Use Dockerhub base image to build  expungeservice

### DIFF
--- a/src/backend/dockerbase/Dockerfile
+++ b/src/backend/dockerbase/Dockerfile
@@ -1,0 +1,5 @@
+FROM library/ubuntu
+RUN apt-get update &&\
+    apt-get install -y python3.7 python3.7-dev python3-pip curl libpq-dev &&\
+    python3.7 -m pip install pip --upgrade &&\
+    python3.7 -m pip install wheel

--- a/src/backend/dockerbase/README.md
+++ b/src/backend/dockerbase/README.md
@@ -1,0 +1,14 @@
+This is a docker image containing the more static content of the expungeservice docker image. This image is pushed onto the Docker Hub and intended to reduce the project build time. 
+
+This image contains any dependencies other than project source code. Any changes to the Dockerfile should be pushed to the Docker Hub.
+
+To rebuild and then push the image, use:
+
+`docker build -t recordexpungpdx:expungeservicebase ./
+docker push recordexpungpdx:expungeservicebase`
+
+To push to the project hub you will need to have logged in with
+
+`docker login`
+
+using the project login credentials. 

--- a/src/backend/expungeservice/Dockerfile
+++ b/src/backend/expungeservice/Dockerfile
@@ -1,4 +1,4 @@
-FROM recordexpungpdx:expungeservicebase
+FROM recordexpungpdx/recordexpungpdx:expungeservicebase
 
 RUN mkdir -p /var/www/expungeservice
 COPY . /var/www/expungeservice

--- a/src/backend/expungeservice/Dockerfile
+++ b/src/backend/expungeservice/Dockerfile
@@ -1,8 +1,4 @@
-FROM library/ubuntu
-RUN apt-get update &&\
-    apt-get install -y python3.7 python3.7-dev python3-pip curl libpq-dev &&\
-    python3.7 -m pip install pip --upgrade &&\
-    python3.7 -m pip install wheel
+FROM recordexpungpdx:expungeservicebase
 
 RUN mkdir -p /var/www/expungeservice
 COPY . /var/www/expungeservice


### PR DESCRIPTION
This separates the expungeservice Docker build into two separate Dockerfiles, one of which can be used to push the base image to the Dockerhub and so that it does not get rebuilt during each project build. The other Dockerfile installs the project source code on top of the base image.

This reduces build time on Travis-CI from ~4 minutes to ~2.5 minutes.

The base image is hosted at https://hub.docker.com/u/recordexpungpdx
