### PR TITLE
Create a db connection upon incoming request

### DIFF
--- a/src/backend/expungeservice/__init__.py
+++ b/src/backend/expungeservice/__init__.py
@@ -3,3 +3,4 @@ from .app import create_app
 from . import database
 from . import endpoints
 from . import expunger
+from . import request

--- a/src/backend/expungeservice/app.py
+++ b/src/backend/expungeservice/app.py
@@ -1,12 +1,10 @@
-import importlib
-import os
-
 from flask import Flask
 
 from .config import app_config
 
 # Add new endpoint imports here:
 from .endpoints import hello, auth, users, protected
+from .request import before, teardown
 
 def create_app(env_name):
     """
@@ -23,4 +21,6 @@ def create_app(env_name):
     users.register(app)
     protected.register(app)
 
+    app.before_request(before)
+    app.teardown_request(teardown)
     return app

--- a/src/backend/expungeservice/request/__init__.py
+++ b/src/backend/expungeservice/request/__init__.py
@@ -1,0 +1,1 @@
+from .request import *

--- a/src/backend/expungeservice/request/request.py
+++ b/src/backend/expungeservice/request/request.py
@@ -1,0 +1,22 @@
+from flask import g
+import os
+from expungeservice.database import Database
+
+
+def before():
+
+    host = os.environ['PGHOST']
+    port = os.environ['PGPORT']
+    name = os.environ['PGDATABASE']
+    username = os.environ['PGUSER']
+    password = os.environ['POSTGRES_PASSWORD']
+
+    g.database = Database(
+        host=host,
+        port=port,
+        name=name,
+        username=username,
+        password=password)
+
+def teardown(exception):
+    g.database.close_connection()

--- a/src/backend/tests/app/test_flask_app.py
+++ b/src/backend/tests/app/test_flask_app.py
@@ -1,0 +1,27 @@
+import unittest
+import expungeservice
+from flask import g
+
+
+class TestFlaskApp(unittest.TestCase):
+
+    def setUp(self):
+        self.app = expungeservice.app.create_app('development')
+        self.test_client = self.app.test_client()
+
+
+    def test_get_database_connection(self):
+
+        with self.app.app_context():
+
+            expungeservice.request.before()
+
+            assert g.database
+
+            query = 'SELECT * FROM users;'
+            g.database.cursor.execute(query, ())
+            rows = g.database.cursor.fetchall()
+            assert rows or rows == []
+
+            expungeservice.request.teardown(None)
+            assert g.database.cursor.closed


### PR DESCRIPTION
Created a new `request` submodule to store the `before` and `teardown` functions which are registered with the Flask app to run before and after each incoming request. I like this organization as opposed to decorating a get_connection() function with the @before_request decorator, because this explicitly keeps all of the before_request and teardown_requestion behavior in one function. There might be additional setup/teardown behavior needed later on.  

A drawback to triggering a db connection in this way is that a database connection is created even if the current request doesn't necessarily need one. In practice, all of our api endpoints do use the database, though this may change in the future. 

closes #173 