### PR TITLE
Set empty string as default value for section attr

### DIFF
--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -92,7 +92,7 @@ class Charge:
     def __set_section(statute):
         statute = Charge.__strip_non_alphanumeric_chars(statute)
         if len(statute) < 6:
-            return None
+            return ''
         elif statute[3].isalpha():
             return statute[0:7]
         return statute[0:6]

--- a/src/backend/tests/expunger/test_expunger.py
+++ b/src/backend/tests/expunger/test_expunger.py
@@ -188,3 +188,13 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         expunger.run()
 
         assert expunger._most_recent_charge == two_year_ago_dismissal
+
+    def test_two_digit_statute_executes(self):
+        case = CaseFactory.create()
+        parking_ticket = ChargeFactory.create(statute='82',
+                                              disposition=['Convicted', self.ONE_YEAR_AGO_DATE])
+
+        case.charges = [parking_ticket]
+        expunger = Expunger([case])
+
+        assert expunger.run()

--- a/src/backend/tests/models/test_charge.py
+++ b/src/backend/tests/models/test_charge.py
@@ -93,7 +93,7 @@ class TestChargeStatuteSectionAssignment(unittest.TestCase):
     def test_it_sets_section_to_none_if_statute_is_does_not_contain_a_section(self):
         charge = ChargeFactory.create(statute='29')
 
-        assert charge._section is None
+        assert charge._section == ''
 
     def test_it_normalizes_section(self):
         charge = ChargeFactory.create(statute='475B.349(3)(C)')


### PR DESCRIPTION
This is being done because isDigit() method cannot be called on
NoneType.

Fixes #150