### PR TITLE
Remove -e option from pipenv install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: install run clean
 
 install:
-	pipenv install '-e .'
+	pipenv install
 
 run: install
 	pipenv run flask run


### PR DESCRIPTION
The -e option tells pipenv to also install dependencies listed in
setup.py. As far as I know we actually don't need a setup.py file,
because we are not distributing this app since it is a webapp. This is
mainly being removed at this time, when -e is enabled it is installing a
pypi package called UNKNOWN, I assume because setup.py does not contain
any dependencies.

Fixes #188