### PR TITLE
Set traffic ticket rules

### DIFF
--- a/src/backend/expungeservice/expunger/expunger.py
+++ b/src/backend/expungeservice/expunger/expunger.py
@@ -108,5 +108,5 @@ class Expunger:
 
     def _most_recent_non_traffic_violation(self):
         for charge in self._charges:
-            if not charge.traffic_crime():
+            if not charge.motor_vehicle_violation():
                 return charge

--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -49,6 +49,9 @@ class Charge:
         else:
             return False
 
+    def motor_vehicle_violation(self):
+        return self.parking_ticket() or self.traffic_crime()
+
     def marijuana_ineligible(self):
         if self.statute == '475B3493C':
             return True

--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -65,7 +65,7 @@ class Charge:
         return self._section in ineligible_statutes
 
     def ineligible_under_137_225_5(self):
-        return self._crime_against_person() or self.traffic_crime() or self._felony_class_a()
+        return self._crime_against_person() or self.motor_vehicle_violation() or self._felony_class_a()
 
     def possession_sched_1(self):
         return self._section in ['475854', '475874', '475884', '475894']

--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -42,6 +42,13 @@ class Charge:
         else:
             return False
 
+    def parking_ticket(self):
+        statute_range = range(1, 100)
+        if self.statute.isdigit():
+            return int(self.statute) in statute_range
+        else:
+            return False
+
     def marijuana_ineligible(self):
         if self.statute == '475B3493C':
             return True

--- a/src/backend/tests/expunger/test_expunger.py
+++ b/src/backend/tests/expunger/test_expunger.py
@@ -189,12 +189,14 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
 
         assert expunger._most_recent_charge == two_year_ago_dismissal
 
-    def test_two_digit_statute_executes(self):
+    def test_parking_ticket_is_not_recent_charge(self):
         case = CaseFactory.create()
-        parking_ticket = ChargeFactory.create(statute='82',
+        parking_ticket = ChargeFactory.create(statute='40',
                                               disposition=['Convicted', self.ONE_YEAR_AGO_DATE])
 
         case.charges = [parking_ticket]
-        expunger = Expunger([case])
 
-        assert expunger.run()
+        expunger = Expunger([case])
+        expunger.run()
+
+        assert expunger._most_recent_charge is None

--- a/src/backend/tests/expunger/test_type_analyzer_convicted_charges.py
+++ b/src/backend/tests/expunger/test_type_analyzer_convicted_charges.py
@@ -539,7 +539,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
 
     def test_non_traffic_violation(self):
         self.single_charge['name'] = 'Viol Treatment'
-        self.single_charge['statute'] = '1615652'
+        self.single_charge['statute'] = '1615662'
         self.single_charge['level'] = 'Violation Unclassified'
         charge = self.create_recent_charge()
         self.charges.append(charge)

--- a/src/backend/tests/expunger/test_type_analyzer_convicted_charges.py
+++ b/src/backend/tests/expunger/test_type_analyzer_convicted_charges.py
@@ -548,6 +548,18 @@ class TestSingleChargeConvictions(unittest.TestCase):
         assert charge.expungement_result.type_eligibility is True
         assert charge.expungement_result.type_eligibility_reason == 'Eligible under 137.225(5)(d)'
 
+    # Parking ticket
+
+    def test_parking_violation(self):
+        self.single_charge['name'] = 'Loading Zone'
+        self.single_charge['statute'] = '29'
+        self.single_charge['level'] = 'Violation Unclassified'
+        charge = self.create_recent_charge()
+        self.type_analyzer.evaluate([charge])
+
+        assert charge.expungement_result.type_eligibility is False
+        assert charge.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+
 
 class TestMultipleCharges(unittest.TestCase):
 

--- a/src/backend/tests/models/test_charge.py
+++ b/src/backend/tests/models/test_charge.py
@@ -135,3 +135,21 @@ class TestTrafficTickets(unittest.TestCase):
         charge = ChargeFactory.save(self.charge)
 
         assert charge.parking_ticket() is True
+
+
+class TestMotorVehicleViolation(unittest.TestCase):
+
+    def setUp(self):
+        self.charge = ChargeFactory.build()
+
+    def test_parking_violation_is_a_motor_vehicle_violation(self):
+        self.charge['statute'] = '01'
+        charge = ChargeFactory.save(self.charge)
+
+        assert charge.motor_vehicle_violation() is True
+
+    def test_driving_charge_is_motor_vehicle_violation(self):
+        self.charge['statute'] = '825.999'
+        charge = ChargeFactory.save(self.charge)
+
+        assert charge.motor_vehicle_violation() is True

--- a/src/backend/tests/models/test_charge.py
+++ b/src/backend/tests/models/test_charge.py
@@ -99,3 +99,39 @@ class TestChargeStatuteSectionAssignment(unittest.TestCase):
         charge = ChargeFactory.create(statute='475B.349(3)(C)')
 
         assert charge._section == '475B349'
+
+
+class TestTrafficTickets(unittest.TestCase):
+
+    def setUp(self):
+        self.charge = ChargeFactory.build()
+
+    def test_it_knows_parking_tickets(self):
+        self.charge['statute'] = '01'
+        charge = ChargeFactory.save(self.charge)
+
+        assert charge.parking_ticket() is True
+
+    def test_00_is_not_a_parking_ticket(self):
+        self.charge['statute'] = '00'
+        charge = ChargeFactory.save(self.charge)
+
+        assert charge.parking_ticket() is False
+
+    def test_100_is_not_a_parking_ticket(self):
+        self.charge['statute'] = '100'
+        charge = ChargeFactory.save(self.charge)
+
+        assert charge.parking_ticket() is False
+
+    def test_99_is_a_parking_ticket(self):
+        self.charge['statute'] = '99'
+        charge = ChargeFactory.save(self.charge)
+
+        assert charge.parking_ticket() is True
+
+    def test_55_is_a_parking_ticket(self):
+        self.charge['statute'] = '55'
+        charge = ChargeFactory.save(self.charge)
+
+        assert charge.parking_ticket() is True


### PR DESCRIPTION
Added two system tests. One runs through the expunger to check that a parking ticket is not classified as a recent charge (this is done since motor vehicle violations are excluded from the time analysis), and the other runs through the type analyzer to check that a parking ticket is not expungeable. 

Implemented unit tests to check various statute numbers for parking tickets. Added the parking ticket method which can be called to determine if a charge is a parking ticket. 
Added a method motor vehicle violation that determines if the charge is either a parking ticket or a 800 level driving charge.

Updated the system to check for motor vehicle violations instead of only checking for 800 level driving charges when determining expungeability.

Fixes #168 