### PR TITLE
Set birth year given multiple formats

### DIFF
--- a/src/backend/expungeservice/models/case.py
+++ b/src/backend/expungeservice/models/case.py
@@ -29,6 +29,6 @@ class Case:
     @staticmethod
     def _set_birth_year(info):
         if len(info) > 1:
-            return int(info[1])
+            return int(info[1].split('/')[-1])
         else:
             return ''

--- a/src/backend/tests/models/test_case.py
+++ b/src/backend/tests/models/test_case.py
@@ -42,7 +42,8 @@ class TestCaseClosedMethod(unittest.TestCase):
         assert self.case.closed() is True
 
 
-class TestBirthYearDefaultValue(unittest.TestCase):
+class TestBirthYearInitializesGivenMultipleValues(unittest.TestCase):
+
     def setUp(self):
         self.case = CaseFactory.build()
 
@@ -51,3 +52,15 @@ class TestBirthYearDefaultValue(unittest.TestCase):
         case = CaseFactory.save(self.case)
 
         assert case.birth_year == ''
+
+    def test_it_assigns_birth_year_when_given_the_year(self):
+        self.case['info'] = ['John Doe', '1979']
+        case = CaseFactory.save(self.case)
+
+        assert case.birth_year == 1979
+
+    def test_it_assigns_birth_year_when_given_the_month_day_year_format(self):
+        self.case['info'] = ['John Doe', '12/21/1979']
+        case = CaseFactory.save(self.case)
+
+        assert case.birth_year == 1979


### PR DESCRIPTION
Added test case for birth year 'mm/dd/yyyy' format
When the user searches for a record passing in the birth date format
then the response returned also includes that birth date instead of the
default value (birth year).

To set the birth year the argument is split on '/' and the year is assigned.

Perhaps we could just assign the string that is returned when parsed?

Fixes #200