### PR TITLE
Crawler returns a Record object

### DIFF
--- a/src/backend/expungeservice/crawler/crawler.py
+++ b/src/backend/expungeservice/crawler/crawler.py
@@ -2,6 +2,7 @@ import requests
 
 from expungeservice.models.charge import Charge
 from expungeservice.models.disposition import Disposition
+from expungeservice.models.record import Record
 from expungeservice.crawler.parsers.param_parser import ParamParser
 from expungeservice.crawler.parsers.node_parser import NodeParser
 from expungeservice.crawler.parsers.record_parser import RecordParser
@@ -42,6 +43,7 @@ class Crawler:
                 case.charges.append(new_charge)
 
         self.session.close()
+        return Record(self.result.cases)
 
     def __parse_nodes(self, url):
         node_parser = NodeParser()

--- a/src/backend/expungeservice/models/record.py
+++ b/src/backend/expungeservice/models/record.py
@@ -1,9 +1,9 @@
-from expungeservice.models.case import Case
-
 class Record:
+
     def __init__(self, list_cases):
         self.cases = list_cases
 
+    @property
     def charges(self):
         list_charges = []
 
@@ -12,8 +12,9 @@ class Record:
 
         return list_charges
 
+    @property
     def total_balance_due(self):
-        total = 0.0
+        total = 0
 
         for case in self.cases:
             total += case.balance_due_in_cents

--- a/src/backend/tests/crawler/test_crawler.py
+++ b/src/backend/tests/crawler/test_crawler.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from tests.factories.crawler_factory import CrawlerFactory
 from tests.fixtures.case_details import CaseDetails
 from tests.fixtures.john_doe import JohnDoe
+from expungeservice.models.record import Record
 
 
 class TestCrawler(unittest.TestCase):
@@ -12,10 +13,11 @@ class TestCrawler(unittest.TestCase):
         self.crawler = CrawlerFactory.setup()
 
     def test_search_function(self):
-        CrawlerFactory.create(self.crawler, JohnDoe.RECORD, {'X0001': CaseDetails.CASE_X1,
+        record = CrawlerFactory.create(self.crawler, JohnDoe.RECORD, {'X0001': CaseDetails.CASE_X1,
                                                              'X0002': CaseDetails.CASE_WITHOUT_FINANCIAL_SECTION,
                                                              'X0003': CaseDetails.CASE_WITHOUT_DISPOS})
 
+        assert record.__class__ == Record
         assert len(self.crawler.result.cases) == 3
 
         assert len(self.crawler.result.cases[0].charges) == 3

--- a/src/backend/tests/crawler/test_crawler.py
+++ b/src/backend/tests/crawler/test_crawler.py
@@ -18,55 +18,55 @@ class TestCrawler(unittest.TestCase):
                                                              'X0003': CaseDetails.CASE_WITHOUT_DISPOS})
 
         assert record.__class__ == Record
-        assert len(self.crawler.result.cases) == 3
+        assert len(record.cases) == 3
 
-        assert len(self.crawler.result.cases[0].charges) == 3
-        assert len(self.crawler.result.cases[1].charges) == 1
-        assert len(self.crawler.result.cases[2].charges) == 3
+        assert len(record.cases[0].charges) == 3
+        assert len(record.cases[1].charges) == 1
+        assert len(record.cases[2].charges) == 3
 
-        assert self.crawler.result.cases[0].charges[0].disposition.ruling == 'Convicted - Failure to Appear'
-        assert self.crawler.result.cases[0].charges[0].disposition.date == datetime.date(datetime.strptime('06/12/2017', '%m/%d/%Y'))
-        assert self.crawler.result.cases[0].charges[1].disposition.ruling == 'Dismissed'
-        assert self.crawler.result.cases[0].charges[1].disposition.date == datetime.date(datetime.strptime('06/12/2017', '%m/%d/%Y'))
-        assert self.crawler.result.cases[0].charges[2].disposition.ruling == 'Dismissed'
-        assert self.crawler.result.cases[0].charges[2].disposition.date == datetime.date(datetime.strptime('06/12/2017', '%m/%d/%Y'))
+        assert record.cases[0].charges[0].disposition.ruling == 'Convicted - Failure to Appear'
+        assert record.cases[0].charges[0].disposition.date == datetime.date(datetime.strptime('06/12/2017', '%m/%d/%Y'))
+        assert record.cases[0].charges[1].disposition.ruling == 'Dismissed'
+        assert record.cases[0].charges[1].disposition.date == datetime.date(datetime.strptime('06/12/2017', '%m/%d/%Y'))
+        assert record.cases[0].charges[2].disposition.ruling == 'Dismissed'
+        assert record.cases[0].charges[2].disposition.date == datetime.date(datetime.strptime('06/12/2017', '%m/%d/%Y'))
 
-        assert self.crawler.result.cases[1].charges[0].disposition.ruling == 'Dismissed'
-        assert self.crawler.result.cases[1].charges[0].disposition.date == datetime.date(datetime.strptime('04/30/1992', '%m/%d/%Y'))
+        assert record.cases[1].charges[0].disposition.ruling == 'Dismissed'
+        assert record.cases[1].charges[0].disposition.date == datetime.date(datetime.strptime('04/30/1992', '%m/%d/%Y'))
 
-        assert self.crawler.result.cases[2].charges[0].disposition.ruling is None
-        assert self.crawler.result.cases[2].charges[0].disposition.date is None
-        assert self.crawler.result.cases[2].charges[1].disposition.ruling is None
-        assert self.crawler.result.cases[2].charges[1].disposition.date is None
-        assert self.crawler.result.cases[2].charges[2].disposition.ruling is None
-        assert self.crawler.result.cases[2].charges[2].disposition.date is None
+        assert record.cases[2].charges[0].disposition.ruling is None
+        assert record.cases[2].charges[0].disposition.date is None
+        assert record.cases[2].charges[1].disposition.ruling is None
+        assert record.cases[2].charges[1].disposition.date is None
+        assert record.cases[2].charges[2].disposition.ruling is None
+        assert record.cases[2].charges[2].disposition.date is None
 
     def test_a_blank_search_response(self):
-        CrawlerFactory.create(self.crawler, JohnDoe.BLANK_RECORD, {})
+        record = CrawlerFactory.create(self.crawler, JohnDoe.BLANK_RECORD, {})
 
-        assert len(self.crawler.result.cases) == 0
+        assert len(record.cases) == 0
 
     def test_single_charge_conviction(self):
-        CrawlerFactory.create(self.crawler, JohnDoe.SINGLE_CASE_RECORD, {'CASEJD1': CaseDetails.CASEJD1})
+        record = CrawlerFactory.create(self.crawler, JohnDoe.SINGLE_CASE_RECORD, {'CASEJD1': CaseDetails.CASEJD1})
 
-        assert len(self.crawler.result.cases) == 1
-        assert len(self.crawler.result.cases[0].charges) == 1
+        assert len(record.cases) == 1
+        assert len(record.cases[0].charges) == 1
 
-        assert self.crawler.result.cases[0].charges[0].name == 'Loading Zone'
-        assert self.crawler.result.cases[0].charges[0].statute == '29'
-        assert self.crawler.result.cases[0].charges[0].level == 'Violation Unclassified'
-        assert self.crawler.result.cases[0].charges[0].date == datetime.date(datetime.strptime('09/04/2008', '%m/%d/%Y'))
-        assert self.crawler.result.cases[0].charges[0].disposition.ruling == 'Convicted'
-        assert self.crawler.result.cases[0].charges[0].disposition.date == datetime.date(datetime.strptime('11/18/2008', '%m/%d/%Y'))
+        assert record.cases[0].charges[0].name == 'Loading Zone'
+        assert record.cases[0].charges[0].statute == '29'
+        assert record.cases[0].charges[0].level == 'Violation Unclassified'
+        assert record.cases[0].charges[0].date == datetime.date(datetime.strptime('09/04/2008', '%m/%d/%Y'))
+        assert record.cases[0].charges[0].disposition.ruling == 'Convicted'
+        assert record.cases[0].charges[0].disposition.date == datetime.date(datetime.strptime('11/18/2008', '%m/%d/%Y'))
 
     def test_nonzero_balance_due_on_case(self):
-        CrawlerFactory.create(self.crawler, JohnDoe.RECORD, {'X0001': CaseDetails.CASE_X1,
+        record = CrawlerFactory.create(self.crawler, JohnDoe.RECORD, {'X0001': CaseDetails.CASE_X1,
                                                              'X0002': CaseDetails.CASE_WITHOUT_FINANCIAL_SECTION,
                                                              'X0003': CaseDetails.CASE_WITHOUT_DISPOS})
 
-        assert self.crawler.result.cases[0].get_balance_due() == 1516.80
+        assert record.cases[0].get_balance_due() == 1516.80
 
     def test_zero_balance_due_on_case(self):
-        CrawlerFactory.create(self.crawler, JohnDoe.SINGLE_CASE_RECORD, {'CASEJD1': CaseDetails.CASEJD1})
+        record = CrawlerFactory.create(self.crawler, JohnDoe.SINGLE_CASE_RECORD, {'CASEJD1': CaseDetails.CASEJD1})
 
-        assert self.crawler.result.cases[0].get_balance_due() == 0
+        assert record.cases[0].get_balance_due() == 0

--- a/src/backend/tests/factories/crawler_factory.py
+++ b/src/backend/tests/factories/crawler_factory.py
@@ -35,4 +35,4 @@ class CrawlerFactory:
             for key, value in cases.items():
                 m.get("{}{}{}".format(base_url, 'CaseDetail.aspx?CaseID=', key), text=value)
 
-            crawler.search('John', 'Doe')
+            return crawler.search('John', 'Doe')

--- a/src/backend/tests/functional_tests/test_crawler_expunger.py
+++ b/src/backend/tests/functional_tests/test_crawler_expunger.py
@@ -18,32 +18,32 @@ class TestCrawlerAndExpunger(unittest.TestCase):
         self.crawler = CrawlerFactory.setup()
 
     def test_expunger_with_open_case(self):
-        CrawlerFactory.create(self.crawler, JohnDoe.RECORD, {'X0001': CaseDetails.CASE_X1,
+        record = CrawlerFactory.create(self.crawler, JohnDoe.RECORD, {'X0001': CaseDetails.CASE_X1,
                                                              'X0002': CaseDetails.CASE_WITHOUT_FINANCIAL_SECTION,
                                                              'X0003': CaseDetails.CASE_WITHOUT_DISPOS})
-        expunger = Expunger(self.crawler.result.cases)
+        expunger = Expunger(record.cases)
         assert expunger.run() is False
         assert expunger.errors == ['Open cases exist']
 
     def test_type_analyzer_runs_when_open_cases_exit(self):
-        CrawlerFactory.create(self.crawler, JohnDoe.RECORD, {'X0001': CaseDetails.CASE_X1,
+        record = CrawlerFactory.create(self.crawler, JohnDoe.RECORD, {'X0001': CaseDetails.CASE_X1,
                                                              'X0002': CaseDetails.CASE_WITHOUT_FINANCIAL_SECTION,
                                                              'X0003': CaseDetails.CASE_WITHOUT_DISPOS})
-        expunger = Expunger(self.crawler.result.cases)
+        expunger = Expunger(record.cases)
         expunger.run()
 
         assert expunger.cases[0].charges[1].expungement_result.type_eligibility is True
 
     def test_expunger_with_an_empty_record(self):
-        CrawlerFactory.create(self.crawler, JohnDoe.BLANK_RECORD, {})
-        expunger = Expunger(self.crawler.result.cases)
+        record = CrawlerFactory.create(self.crawler, JohnDoe.BLANK_RECORD, {})
+        expunger = Expunger(record.cases)
 
         assert expunger.run() is True
         assert expunger._most_recent_dismissal is None
         assert expunger._most_recent_conviction is None
 
     def test_expunger_categorizes_charges(self):
-        CrawlerFactory.create(self.crawler,
+        record = CrawlerFactory.create(self.crawler,
                               cases={'X0001': CaseDetails.case_x(dispo_ruling_1='Convicted - Failure to show',
                                                                  dispo_ruling_2='Dismissed',
                                                                  dispo_ruling_3='Acquitted'),
@@ -53,14 +53,14 @@ class TestCrawlerAndExpunger(unittest.TestCase):
                                      'X0003': CaseDetails.case_x(dispo_ruling_1='No Complaint',
                                                                  dispo_ruling_2='Dismissed',
                                                                  dispo_ruling_3='Convicted')})
-        expunger = Expunger(self.crawler.result.cases)
+        expunger = Expunger(record.cases)
 
         assert expunger.run() is True
         assert len(expunger._acquittals) == 5
         assert len(expunger._convictions) == 4
 
     def test_expunger_calls_time_analyzer(self):
-        CrawlerFactory.create(self.crawler,
+        record = CrawlerFactory.create(self.crawler,
                               cases={'X0001': CaseDetails.case_x(arrest_date=self.FIFTEEN_YEARS_AGO.strftime('%m/%d/%Y'),
                                                                  dispo_ruling_1='Dismissed',
                                                                  dispo_ruling_2='Dismissed',
@@ -73,7 +73,7 @@ class TestCrawlerAndExpunger(unittest.TestCase):
                                                                  dispo_ruling_1='No Complaint',
                                                                  dispo_ruling_2='Convicted',
                                                                  dispo_ruling_3='No Complaint')})
-        expunger = Expunger(self.crawler.result.cases)
+        expunger = Expunger(record.cases)
 
         assert expunger.run() is True
 
@@ -83,7 +83,7 @@ class TestCrawlerAndExpunger(unittest.TestCase):
         assert expunger._time_analyzer._num_acquittals == 4
 
     def test_expunger_invokes_time_analyzer_with_most_recent_charge(self):
-        CrawlerFactory.create(self.crawler,
+        record = CrawlerFactory.create(self.crawler,
                               cases={'X0001': CaseDetails.case_x(arrest_date=self.FIFTEEN_YEARS_AGO.strftime('%m/%d/%Y'),
                                                                  charge1_name='Aggravated theft in the first degree',
                                                                  charge1_statute='164.057',
@@ -93,7 +93,7 @@ class TestCrawlerAndExpunger(unittest.TestCase):
                                      'X0002': CaseDetails.case_x(),
                                      'X0003': CaseDetails.case_x()})
 
-        expunger = Expunger(self.crawler.result.cases)
+        expunger = Expunger(record.cases)
         expunger.run()
 
         assert len(expunger._type_analyzer.class_b_felonies) == 1
@@ -102,7 +102,7 @@ class TestCrawlerAndExpunger(unittest.TestCase):
         assert expunger._time_analyzer._most_recent_charge.name == 'Aggravated theft in the first degree'
 
     def test_expunger_expunges(self):
-        CrawlerFactory.create(self.crawler,
+        record = CrawlerFactory.create(self.crawler,
                               cases={'X0001': CaseDetails.case_x(arrest_date=self.FIFTEEN_YEARS_AGO.strftime('%m/%d/%Y'),
                                                                  dispo_date=self.FIFTEEN_YEARS_AGO.strftime('%m/%d/%Y'),
                                                                  dispo_ruling_1='Dismissed',
@@ -116,7 +116,7 @@ class TestCrawlerAndExpunger(unittest.TestCase):
                                                                  dispo_ruling_1='No Complaint',
                                                                  dispo_ruling_2='No Complaint',
                                                                  dispo_ruling_3='No Complaint')})
-        expunger = Expunger(self.crawler.result.cases)
+        expunger = Expunger(record.cases)
 
         assert expunger.run() is True
 

--- a/src/backend/tests/models/test_record.py
+++ b/src/backend/tests/models/test_record.py
@@ -1,7 +1,7 @@
 import unittest
 
 from expungeservice.models.case import Case
-from expungeservice.models.record_object import Record
+from expungeservice.models.record import Record
 from tests.factories.case_factory import CaseFactory
 from tests.factories.charge_factory import ChargeFactory
 
@@ -27,8 +27,8 @@ class TestRecordObject(unittest.TestCase):
         self.record = Record(self.list_cases)
 
     def test_print_balance_in_cents(self):
-        assert self.record.total_balance_due() == 369.0
+        assert self.record.total_balance_due == 369.0
 
     def test_print_list_charges(self):
-        assert self.record.charges()[0] == self.list_charges[0]
-        assert self.record.charges()[1] == self.list_charges[0]
+        assert self.record.charges[0] == self.list_charges[0]
+        assert self.record.charges[1] == self.list_charges[0]


### PR DESCRIPTION
A minimal change: The crawler.search() returns a new Record data object containing case data.

Test cases updated to refer to the new object instead of the crawler's internal data, to match the preferred usage of the main code. 

Also changed the Record object to use the property decorator as mentioned in a #214 comment from @NickSchimek . 
 
Renamed record_object.py to record.py to match other files in /models/

Closes #139 