### PR TITLE
Inject Record object into expunger

### DIFF
--- a/src/backend/expungeservice/expunger/expunger.py
+++ b/src/backend/expungeservice/expunger/expunger.py
@@ -13,15 +13,15 @@ class Expunger:
     query's if/when we start persisting the model objects to the db.
     """
 
-    def __init__(self, cases):
+    def __init__(self, record):
         '''
         Constructor
 
-        :param cases: A list of cases
+        :param record: A Record object
         '''
-        self.cases = cases
+        self.record = record
+        self._charges = record.charges
         self.errors = []
-        self._charges = []
         self._most_recent_dismissal = None
         self._most_recent_conviction = None
         self._second_most_recent_conviction = None
@@ -43,7 +43,6 @@ class Expunger:
             self.errors.append('Open cases exist')
             return False
 
-        self._create_charge_list()
         self._categorize_charges()
         self._set_most_recent_dismissal()
         self._set_most_recent_convictions()
@@ -60,14 +59,10 @@ class Expunger:
         return True
 
     def _open_cases(self):
-        for case in self.cases:
+        for case in self.record.cases:
             if not case.closed():
                 return True
         return False
-
-    def _create_charge_list(self):
-        for case in self.cases:
-            self._charges.extend(case.charges)
 
     def _create_charge_list_from_closed_cases(self):
         for case in self.cases:

--- a/src/backend/expungeservice/expunger/expunger.py
+++ b/src/backend/expungeservice/expunger/expunger.py
@@ -39,7 +39,6 @@ class Expunger:
         :return: True if there are no open cases; otherwise False
         """
         if self._open_cases():
-            self._create_charge_list_from_closed_cases()
             self.errors.append('Open cases exist')
             return False
 
@@ -63,11 +62,6 @@ class Expunger:
             if not case.closed():
                 return True
         return False
-
-    def _create_charge_list_from_closed_cases(self):
-        for case in self.cases:
-            if case.closed():
-                self._charges.extend(case.charges)
 
     def _categorize_charges(self):
         for charge in self._charges:

--- a/src/backend/tests/expunger/test_expunger.py
+++ b/src/backend/tests/expunger/test_expunger.py
@@ -4,6 +4,7 @@ from datetime import date
 from dateutil.relativedelta import relativedelta
 from expungeservice.expunger.expunger import Expunger
 from expungeservice.models.disposition import Disposition
+from expungeservice.models.record import Record
 from tests.factories.case_factory import CaseFactory
 from tests.factories.charge_factory import ChargeFactory
 
@@ -26,8 +27,9 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         case = CaseFactory.create()
         mrd_charge = ChargeFactory.create_dismissed_charge(date=self.LESS_THAN_THREE_YEARS_AGO)
         case.charges = [mrd_charge]
+        record = Record([case])
 
-        expunger = Expunger([case])
+        expunger = Expunger(record)
         expunger.run()
 
         assert expunger._most_recent_dismissal is mrd_charge
@@ -37,8 +39,9 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         charge_1 = ChargeFactory.create_dismissed_charge(date=self.THREE_YEARS_AGO)
         charge_2 = ChargeFactory.create_dismissed_charge(date=self.THREE_YEARS_AGO)
         case.charges = [charge_1, charge_2]
+        record = Record([case])
 
-        expunger = Expunger([case])
+        expunger = Expunger(record)
         expunger.run()
 
         assert expunger._most_recent_dismissal is None
@@ -48,8 +51,9 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         mrd_charge = ChargeFactory.create_dismissed_charge(date=self.TWO_YEARS_AGO)
         charge = ChargeFactory.create_dismissed_charge(date=self.LESS_THAN_THREE_YEARS_AGO)
         case.charges = [charge, charge, mrd_charge, charge, charge]
+        record = Record([case])
 
-        expunger = Expunger([case])
+        expunger = Expunger(record)
         expunger.run()
 
         assert expunger._most_recent_dismissal is mrd_charge
@@ -59,8 +63,9 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         mrd_charge = ChargeFactory.create_dismissed_charge(date=self.TWO_YEARS_AGO)
         charge = ChargeFactory.create_dismissed_charge(date=self.LESS_THAN_THREE_YEARS_AGO)
         case.charges = [charge, charge, mrd_charge]
+        record = Record([case])
 
-        expunger = Expunger([case])
+        expunger = Expunger(record)
         expunger.run()
 
         assert expunger._most_recent_dismissal is mrd_charge
@@ -70,8 +75,9 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         mrc_charge = ChargeFactory.create()
         mrc_charge.disposition = Disposition(self.LESS_THAN_TEN_YEARS_AGO, 'Convicted')
         case.charges = [mrc_charge]
+        record = Record([case])
 
-        expunger = Expunger([case])
+        expunger = Expunger(record)
         expunger.run()
 
         assert expunger._most_recent_conviction is mrc_charge
@@ -84,8 +90,9 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         second_mrc_charge.disposition = Disposition(self.LESS_THAN_TEN_YEARS_AGO, 'Convicted')
 
         case.charges = [second_mrc_charge, mrc_charge]
+        record = Record([case])
 
-        expunger = Expunger([case])
+        expunger = Expunger(record)
         expunger.run()
 
         assert expunger._second_most_recent_conviction is second_mrc_charge
@@ -95,8 +102,9 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         mrc_charge = ChargeFactory.create()
         mrc_charge.disposition = Disposition(self.TEN_YEARS, 'Convicted')
         case.charges = [mrc_charge]
+        record = Record([case])
 
-        expunger = Expunger([case])
+        expunger = Expunger(record)
         expunger.run()
 
         assert expunger._most_recent_conviction is None
@@ -108,8 +116,9 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         second_mrc_charge = ChargeFactory.create()
         second_mrc_charge.disposition = Disposition(self.TEN_YEARS, 'Convicted')
         case.charges = [mrc_charge, second_mrc_charge]
+        record = Record([case])
 
-        expunger = Expunger([case])
+        expunger = Expunger(record)
         expunger.run()
 
         assert expunger._second_most_recent_conviction is None
@@ -123,8 +132,9 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         charge = ChargeFactory.create()
         charge.disposition = Disposition(self.TEN_YEARS, 'Convicted')
         case.charges = [charge, charge, second_mrc_charge, mrc_charge, charge, charge]
+        record = Record([case])
 
-        expunger = Expunger([case])
+        expunger = Expunger(record)
         expunger.run()
 
         assert expunger._most_recent_conviction is mrc_charge
@@ -138,8 +148,9 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         three_year_ago_dismissal = ChargeFactory.create_dismissed_charge(date=self.THREE_YEARS_AGO)
 
         case.charges = [one_year_ago_dismissal, two_year_ago_dismissal, three_year_ago_dismissal, less_than_3_year_ago_dismissal]
+        record = Record([case])
 
-        expunger = Expunger([case])
+        expunger = Expunger(record)
         expunger.run()
 
         assert expunger._num_acquittals == 3
@@ -149,8 +160,9 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         three_year_ago_dismissal = ChargeFactory.create_dismissed_charge(date=self.THREE_YEARS_AGO)
 
         case.charges = [three_year_ago_dismissal]
+        record = Record([case])
 
-        expunger = Expunger([case])
+        expunger = Expunger(record)
         expunger.run()
 
         assert expunger._num_acquittals == 0
@@ -163,8 +175,9 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
                                                        disposition=['Convicted', self.ONE_YEAR_AGO_DATE])
 
         case.charges = [one_year_traffic_charge]
+        record = Record([case])
 
-        expunger = Expunger([case])
+        expunger = Expunger(record)
         expunger.run()
 
         assert expunger._most_recent_charge is None
@@ -183,8 +196,9 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
                                                         disposition=['Convicted', self.FOUR_YEAR_AGO_DATE])
 
         case.charges = [one_year_traffic_charge, two_year_ago_dismissal, three_year_ago_dismissal, four_year_traffic_charge]
+        record = Record([case])
 
-        expunger = Expunger([case])
+        expunger = Expunger(record)
         expunger.run()
 
         assert expunger._most_recent_charge == two_year_ago_dismissal
@@ -195,8 +209,9 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
                                               disposition=['Convicted', self.ONE_YEAR_AGO_DATE])
 
         case.charges = [parking_ticket]
+        record = Record([case])
 
-        expunger = Expunger([case])
+        expunger = Expunger(record)
         expunger.run()
 
         assert expunger._most_recent_charge is None

--- a/src/backend/tests/functional_tests/test_crawler_expunger.py
+++ b/src/backend/tests/functional_tests/test_crawler_expunger.py
@@ -21,7 +21,7 @@ class TestCrawlerAndExpunger(unittest.TestCase):
         record = CrawlerFactory.create(self.crawler, JohnDoe.RECORD, {'X0001': CaseDetails.CASE_X1,
                                                              'X0002': CaseDetails.CASE_WITHOUT_FINANCIAL_SECTION,
                                                              'X0003': CaseDetails.CASE_WITHOUT_DISPOS})
-        expunger = Expunger(record.cases)
+        expunger = Expunger(record)
         assert expunger.run() is False
         assert expunger.errors == ['Open cases exist']
 
@@ -29,14 +29,14 @@ class TestCrawlerAndExpunger(unittest.TestCase):
         record = CrawlerFactory.create(self.crawler, JohnDoe.RECORD, {'X0001': CaseDetails.CASE_X1,
                                                              'X0002': CaseDetails.CASE_WITHOUT_FINANCIAL_SECTION,
                                                              'X0003': CaseDetails.CASE_WITHOUT_DISPOS})
-        expunger = Expunger(record.cases)
+        expunger = Expunger(record)
         expunger.run()
 
-        assert expunger.cases[0].charges[1].expungement_result.type_eligibility is True
+        assert record.cases[0].charges[1].expungement_result.type_eligibility is True
 
     def test_expunger_with_an_empty_record(self):
         record = CrawlerFactory.create(self.crawler, JohnDoe.BLANK_RECORD, {})
-        expunger = Expunger(record.cases)
+        expunger = Expunger(record)
 
         assert expunger.run() is True
         assert expunger._most_recent_dismissal is None
@@ -53,7 +53,7 @@ class TestCrawlerAndExpunger(unittest.TestCase):
                                      'X0003': CaseDetails.case_x(dispo_ruling_1='No Complaint',
                                                                  dispo_ruling_2='Dismissed',
                                                                  dispo_ruling_3='Convicted')})
-        expunger = Expunger(record.cases)
+        expunger = Expunger(record)
 
         assert expunger.run() is True
         assert len(expunger._acquittals) == 5
@@ -73,7 +73,7 @@ class TestCrawlerAndExpunger(unittest.TestCase):
                                                                  dispo_ruling_1='No Complaint',
                                                                  dispo_ruling_2='Convicted',
                                                                  dispo_ruling_3='No Complaint')})
-        expunger = Expunger(record.cases)
+        expunger = Expunger(record)
 
         assert expunger.run() is True
 
@@ -93,7 +93,7 @@ class TestCrawlerAndExpunger(unittest.TestCase):
                                      'X0002': CaseDetails.case_x(),
                                      'X0003': CaseDetails.case_x()})
 
-        expunger = Expunger(record.cases)
+        expunger = Expunger(record)
         expunger.run()
 
         assert len(expunger._class_b_felonies) == 1
@@ -116,7 +116,7 @@ class TestCrawlerAndExpunger(unittest.TestCase):
                                                                  dispo_ruling_1='No Complaint',
                                                                  dispo_ruling_2='No Complaint',
                                                                  dispo_ruling_3='No Complaint')})
-        expunger = Expunger(record.cases)
+        expunger = Expunger(record)
 
         assert expunger.run() is True
 
@@ -125,23 +125,23 @@ class TestCrawlerAndExpunger(unittest.TestCase):
         assert expunger._most_recent_dismissal.disposition.ruling == 'No Complaint'
         assert len(expunger._acquittals) == 8
 
-        assert expunger.cases[0].charges[0].expungement_result.type_eligibility is True
-        assert expunger.cases[0].charges[0].expungement_result.time_eligibility is False
-        assert expunger.cases[0].charges[1].expungement_result.type_eligibility is False
-        assert expunger.cases[0].charges[1].expungement_result.time_eligibility is False
-        assert expunger.cases[0].charges[2].expungement_result.type_eligibility is True
-        assert expunger.cases[0].charges[2].expungement_result.time_eligibility is False
+        assert record.cases[0].charges[0].expungement_result.type_eligibility is True
+        assert record.cases[0].charges[0].expungement_result.time_eligibility is False
+        assert record.cases[0].charges[1].expungement_result.type_eligibility is False
+        assert record.cases[0].charges[1].expungement_result.time_eligibility is False
+        assert record.cases[0].charges[2].expungement_result.type_eligibility is True
+        assert record.cases[0].charges[2].expungement_result.time_eligibility is False
 
-        assert expunger.cases[1].charges[0].expungement_result.type_eligibility is True
-        assert expunger.cases[1].charges[0].expungement_result.time_eligibility is False
-        assert expunger.cases[1].charges[1].expungement_result.type_eligibility is True
-        assert expunger.cases[1].charges[1].expungement_result.time_eligibility is False
-        assert expunger.cases[1].charges[2].expungement_result.type_eligibility is True
-        assert expunger.cases[1].charges[2].expungement_result.time_eligibility is False
+        assert record.cases[1].charges[0].expungement_result.type_eligibility is True
+        assert record.cases[1].charges[0].expungement_result.time_eligibility is False
+        assert record.cases[1].charges[1].expungement_result.type_eligibility is True
+        assert record.cases[1].charges[1].expungement_result.time_eligibility is False
+        assert record.cases[1].charges[2].expungement_result.type_eligibility is True
+        assert record.cases[1].charges[2].expungement_result.time_eligibility is False
 
-        assert expunger.cases[2].charges[0].expungement_result.type_eligibility is True
-        assert expunger.cases[2].charges[0].expungement_result.time_eligibility is True
-        assert expunger.cases[2].charges[1].expungement_result.type_eligibility is True
-        assert expunger.cases[2].charges[1].expungement_result.time_eligibility is True
-        assert expunger.cases[2].charges[2].expungement_result.type_eligibility is True
-        assert expunger.cases[2].charges[2].expungement_result.time_eligibility is True
+        assert record.cases[2].charges[0].expungement_result.type_eligibility is True
+        assert record.cases[2].charges[0].expungement_result.time_eligibility is True
+        assert record.cases[2].charges[1].expungement_result.type_eligibility is True
+        assert record.cases[2].charges[1].expungement_result.time_eligibility is True
+        assert record.cases[2].charges[2].expungement_result.type_eligibility is True
+        assert record.cases[2].charges[2].expungement_result.time_eligibility is True


### PR DESCRIPTION
small refactoring. However this does change the api for the expunger. It now takes a Record object instead of a list of cases. @ash-tamraz you OK with this change?

I'm going to continue refactoring on this branch over the next couple days, but wanted to get this in since it affects @ash-tamraz work on the search endpoint. 

Fixes #241 
