### PR TITLE
Tag and skip charges without dispositions

### DIFF
--- a/src/backend/expungeservice/expunger/expunger.py
+++ b/src/backend/expungeservice/expunger/expunger.py
@@ -22,6 +22,7 @@ class Expunger:
         self.record = record
         self._charges = record.charges
         self.errors = []
+        self._dispositionless_charges = []
         self._most_recent_dismissal = None
         self._most_recent_conviction = None
         self._second_most_recent_conviction = None
@@ -42,6 +43,8 @@ class Expunger:
             self.errors.append('Open cases exist')
             return False
 
+        self._tag_dispositionless_charges()
+        self._remove_dispositionless_charge()
         self._categorize_charges()
         self._set_most_recent_dismissal()
         self._set_most_recent_convictions()
@@ -62,6 +65,16 @@ class Expunger:
             if not case.closed():
                 return True
         return False
+
+    def _tag_dispositionless_charges(self):
+        for charge in self._charges:
+            if Expunger._charge_without_disposition(charge):
+                charge.expungement_result.type_eligibility_reason = "Disposition not found. Needs further analysis"
+                self._dispositionless_charges.append(charge)
+
+    def _remove_dispositionless_charge(self):
+        for charge in self._dispositionless_charges:
+            self._charges.remove(charge)
 
     def _categorize_charges(self):
         for charge in self._charges:
@@ -102,3 +115,10 @@ class Expunger:
         for charge in self._charges:
             if charge.__class__.__name__ == 'FelonyClassB':
                 self._class_b_felonies.append(charge)
+
+    @staticmethod
+    def _charge_without_disposition(charge):
+        if not charge.disposition.ruling:
+            return True
+        else:
+            return False

--- a/src/backend/expungeservice/models/charge_types/base_charge.py
+++ b/src/backend/expungeservice/models/charge_types/base_charge.py
@@ -27,7 +27,9 @@ class BaseCharge:
         return False
 
     def acquitted(self):
-        if self.disposition.ruling:
+        if not self.disposition.ruling:
+            return False
+        else:
             return self.disposition.ruling[0:9] != 'Convicted'
 
     def recent_conviction(self):

--- a/src/backend/tests/expunger/test_expunger.py
+++ b/src/backend/tests/expunger/test_expunger.py
@@ -215,3 +215,12 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         expunger.run()
 
         assert expunger._most_recent_charge is None
+
+    def test_it_skips_closed_cases_without_dispositions(self):
+        case = CaseFactory.create()
+        charge_without_dispo = ChargeFactory.create()
+        case.charges = [charge_without_dispo]
+        record = Record([case])
+        expunger = Expunger(record)
+
+        assert expunger.run()


### PR DESCRIPTION
Sometimes a charge in a closed case will not have a disposition, tag and
skipping per clients request.

Fixes #210 