### PR TITLE
Juvenile charges should be ignored

### DIFF
--- a/src/backend/expungeservice/expunger/expunger.py
+++ b/src/backend/expungeservice/expunger/expunger.py
@@ -22,7 +22,7 @@ class Expunger:
         self.record = record
         self._charges = record.charges
         self.errors = []
-        self._dispositionless_charges = []
+        self._skipped_charges = []
         self._most_recent_dismissal = None
         self._most_recent_conviction = None
         self._second_most_recent_conviction = None
@@ -43,8 +43,8 @@ class Expunger:
             self.errors.append('Open cases exist')
             return False
 
-        self._tag_dispositionless_charges()
-        self._remove_dispositionless_charge()
+        self._tag_skipped_charges()
+        self._remove_skipped_charges()
         self._categorize_charges()
         self._set_most_recent_dismissal()
         self._set_most_recent_convictions()
@@ -66,14 +66,13 @@ class Expunger:
                 return True
         return False
 
-    def _tag_dispositionless_charges(self):
+    def _tag_skipped_charges(self):
         for charge in self._charges:
-            if Expunger._charge_without_disposition(charge):
-                charge.expungement_result.type_eligibility_reason = "Disposition not found. Needs further analysis"
-                self._dispositionless_charges.append(charge)
+            if charge.skip_analysis():
+                self._skipped_charges.append(charge)
 
-    def _remove_dispositionless_charge(self):
-        for charge in self._dispositionless_charges:
+    def _remove_skipped_charges(self):
+        for charge in self._skipped_charges:
             self._charges.remove(charge)
 
     def _categorize_charges(self):
@@ -115,10 +114,3 @@ class Expunger:
         for charge in self._charges:
             if charge.__class__.__name__ == 'FelonyClassB':
                 self._class_b_felonies.append(charge)
-
-    @staticmethod
-    def _charge_without_disposition(charge):
-        if not charge.disposition.ruling:
-            return True
-        else:
-            return False

--- a/src/backend/expungeservice/models/charge_types/base_charge.py
+++ b/src/backend/expungeservice/models/charge_types/base_charge.py
@@ -40,6 +40,13 @@ class BaseCharge:
         three_years_ago = (date_class.today() + relativedelta(years=-3))
         return self.acquitted() and self.date > three_years_ago
 
+    def skip_analysis(self):
+        if not self.disposition.ruling:
+            self.expungement_result.type_eligibility_reason = "Disposition not found. Needs further analysis"
+            return True
+        else:
+            return False
+
     def set_time_ineligible(self, reason, date_of_eligibility):
         self.expungement_result.time_eligibility = False
         self.expungement_result.time_eligibility_reason = reason

--- a/src/backend/expungeservice/models/charge_types/juvenile_charge.py
+++ b/src/backend/expungeservice/models/charge_types/juvenile_charge.py
@@ -7,3 +7,6 @@ class JuvenileCharge(BaseCharge):
         super(JuvenileCharge, self).__init__(**kwargs)
         self.expungement_result.set_type_eligibility(None)
         self.expungement_result.set_reason('Juvenile Charge : Needs further analysis')
+
+    def skip_analysis(self):
+        return True

--- a/src/backend/expungeservice/models/charge_types/juvenile_charge.py
+++ b/src/backend/expungeservice/models/charge_types/juvenile_charge.py
@@ -1,0 +1,9 @@
+from expungeservice.models.charge_types.base_charge import BaseCharge
+
+
+class JuvenileCharge(BaseCharge):
+
+    def __init__(self, **kwargs):
+        super(JuvenileCharge, self).__init__(**kwargs)
+        self.expungement_result.set_type_eligibility(None)
+        self.expungement_result.set_reason('Juvenile Charge : Needs further analysis')

--- a/src/backend/tests/expunger/test_expunger.py
+++ b/src/backend/tests/expunger/test_expunger.py
@@ -224,3 +224,15 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         expunger = Expunger(record)
 
         assert expunger.run()
+
+    def test_it_skips_juvenile_charges(self):
+        case = CaseFactory.create(type_status=['a juvenile case', 'Closed'])
+        juvenile_charge = ChargeFactory.create(case=case)
+        case.charges = [juvenile_charge]
+
+        record = Record([case])
+        expunger = Expunger(record)
+
+        assert expunger.run()
+        assert expunger._skipped_charges[0] == juvenile_charge
+        assert expunger._charges == []

--- a/src/backend/tests/models/charge_types/test_juvenile_charge.py
+++ b/src/backend/tests/models/charge_types/test_juvenile_charge.py
@@ -1,0 +1,15 @@
+import unittest
+
+from tests.factories.case_factory import CaseFactory
+from tests.factories.charge_factory import ChargeFactory
+
+
+class TestJuvenileCharge(unittest.TestCase):
+
+    def test_juvenile_charge(self):
+        case = CaseFactory.create(type_status=['Juvenile Delinquency: Misdemeanor', 'Closed'])
+        juvenile_charge = ChargeFactory.create(case=case)
+
+        assert juvenile_charge.__class__.__name__ == 'JuvenileCharge'
+        assert juvenile_charge.expungement_result.type_eligibility is None
+        assert juvenile_charge.expungement_result.type_eligibility_reason == 'Juvenile Charge : Needs further analysis'


### PR DESCRIPTION
## Description
Juvenile charges should not be analyzed, and should be completely ignored.

Created Juvenile Charge class and removed it from being analyzed in the expunger via the `skip_analysis` method

Fixes #202 and Fixes #236 