### PR TITLE
Update Docker make targets and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,10 @@
 install:
 	pipenv install
 
-run: install
-	pipenv run flask run
-
 clean:
+	rm -rf src/backend/*.egg-info
 	find . -type f -name \*~ | xargs rm
 	find . -type f -name \*pyc | xargs rm
-	rm -rf src/backend/*.egg-info
 
 IMAGES := database_image expungeservice_image webserver_image
 
@@ -21,7 +18,10 @@ REQUIREMENTS_TXT := src/backend/expungeservice/requirements.txt
 dev: $(REQUIREMENTS_TXT) dev_deploy
 	echo $@
 
-dev_deploy: $(IMAGES)
+dev_deploy: $(IMAGES) dev_start
+	echo $@
+
+dev_start:
 	echo $@
 	docker stack deploy -c docker-compose.yml -c docker-compose.dev.yml $(STACK_NAME)
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Our dev environment uses pipenv for maintaining backend dependencies, and npm to
       brew install postgresql
       ```
       Note: this step is only required to meet a dependency for python's psycopg2 package, namely `libpq-dev`. The dev environment doesn't require a local installation of the database, because the database runs within the docker stack.
-      
+
       It may be necessary to then run
       ```
       export LDFLAGS="-L/usr/local/opt/openssl/lib"
@@ -120,10 +120,10 @@ Our dev environment uses pipenv for maintaining backend dependencies, and npm to
           (click on Get Docker for Mac [Stable])
 
    * **Linux**
-    
+
         - [Docker Installation](https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-using-the-repository)
-	
-        - Configure your user to run docker without sudo: https://docs.docker.com/install/linux/linux-postinstall/ 
+
+        - Configure your user to run docker without sudo: https://docs.docker.com/install/linux/linux-postinstall/
 
 9. Create a local .env file
 
@@ -132,23 +132,6 @@ While in the directory of your local repo, run:
 cp .env.example .env
 
 ```
-## Running Components
-
-### Backend
-
-#### Running Backend Development Server
-
-While in the directory of your local repo, run:
-
-```
-$ make run
-```
-
-Doing so runs the `Flask` app inside a `Pipenv` virtualenv (the `Flask` app will
-also install dependencies as part of this process). On success, a
-development server for the backend should be started on `http://localhost:5000`.
-To check this, navigate to `http://localhost:5000/api/hello`. If everything worked
-correctly, your browser should display the text `Hello, world!`. Be sure to stop this process before launching the docker stack, because its backend service publishes to the same port.
 
 ##### Cleaning
 
@@ -161,12 +144,18 @@ in order to remove build artifacts.
 
 #### Running the Docker stack
 
-Docker provides a fully sandboxed virual environment from which we will run the app in production. The project stack must be built and run locally for the complete set of tests (discussed below) to pass, because it runs a local instance of the database. While in the directory of your local repo, run:
+Docker provides a fully sandboxed virtual environment from which we will run the app in production. The project stack must be built and run locally for the complete set of tests (discussed below) to pass, because it runs a local instance of the database. While in the directory of your local repo, run:
 
 ```
 docker swarm init
+```
+
+This enables docker to run a stack locally and only needs to be run once.
+
+```
 make dev
 ```
+
 This command builds the docker images (web server, flask backend, and postgres database) and launches a docker stack running the three services. Verify the backend is serving requests by navigating to `http://localhost:5000/api/hello`. The frontend can be reached at `http://localhost:3000`.
 
 Note: running docker requires root access by default. If you try to run this command with sudo it may fail because it messes up pipenv. Be sure to configure docker so you can run it without using sudo (see above).
@@ -183,6 +172,8 @@ Run all tests with the following command:
 ```bash
 $ make test
 ```
+
+If all of these tests pass, you have successfully set up the backend dev environment!
 
 ## Project Layout
 
@@ -201,7 +192,6 @@ $ make test
 `src`: Source dir
 
 `src/backend/expungeservice/app.py`: Flask application
-`
 
 ## <a name="contributing"></a>Contributing
 

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -1,25 +1,6 @@
 Record Expunge Docker Setup
 ===========================
 
-
-Installing on Mac
------------------
-
-Follow installation instructions in:
-
-    [Getting Started -- Docker on Mac OS X](https://medium.com/allenhwkim/getting-started-docker-on-mac-os-x-72c64670464a)
-
-(click on `Get Docker for Mac [Stable])
-
-
-Installing on Linux
--------------------
-
-[Ubuntu Installation](https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-using-the-repository)
-Links to install instructions for other linux distros listed in the sidebar.
-
-Configure Docker so that your user can run docker commands without using sudo: https://docs.docker.com/install/linux/linux-postinstall/
-
 Documentation
 -------------
 
@@ -31,7 +12,7 @@ Containers
 
 We will have three containers: a container for the web server and webapp; a container for the database; and a container for our service.
 
-Each container will have a Dockerfile that describes the container's contents. As a group the containers will be managed with `docker swarm`. For conveninence any complex/multi-part command will have a shorter Make target.
+Each container will have a Dockerfile that describes the container's contents. For conveninence any complex/multi-part command will have a shorter Make target.
 
 We will have two configurations:
 
@@ -53,7 +34,7 @@ This container will run the PostgreSQL database.
 
 **Service Container**
 
-This container will the Python/Flask backend.
+This container will run the Python/Flask backend.
 
 
 Running the containers
@@ -74,12 +55,14 @@ To build and start the containers, do:
 
 This builds the docker images that contain the different app components, then launches the docker stack by instantiating a docker service (which wraps one or more replicated containers) from each component image. While the dev stack is running, each service is accessible in the dev environment at `localhost:<port>`, at the exposed ports defined in the docker-compose.dev.yml file.
 
+Take a look at the Makefile to see all the steps in this make target. You can run these steps individually using the additional make targets provided.
+
 To see which containers are running:
 
     docker ps
 
 
-Individual targets in the Makefile exist for building each docker image. If making local changes to a single component, you can propagate them to the docker stack by rebuilding the image with:
+Individual targets in the Makefile exist for building each docker image. If making local changes to a single component, you can propagate them to the docker stack by first rebuilding the image with:
 
     make <image_name>
 
@@ -94,9 +77,9 @@ While the docker stack is running, it will restart any stopped containers automa
     make dev_stop
     make dev_deploy
 
-Note: the `dev_deploy` target rebuilds every image in the stack which may be time-consuming and not necessary if only updating a single image/service. To start a new docker stack without rebuilding the images, run this docker command directly while in the project's top-level directory:
+Note: the `dev_deploy` target rebuilds every image in the stack which may be time-consuming and not necessary if only updating a single image/service. To start a new docker stack without rebuilding the images, use:
 
-docker stack deploy -c docker-compose.yml -c docker-compose.dev.yml recordexpungpdx 
+    make dev_start
 
 
 To explore the database:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,6 +8,10 @@ services:
     webserver:
         ports:
             - "3000:3000"
+        ### uncomment these lines to disable the webserver in the docker stack.
+        ### This is useful if you'd rather run the npm server while developing frontend code.
+        #deploy:
+        #    replicas: 0
 
 
     db:

--- a/src/frontend/README.md
+++ b/src/frontend/README.md
@@ -31,9 +31,12 @@ See https://nodejs.org/api/errors.html#errors_common_system_errors for more info
 The proxy error is expected pending updates to the backend.
 
 
+5. While developing frontend code, may be useful to run the app backend to have access to its api endpoints. This process runs in the project Docker stack, which also runs an instance of the frontend webserver, at the same port used by `npm start`. In order to run the the npm server instead, you can first launch the docker stack (see the README.md file at the project's top-level directory) and then kill the docker webserver with `docker service rm recordexpungpdx_webserver`. You can also locally prevent the webserver from running within the docker stack, by uncommenting the relevant lines in the docker-compose.dev.yml file at the top-level project directory.
+
 If you run into any issues with the above steps, please ask someone for help.
 
-- - - 
+- - -
+
 
 The rest of this README is the text that [Create React App](https://github.com/facebook/create-react-app) (which we used to bootstrap the app) generates by default.
 


### PR DESCRIPTION
- removed the obsolete `make run` because the dev backend should run in Docker, not  with the Flask server.
- added a new make target `dev_start` and  few recommendations for using Docker