### PR TITLE
Refactor time analyzer

### DIFF
--- a/src/backend/expungeservice/expunger/analyzers/time_analyzer.py
+++ b/src/backend/expungeservice/expunger/analyzers/time_analyzer.py
@@ -9,29 +9,14 @@ class TimeAnalyzer:
     TEN_YEARS = 10
     THREE_YEARS = 3
 
-    def __init__(self, most_recent_conviction=None, second_most_recent_conviction=None, most_recent_dismissal=None,
-                 num_acquittals=0, class_b_felonies=[], most_recent_charge=None):
-        """
-
-        :param most_recent_conviction: Most recent conviction if one exists from within the last ten years
-        :param second_most_recent_conviction: Second most recent conviction if one exists from within the last ten years
-        :param most_recent_dismissal: Most recent dismissal if one exists from within the last three years
-        :param num_acquittals: Number of acquittals within the last three years
-        :param class_b_felonies: A list of class B felonies; excluding person crimes or firearm crimes
-        :param most_recent_charge: The most recent charge within the last 20yrs; excluding traffic violations
-        """
-        self._most_recent_conviction = most_recent_conviction
-        self._second_most_recent_conviction = second_most_recent_conviction
-        self._most_recent_dismissal = most_recent_dismissal
-        self._num_acquittals = num_acquittals
-        self._class_b_felonies = class_b_felonies
-        self._most_recent_charge = most_recent_charge
+    def __init__(self, expunger):
+        self._expunger = expunger
 
     def evaluate(self, charges):
-        if self._most_recent_conviction:
+        if self._expunger.most_recent_conviction:
             self._mark_all_charges_ineligible_using_mrc_date(charges, 'Time-ineligible under 137.225(7)(b)', self.TEN_YEARS)
             self._check_mrc_time_eligibility()
-        elif self._most_recent_dismissal and self._more_than_one_recent_acquittal_from_another_case():
+        elif self._expunger.most_recent_dismissal and self._more_than_one_recent_acquittal_from_another_case():
             self._mark_all_charges_ineligible_using_mrd_date(charges, 'Recommend sequential expungement of arrests')
             self._mark_all_mrd_case_related_charges_eligible()
         else:
@@ -40,41 +25,41 @@ class TimeAnalyzer:
         self._evaluate_class_b_felonies()
 
     def _mark_all_charges_ineligible_using_mrc_date(self, charges, reason, years):
-        eligibility_date = self._most_recent_conviction.disposition.date + relativedelta(years=years)
+        eligibility_date = self._expunger.most_recent_conviction.disposition.date + relativedelta(years=years)
         for charge in charges:
             charge.set_time_ineligible(reason, eligibility_date)
 
     def _check_mrc_time_eligibility(self):
-        if self._second_most_recent_conviction:
-            eligibility_date = self._second_most_recent_conviction.disposition.date + relativedelta(years=self.TEN_YEARS)
-            self._most_recent_conviction.set_time_ineligible('Multiple convictions within last ten years', eligibility_date)
+        if self._expunger.second_most_recent_conviction:
+            eligibility_date = self._expunger.second_most_recent_conviction.disposition.date + relativedelta(years=self.TEN_YEARS)
+            self._expunger.most_recent_conviction.set_time_ineligible('Multiple convictions within last ten years', eligibility_date)
         elif self._most_recent_conviction_is_greater_than_three_years_old():
-            self._most_recent_conviction.set_time_eligible()
+            self._expunger.most_recent_conviction.set_time_eligible()
         else:
-            eligibility_date = self._most_recent_conviction.disposition.date + relativedelta(years=self.THREE_YEARS)
-            self._most_recent_conviction.set_time_ineligible('Most recent conviction is less than three years old', eligibility_date)
+            eligibility_date = self._expunger.most_recent_conviction.disposition.date + relativedelta(years=self.THREE_YEARS)
+            self._expunger.most_recent_conviction.set_time_ineligible('Most recent conviction is less than three years old', eligibility_date)
 
     def _most_recent_conviction_is_greater_than_three_years_old(self):
         three_years_ago = date.today() + relativedelta(years=-3)
-        return self._most_recent_conviction.disposition.date <= three_years_ago
+        return self._expunger.most_recent_conviction.disposition.date <= three_years_ago
 
     def _more_than_one_recent_acquittal_from_another_case(self):
-        return self._num_acquittals - len(self._most_recent_dismissal.case()().charges) > 0
+        return self._expunger.num_acquittals - len(self._expunger.most_recent_dismissal.case()().charges) > 0
 
     def _mark_all_charges_ineligible_using_mrd_date(self, charges, reason):
-        eligibility_date = self._most_recent_dismissal.date + relativedelta(years=+self.THREE_YEARS)
+        eligibility_date = self._expunger.most_recent_dismissal.date + relativedelta(years=+self.THREE_YEARS)
         for charge in charges:
             charge.set_time_ineligible(reason, eligibility_date)
 
     def _mark_all_mrd_case_related_charges_eligible(self):
-        for charge in self._most_recent_dismissal.case()().charges:
+        for charge in self._expunger.most_recent_dismissal.case()().charges:
             charge.set_time_eligible('Recommend sequential expungement of arrests')
 
     def _evaluate_class_b_felonies(self):
-        if self._most_recent_charge and self._most_recent_charge.disposition.date > self.TWENTY_YEARS_AGO:
-            for charge in self._class_b_felonies:
+        if self._expunger.most_recent_charge and self._expunger.most_recent_charge.disposition.date > self.TWENTY_YEARS_AGO:
+            for charge in self._expunger.class_b_felonies:
                 charge.set_time_ineligible('Time-ineligible under 137.225(5)(a)(A)(i)',
-                                           self._most_recent_charge.disposition.date + relativedelta(
+                                           self._expunger.most_recent_charge.disposition.date + relativedelta(
                                                years=self.TWENTY_YEARS))
 
     @staticmethod

--- a/src/backend/expungeservice/expunger/analyzers/time_analyzer.py
+++ b/src/backend/expungeservice/expunger/analyzers/time_analyzer.py
@@ -9,60 +9,65 @@ class TimeAnalyzer:
     TEN_YEARS = 10
     THREE_YEARS = 3
 
-    def __init__(self, expunger):
-        self._expunger = expunger
-
-    def evaluate(self, charges):
-        if self._expunger.most_recent_conviction:
-            self._mark_all_charges_ineligible_using_mrc_date(charges, 'Time-ineligible under 137.225(7)(b)', self.TEN_YEARS)
-            self._check_mrc_time_eligibility()
-        elif self._expunger.most_recent_dismissal and self._more_than_one_recent_acquittal_from_another_case():
-            self._mark_all_charges_ineligible_using_mrd_date(charges, 'Recommend sequential expungement of arrests')
-            self._mark_all_mrd_case_related_charges_eligible()
+    @staticmethod
+    def evaluate(expunger):
+        if expunger.most_recent_conviction:
+            TimeAnalyzer._mark_all_charges_ineligible_using_mrc_date(expunger, 'Time-ineligible under 137.225(7)(b)', TimeAnalyzer.TEN_YEARS)
+            TimeAnalyzer._check_mrc_time_eligibility(expunger)
+        elif expunger.most_recent_dismissal and TimeAnalyzer._more_than_one_recent_acquittal_from_another_case(expunger):
+            TimeAnalyzer._mark_all_charges_ineligible_using_mrd_date(expunger, 'Recommend sequential expungement of arrests')
+            TimeAnalyzer._mark_all_mrd_case_related_charges_eligible(expunger)
         else:
-            TimeAnalyzer._mark_all_charges_eligible(charges)
+            TimeAnalyzer._mark_all_charges_eligible(expunger)
 
-        self._evaluate_class_b_felonies()
-
-    def _mark_all_charges_ineligible_using_mrc_date(self, charges, reason, years):
-        eligibility_date = self._expunger.most_recent_conviction.disposition.date + relativedelta(years=years)
-        for charge in charges:
-            charge.set_time_ineligible(reason, eligibility_date)
-
-    def _check_mrc_time_eligibility(self):
-        if self._expunger.second_most_recent_conviction:
-            eligibility_date = self._expunger.second_most_recent_conviction.disposition.date + relativedelta(years=self.TEN_YEARS)
-            self._expunger.most_recent_conviction.set_time_ineligible('Multiple convictions within last ten years', eligibility_date)
-        elif self._most_recent_conviction_is_greater_than_three_years_old():
-            self._expunger.most_recent_conviction.set_time_eligible()
-        else:
-            eligibility_date = self._expunger.most_recent_conviction.disposition.date + relativedelta(years=self.THREE_YEARS)
-            self._expunger.most_recent_conviction.set_time_ineligible('Most recent conviction is less than three years old', eligibility_date)
-
-    def _most_recent_conviction_is_greater_than_three_years_old(self):
-        three_years_ago = date.today() + relativedelta(years=-3)
-        return self._expunger.most_recent_conviction.disposition.date <= three_years_ago
-
-    def _more_than_one_recent_acquittal_from_another_case(self):
-        return self._expunger.num_acquittals - len(self._expunger.most_recent_dismissal.case()().charges) > 0
-
-    def _mark_all_charges_ineligible_using_mrd_date(self, charges, reason):
-        eligibility_date = self._expunger.most_recent_dismissal.date + relativedelta(years=+self.THREE_YEARS)
-        for charge in charges:
-            charge.set_time_ineligible(reason, eligibility_date)
-
-    def _mark_all_mrd_case_related_charges_eligible(self):
-        for charge in self._expunger.most_recent_dismissal.case()().charges:
-            charge.set_time_eligible('Recommend sequential expungement of arrests')
-
-    def _evaluate_class_b_felonies(self):
-        if self._expunger.most_recent_charge and self._expunger.most_recent_charge.disposition.date > self.TWENTY_YEARS_AGO:
-            for charge in self._expunger.class_b_felonies:
-                charge.set_time_ineligible('Time-ineligible under 137.225(5)(a)(A)(i)',
-                                           self._expunger.most_recent_charge.disposition.date + relativedelta(
-                                               years=self.TWENTY_YEARS))
+        TimeAnalyzer._evaluate_class_b_felonies(expunger)
 
     @staticmethod
-    def _mark_all_charges_eligible(charges):
-        for charge in charges:
+    def _mark_all_charges_ineligible_using_mrc_date(expunger, reason, years):
+        eligibility_date = expunger.most_recent_conviction.disposition.date + relativedelta(years=years)
+        for charge in expunger.charges:
+            charge.set_time_ineligible(reason, eligibility_date)
+
+    @staticmethod
+    def _check_mrc_time_eligibility(expunger):
+        if expunger.second_most_recent_conviction:
+            eligibility_date = expunger.second_most_recent_conviction.disposition.date + relativedelta(years=TimeAnalyzer.TEN_YEARS)
+            expunger.most_recent_conviction.set_time_ineligible('Multiple convictions within last ten years', eligibility_date)
+        elif TimeAnalyzer._most_recent_conviction_is_greater_than_three_years_old(expunger):
+            expunger.most_recent_conviction.set_time_eligible()
+        else:
+            eligibility_date = expunger.most_recent_conviction.disposition.date + relativedelta(years=TimeAnalyzer.THREE_YEARS)
+            expunger.most_recent_conviction.set_time_ineligible('Most recent conviction is less than three years old', eligibility_date)
+
+    @staticmethod
+    def _most_recent_conviction_is_greater_than_three_years_old(expunger):
+        three_years_ago = date.today() + relativedelta(years=-3)
+        return expunger.most_recent_conviction.disposition.date <= three_years_ago
+
+    @staticmethod
+    def _more_than_one_recent_acquittal_from_another_case(expunger):
+        return expunger.num_acquittals - len(expunger.most_recent_dismissal.case()().charges) > 0
+
+    @staticmethod
+    def _mark_all_charges_ineligible_using_mrd_date(expunger, reason):
+        eligibility_date = expunger.most_recent_dismissal.date + relativedelta(years=+TimeAnalyzer.THREE_YEARS)
+        for charge in expunger.charges:
+            charge.set_time_ineligible(reason, eligibility_date)
+
+    @staticmethod
+    def _mark_all_mrd_case_related_charges_eligible(expunger):
+        for charge in expunger.most_recent_dismissal.case()().charges:
+            charge.set_time_eligible('Recommend sequential expungement of arrests')
+
+    @staticmethod
+    def _evaluate_class_b_felonies(expunger):
+        if expunger.most_recent_charge and expunger.most_recent_charge.disposition.date > TimeAnalyzer.TWENTY_YEARS_AGO:
+            for charge in expunger.class_b_felonies:
+                charge.set_time_ineligible('Time-ineligible under 137.225(5)(a)(A)(i)',
+                                           expunger.most_recent_charge.disposition.date + relativedelta(
+                                               years=TimeAnalyzer.TWENTY_YEARS))
+
+    @staticmethod
+    def _mark_all_charges_eligible(expunger):
+        for charge in expunger.charges:
             charge.set_time_eligible()

--- a/src/backend/expungeservice/expunger/analyzers/time_analyzer.py
+++ b/src/backend/expungeservice/expunger/analyzers/time_analyzer.py
@@ -12,10 +12,12 @@ class TimeAnalyzer:
     @staticmethod
     def evaluate(expunger):
         if expunger.most_recent_conviction:
-            TimeAnalyzer._mark_all_charges_ineligible_using_mrc_date(expunger, 'Time-ineligible under 137.225(7)(b)', TimeAnalyzer.TEN_YEARS)
+            TimeAnalyzer._mark_all_charges_ineligible_using_mrc_date(expunger, 'Time-ineligible under 137.225(7)(b)',
+                                                                     TimeAnalyzer.TEN_YEARS)
             TimeAnalyzer._check_mrc_time_eligibility(expunger)
         elif expunger.most_recent_dismissal and TimeAnalyzer._more_than_one_recent_acquittal_from_another_case(expunger):
-            TimeAnalyzer._mark_all_charges_ineligible_using_mrd_date(expunger, 'Recommend sequential expungement of arrests')
+            TimeAnalyzer._mark_all_charges_ineligible_using_mrd_date(expunger,
+                                                                     'Recommend sequential expungement of arrests')
             TimeAnalyzer._mark_all_mrd_case_related_charges_eligible(expunger)
         else:
             TimeAnalyzer._mark_all_charges_eligible(expunger)
@@ -31,13 +33,17 @@ class TimeAnalyzer:
     @staticmethod
     def _check_mrc_time_eligibility(expunger):
         if expunger.second_most_recent_conviction:
-            eligibility_date = expunger.second_most_recent_conviction.disposition.date + relativedelta(years=TimeAnalyzer.TEN_YEARS)
-            expunger.most_recent_conviction.set_time_ineligible('Multiple convictions within last ten years', eligibility_date)
+            eligibility_date = expunger.second_most_recent_conviction.disposition.date + relativedelta(
+                years=TimeAnalyzer.TEN_YEARS)
+            expunger.most_recent_conviction.set_time_ineligible('Multiple convictions within last ten years',
+                                                                eligibility_date)
         elif TimeAnalyzer._most_recent_conviction_is_greater_than_three_years_old(expunger):
             expunger.most_recent_conviction.set_time_eligible()
         else:
-            eligibility_date = expunger.most_recent_conviction.disposition.date + relativedelta(years=TimeAnalyzer.THREE_YEARS)
-            expunger.most_recent_conviction.set_time_ineligible('Most recent conviction is less than three years old', eligibility_date)
+            eligibility_date = expunger.most_recent_conviction.disposition.date + relativedelta(
+                years=TimeAnalyzer.THREE_YEARS)
+            expunger.most_recent_conviction.set_time_ineligible('Most recent conviction is less than three years old',
+                                                                eligibility_date)
 
     @staticmethod
     def _most_recent_conviction_is_greater_than_three_years_old(expunger):

--- a/src/backend/expungeservice/expunger/expunger.py
+++ b/src/backend/expungeservice/expunger/expunger.py
@@ -26,7 +26,7 @@ class Expunger:
         :param record: A Record object
         '''
         self.record = record
-        self._charges = record.charges
+        self.charges = record.charges
         self.errors = []
         self._skipped_charges = []
         self.most_recent_dismissal = None
@@ -68,16 +68,16 @@ class Expunger:
         return False
 
     def _tag_skipped_charges(self):
-        for charge in self._charges:
+        for charge in self.charges:
             if charge.skip_analysis():
                 self._skipped_charges.append(charge)
 
     def _remove_skipped_charges(self):
         for charge in self._skipped_charges:
-            self._charges.remove(charge)
+            self.charges.remove(charge)
 
     def _categorize_charges(self):
-        for charge in self._charges:
+        for charge in self.charges:
             if charge.acquitted():
                 self.acquittals.append(charge)
             else:
@@ -101,17 +101,17 @@ class Expunger:
                 self.num_acquittals += 1
 
     def _assign_most_recent_charge(self):
-        self._charges.sort(key=lambda charge: charge.disposition.date, reverse=True)
+        self.charges.sort(key=lambda charge: charge.disposition.date, reverse=True)
 
-        if self._charges:
+        if self.charges:
             self.most_recent_charge = self._most_recent_non_traffic_violation()
 
     def _most_recent_non_traffic_violation(self):
-        for charge in self._charges:
+        for charge in self.charges:
             if not charge.motor_vehicle_violation():
                 return charge
 
     def _assign_class_b_felonies(self):
-        for charge in self._charges:
+        for charge in self.charges:
             if charge.__class__.__name__ == 'FelonyClassB':
                 self.class_b_felonies.append(charge)

--- a/src/backend/expungeservice/expunger/expunger.py
+++ b/src/backend/expungeservice/expunger/expunger.py
@@ -37,7 +37,6 @@ class Expunger:
         self.acquittals = []
         self._convictions = []
         self.class_b_felonies = []
-        self._time_analyzer = None
 
     def run(self):
         """
@@ -57,8 +56,7 @@ class Expunger:
         self._set_num_acquittals()
         self._assign_most_recent_charge()
         self._assign_class_b_felonies()
-        self._time_analyzer = TimeAnalyzer(self)
-        self._time_analyzer.evaluate(self._charges)
+        TimeAnalyzer.evaluate(self)
         return True
 
     def _open_cases(self):

--- a/src/backend/expungeservice/expunger/expunger.py
+++ b/src/backend/expungeservice/expunger/expunger.py
@@ -16,6 +16,12 @@ class Expunger:
     def __init__(self, record):
         '''
         Constructor
+        most_recent_conviction: Most recent conviction if one exists from within the last ten years
+        second_most_recent_conviction: Second most recent conviction if one exists from within the last ten years
+        most_recent_dismissal: Most recent dismissal if one exists from within the last three years
+        num_acquittals: Number of acquittals within the last three years
+        class_b_felonies: A list of class B felonies; excluding person crimes or firearm crimes
+        most_recent_charge: The most recent charge within the last 20yrs; excluding traffic violations
 
         :param record: A Record object
         '''
@@ -51,12 +57,7 @@ class Expunger:
         self._set_num_acquittals()
         self._assign_most_recent_charge()
         self._assign_class_b_felonies()
-        self._time_analyzer = TimeAnalyzer(most_recent_conviction=self._most_recent_conviction,
-                                           second_most_recent_conviction=self._second_most_recent_conviction,
-                                           most_recent_dismissal=self._most_recent_dismissal,
-                                           num_acquittals=self._num_acquittals,
-                                           class_b_felonies=self._class_b_felonies,
-                                           most_recent_charge=self._most_recent_charge)
+        self._time_analyzer = TimeAnalyzer(self)
         self._time_analyzer.evaluate(self._charges)
         return True
 

--- a/src/backend/expungeservice/expunger/expunger.py
+++ b/src/backend/expungeservice/expunger/expunger.py
@@ -23,14 +23,14 @@ class Expunger:
         self._charges = record.charges
         self.errors = []
         self._skipped_charges = []
-        self._most_recent_dismissal = None
-        self._most_recent_conviction = None
-        self._second_most_recent_conviction = None
-        self._most_recent_charge = None
-        self._num_acquittals = 0
-        self._acquittals = []
+        self.most_recent_dismissal = None
+        self.most_recent_conviction = None
+        self.second_most_recent_conviction = None
+        self.most_recent_charge = None
+        self.num_acquittals = 0
+        self.acquittals = []
         self._convictions = []
-        self._class_b_felonies = []
+        self.class_b_felonies = []
         self._time_analyzer = None
 
     def run(self):
@@ -78,32 +78,32 @@ class Expunger:
     def _categorize_charges(self):
         for charge in self._charges:
             if charge.acquitted():
-                self._acquittals.append(charge)
+                self.acquittals.append(charge)
             else:
                 self._convictions.append(charge)
 
     def _set_most_recent_dismissal(self):
-        self._acquittals.sort(key=lambda charge: charge.date)
-        if self._acquittals and self._acquittals[-1].recent_acquittal():
-            self._most_recent_dismissal = self._acquittals[-1]
+        self.acquittals.sort(key=lambda charge: charge.date)
+        if self.acquittals and self.acquittals[-1].recent_acquittal():
+            self.most_recent_dismissal = self.acquittals[-1]
 
     def _set_most_recent_convictions(self):
         self._convictions.sort(key=lambda charge: charge.disposition.date)
         if len(self._convictions) > 0 and self._convictions[-1].recent_conviction():
-            self._most_recent_conviction = self._convictions[-1]
+            self.most_recent_conviction = self._convictions[-1]
         if len(self._convictions) > 1 and self._convictions[-2].recent_conviction():
-            self._second_most_recent_conviction = self._convictions[-2]
+            self.second_most_recent_conviction = self._convictions[-2]
 
     def _set_num_acquittals(self):
-        for charge in self._acquittals:
+        for charge in self.acquittals:
             if charge.recent_acquittal():
-                self._num_acquittals += 1
+                self.num_acquittals += 1
 
     def _assign_most_recent_charge(self):
         self._charges.sort(key=lambda charge: charge.disposition.date, reverse=True)
 
         if self._charges:
-            self._most_recent_charge = self._most_recent_non_traffic_violation()
+            self.most_recent_charge = self._most_recent_non_traffic_violation()
 
     def _most_recent_non_traffic_violation(self):
         for charge in self._charges:
@@ -113,4 +113,4 @@ class Expunger:
     def _assign_class_b_felonies(self):
         for charge in self._charges:
             if charge.__class__.__name__ == 'FelonyClassB':
-                self._class_b_felonies.append(charge)
+                self.class_b_felonies.append(charge)

--- a/src/backend/tests/expunger/test_expunger.py
+++ b/src/backend/tests/expunger/test_expunger.py
@@ -32,7 +32,7 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         expunger = Expunger(record)
         expunger.run()
 
-        assert expunger._most_recent_dismissal is mrd_charge
+        assert expunger.most_recent_dismissal is mrd_charge
 
     def test_expunger_does_not_set_most_recent_dismissal_when_case_is_older_than_3yrs(self):
         case = CaseFactory.create()
@@ -44,7 +44,7 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         expunger = Expunger(record)
         expunger.run()
 
-        assert expunger._most_recent_dismissal is None
+        assert expunger.most_recent_dismissal is None
 
     def test_expunger_sets_mrd_when_mrd_is_in_middle_of_list(self):
         case = CaseFactory.create()
@@ -56,7 +56,7 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         expunger = Expunger(record)
         expunger.run()
 
-        assert expunger._most_recent_dismissal is mrd_charge
+        assert expunger.most_recent_dismissal is mrd_charge
 
     def test_expunger_sets_mrd_when_mrd_is_at_end_of_list(self):
         case = CaseFactory.create()
@@ -68,7 +68,7 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         expunger = Expunger(record)
         expunger.run()
 
-        assert expunger._most_recent_dismissal is mrd_charge
+        assert expunger.most_recent_dismissal is mrd_charge
 
     def test_it_sets_most_recent_conviction_from_the_last_10yrs(self):
         case = CaseFactory.create()
@@ -80,7 +80,7 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         expunger = Expunger(record)
         expunger.run()
 
-        assert expunger._most_recent_conviction is mrc_charge
+        assert expunger.most_recent_conviction is mrc_charge
 
     def test_it_sets_the_second_most_recent_conviction_within_the_last_10yrs(self):
         case = CaseFactory.create()
@@ -95,7 +95,7 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         expunger = Expunger(record)
         expunger.run()
 
-        assert expunger._second_most_recent_conviction is second_mrc_charge
+        assert expunger.second_most_recent_conviction is second_mrc_charge
 
     def test_it_does_not_set_mrc_when_greater_than_10yrs(self):
         case = CaseFactory.create()
@@ -107,7 +107,7 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         expunger = Expunger(record)
         expunger.run()
 
-        assert expunger._most_recent_conviction is None
+        assert expunger.most_recent_conviction is None
 
     def test_it_does_not_set_2nd_mrc_when_greater_than_10yrs(self):
         case = CaseFactory.create()
@@ -121,7 +121,7 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         expunger = Expunger(record)
         expunger.run()
 
-        assert expunger._second_most_recent_conviction is None
+        assert expunger.second_most_recent_conviction is None
 
     def test_mrc_and_second_mrc(self):
         case = CaseFactory.create()
@@ -137,8 +137,8 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         expunger = Expunger(record)
         expunger.run()
 
-        assert expunger._most_recent_conviction is mrc_charge
-        assert expunger._second_most_recent_conviction is second_mrc_charge
+        assert expunger.most_recent_conviction is mrc_charge
+        assert expunger.second_most_recent_conviction is second_mrc_charge
 
     def test_num_acquittals(self):
         case = CaseFactory.create()
@@ -153,7 +153,7 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         expunger = Expunger(record)
         expunger.run()
 
-        assert expunger._num_acquittals == 3
+        assert expunger.num_acquittals == 3
 
     def test_num_acquittals(self):
         case = CaseFactory.create()
@@ -165,7 +165,7 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         expunger = Expunger(record)
         expunger.run()
 
-        assert expunger._num_acquittals == 0
+        assert expunger.num_acquittals == 0
 
     def test_most_recent_charge(self):
         case = CaseFactory.create()
@@ -180,7 +180,7 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         expunger = Expunger(record)
         expunger.run()
 
-        assert expunger._most_recent_charge is None
+        assert expunger.most_recent_charge is None
 
     def test_most_recent_charge_with_non_traffic_violations(self):
         case = CaseFactory.create()
@@ -201,7 +201,7 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         expunger = Expunger(record)
         expunger.run()
 
-        assert expunger._most_recent_charge == two_year_ago_dismissal
+        assert expunger.most_recent_charge == two_year_ago_dismissal
 
     def test_parking_ticket_is_not_recent_charge(self):
         case = CaseFactory.create()
@@ -214,7 +214,7 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         expunger = Expunger(record)
         expunger.run()
 
-        assert expunger._most_recent_charge is None
+        assert expunger.most_recent_charge is None
 
     def test_it_skips_closed_cases_without_dispositions(self):
         case = CaseFactory.create()

--- a/src/backend/tests/expunger/test_expunger.py
+++ b/src/backend/tests/expunger/test_expunger.py
@@ -235,4 +235,4 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
 
         assert expunger.run()
         assert expunger._skipped_charges[0] == juvenile_charge
-        assert expunger._charges == []
+        assert expunger.charges == []

--- a/src/backend/tests/expunger/test_time_analyzer.py
+++ b/src/backend/tests/expunger/test_time_analyzer.py
@@ -23,15 +23,13 @@ class TestSingleChargeAcquittals(unittest.TestCase):
     TEN_YEARS = relativedelta(years=10)
 
     def setUp(self):
-        self.charges = []
         self.expunger = ExpungerFactory.create()
 
     def test_more_than_ten_year_old_conviction(self):
         charge = ChargeFactory.create(disposition=['Convicted', self.TEN_YEARS_AGO])
 
-        time_analyzer = TimeAnalyzer(self.expunger)
-        self.charges.append(charge)
-        time_analyzer.evaluate(self.charges)
+        self.expunger.charges = [charge]
+        TimeAnalyzer.evaluate(self.expunger)
 
         assert charge.expungement_result.time_eligibility is True
         assert charge.expungement_result.time_eligibility_reason == ''
@@ -40,11 +38,10 @@ class TestSingleChargeAcquittals(unittest.TestCase):
     def test_10_yr_old_conviction_with_3_yr_old_mrc(self):
         ten_yr_charge = ChargeFactory.create(disposition=['Convicted', self.TEN_YEARS_AGO])
         three_yr_mrc = ChargeFactory.create(disposition=['Convicted', self.THREE_YEARS_AGO])
-        self.expunger.most_recent_conviction = three_yr_mrc
 
-        time_analyzer = TimeAnalyzer(self.expunger)
-        self.charges.extend([ten_yr_charge, three_yr_mrc])
-        time_analyzer.evaluate(self.charges)
+        self.expunger.most_recent_conviction = three_yr_mrc
+        self.expunger.charges = [ten_yr_charge, three_yr_mrc]
+        TimeAnalyzer.evaluate(self.expunger)
 
         assert ten_yr_charge.expungement_result.time_eligibility is False
         assert ten_yr_charge.expungement_result.time_eligibility_reason == 'Time-ineligible under 137.225(7)(b)'
@@ -57,11 +54,10 @@ class TestSingleChargeAcquittals(unittest.TestCase):
     def test_10_yr_old_conviction_with_less_than_3_yr_old_mrc(self):
         ten_yr_charge = ChargeFactory.create(disposition=['Convicted', self.TEN_YEARS_AGO])
         less_than_three_yr_mrc = ChargeFactory.create(disposition=['Convicted', self.LESS_THAN_THREE_YEARS_AGO])
-        self.expunger.most_recent_conviction = less_than_three_yr_mrc
 
-        time_analyzer = TimeAnalyzer(self.expunger)
-        self.charges.extend([ten_yr_charge, less_than_three_yr_mrc])
-        time_analyzer.evaluate(self.charges)
+        self.expunger.most_recent_conviction = less_than_three_yr_mrc
+        self.expunger.charges = [ten_yr_charge, less_than_three_yr_mrc]
+        TimeAnalyzer.evaluate(self.expunger)
 
         assert ten_yr_charge.expungement_result.time_eligibility is False
         assert ten_yr_charge.expungement_result.time_eligibility_reason == 'Time-ineligible under 137.225(7)(b)'
@@ -73,11 +69,10 @@ class TestSingleChargeAcquittals(unittest.TestCase):
 
     def test_more_than_three_year_rule_conviction(self):
         charge = ChargeFactory.create(disposition=['Convicted', self.THREE_YEARS_AGO])
-        self.expunger.most_recent_conviction = charge
 
-        time_analyzer = TimeAnalyzer(self.expunger)
-        self.charges.append(charge)
-        time_analyzer.evaluate(self.charges)
+        self.expunger.most_recent_conviction = charge
+        self.expunger.charges = [charge]
+        TimeAnalyzer.evaluate(self.expunger)
 
         assert charge.expungement_result.time_eligibility is True
         assert charge.expungement_result.time_eligibility_reason == ''
@@ -85,11 +80,10 @@ class TestSingleChargeAcquittals(unittest.TestCase):
 
     def test_less_than_three_year_rule_conviction(self):
         charge = ChargeFactory.create(disposition=['Convicted', self.LESS_THAN_THREE_YEARS_AGO])
-        self.expunger.most_recent_conviction = charge
 
-        time_analyzer = TimeAnalyzer(self.expunger)
-        self.charges.append(charge)
-        time_analyzer.evaluate(self.charges)
+        self.expunger.most_recent_conviction = charge
+        self.expunger.charges = [charge]
+        TimeAnalyzer.evaluate(self.expunger)
 
         assert charge.expungement_result.time_eligibility is False
         assert charge.expungement_result.time_eligibility_reason == 'Most recent conviction is less than three years old'
@@ -98,12 +92,11 @@ class TestSingleChargeAcquittals(unittest.TestCase):
     def test_3_yr_old_conviction_2_yr_old_mrc(self):
         three_years_ago_charge = ChargeFactory.create(disposition=['Convicted', self.THREE_YEARS_AGO])
         two_years_ago_charge = ChargeFactory.create(disposition=['Convicted', self.TWO_YEARS_AGO])
+
         self.expunger.most_recent_conviction = two_years_ago_charge
         self.expunger.second_most_recent_conviction = three_years_ago_charge
-
-        time_analyzer = TimeAnalyzer(self.expunger)
-        self.charges.extend([three_years_ago_charge, two_years_ago_charge])
-        time_analyzer.evaluate(self.charges)
+        self.expunger.charges = [three_years_ago_charge, two_years_ago_charge]
+        TimeAnalyzer.evaluate(self.expunger)
 
         assert three_years_ago_charge.expungement_result.time_eligibility is False
         assert three_years_ago_charge.expungement_result.time_eligibility_reason == 'Time-ineligible under 137.225(7)(b)'
@@ -116,12 +109,11 @@ class TestSingleChargeAcquittals(unittest.TestCase):
     def test_7_yr_old_conviction_5_yr_old_mrc(self):
         seven_year_ago_charge = ChargeFactory.create(disposition=['Convicted', self.SEVEN_YEARS_AGO])
         five_year_ago_charge = ChargeFactory.create(disposition=['Convicted', self.FIVE_YEARS_AGO])
+
         self.expunger.most_recent_conviction = five_year_ago_charge
         self.expunger.second_most_recent_conviction = seven_year_ago_charge
-
-        time_analyzer = TimeAnalyzer(self.expunger)
-        self.charges.extend([five_year_ago_charge, seven_year_ago_charge])
-        time_analyzer.evaluate(self.charges)
+        self.expunger.charges = [five_year_ago_charge, seven_year_ago_charge]
+        TimeAnalyzer.evaluate(self.expunger)
 
         assert seven_year_ago_charge.expungement_result.time_eligibility is False
         assert seven_year_ago_charge.expungement_result.time_eligibility_reason == 'Time-ineligible under 137.225(7)(b)'
@@ -133,11 +125,10 @@ class TestSingleChargeAcquittals(unittest.TestCase):
 
     def test_less_than_3yr_old_acquittal(self):
         less_than_3yr_acquittal = ChargeFactory.create(disposition=['Dismissed', self.LESS_THAN_THREE_YEARS_AGO])
-        self.expunger.most_recent_dismissal = less_than_3yr_acquittal
 
-        time_analyzer = TimeAnalyzer(self.expunger)
-        self.charges.append(less_than_3yr_acquittal)
-        time_analyzer.evaluate(self.charges)
+        self.expunger.most_recent_dismissal = less_than_3yr_acquittal
+        self.expunger.charges = [less_than_3yr_acquittal]
+        TimeAnalyzer.evaluate(self.expunger)
 
         assert less_than_3yr_acquittal.expungement_result.time_eligibility is True
         assert less_than_3yr_acquittal.expungement_result.time_eligibility_reason == ''
@@ -153,9 +144,8 @@ class TestSingleChargeAcquittals(unittest.TestCase):
         self.expunger.most_recent_dismissal = two_year_acquittal
         self.expunger.num_acquittals = 2
 
-        time_analyzer = TimeAnalyzer(self.expunger)
-        self.charges.extend([two_year_acquittal, less_than_3yr_acquittal])
-        time_analyzer.evaluate(self.charges)
+        self.expunger.charges = [two_year_acquittal, less_than_3yr_acquittal]
+        TimeAnalyzer.evaluate(self.expunger)
 
         assert two_year_acquittal.expungement_result.time_eligibility is True
         assert two_year_acquittal.expungement_result.time_eligibility_reason == 'Recommend sequential expungement of arrests'
@@ -172,12 +162,12 @@ class TestSingleChargeAcquittals(unittest.TestCase):
                                                   disposition=['Dismissed', self.TWO_YEARS_AGO])
         less_than_3yr_acquittal = ChargeFactory.create(case=case, disposition=['Dismissed', self.LESS_THAN_THREE_YEARS_AGO])
         case.charges = [two_year_acquittal, less_than_3yr_acquittal]
+
         self.expunger.most_recent_dismissal = two_year_acquittal
         self.expunger.num_acquittals = 2
 
-        time_analyzer = TimeAnalyzer(self.expunger)
-        self.charges.extend([two_year_acquittal, less_than_3yr_acquittal])
-        time_analyzer.evaluate(self.charges)
+        self.expunger.charges = [two_year_acquittal, less_than_3yr_acquittal]
+        TimeAnalyzer.evaluate(self.expunger)
 
         assert two_year_acquittal.expungement_result.time_eligibility is True
         assert two_year_acquittal.expungement_result.time_eligibility_reason == ''
@@ -198,12 +188,12 @@ class TestSingleChargeAcquittals(unittest.TestCase):
         case_2 = CaseFactory.create()
         less_than_3yr_acquittal_2 = ChargeFactory.create(case=case_2, disposition=['Dismissed', self.LESS_THAN_THREE_YEARS_AGO])
         case_2.charges = [less_than_3yr_acquittal_2]
+
         self.expunger.most_recent_dismissal = two_year_acquittal
         self.expunger.num_acquittals = 3
 
-        time_analyzer = TimeAnalyzer(self.expunger)
-        self.charges.extend([two_year_acquittal, less_than_3yr_acquittal, less_than_3yr_acquittal_2])
-        time_analyzer.evaluate(self.charges)
+        self.expunger.charges = [two_year_acquittal, less_than_3yr_acquittal, less_than_3yr_acquittal_2]
+        TimeAnalyzer.evaluate(self.expunger)
 
         assert two_year_acquittal.expungement_result.time_eligibility is True
         assert two_year_acquittal.expungement_result.time_eligibility_reason == 'Recommend sequential expungement of arrests'
@@ -227,9 +217,8 @@ class TestSingleChargeAcquittals(unittest.TestCase):
         self.expunger.class_b_felonies = [charge]
         self.expunger.most_recent_charge = charge
 
-        self.charges.extend([charge])
-        time_analyzer = TimeAnalyzer(self.expunger)
-        time_analyzer.evaluate(self.charges)
+        self.expunger.charges = [charge]
+        TimeAnalyzer.evaluate(self.expunger)
 
         assert charge.expungement_result.time_eligibility is True
         assert charge.expungement_result.time_eligibility_reason == ''
@@ -245,9 +234,8 @@ class TestSingleChargeAcquittals(unittest.TestCase):
         self.expunger.class_b_felonies = [charge]
         self.expunger.most_recent_charge = charge
 
-        self.charges.extend([charge])
-        time_analyzer = TimeAnalyzer(self.expunger)
-        time_analyzer.evaluate(self.charges)
+        self.expunger.charges = [charge]
+        TimeAnalyzer.evaluate(self.expunger)
 
         assert charge.expungement_result.time_eligibility is False
         assert charge.expungement_result.time_eligibility_reason == 'Time-ineligible under 137.225(5)(a)(A)(i)'

--- a/src/backend/tests/factories/expunger_factory.py
+++ b/src/backend/tests/factories/expunger_factory.py
@@ -1,0 +1,9 @@
+from expungeservice.expunger.expunger import Expunger
+from expungeservice.models.record import Record
+
+
+class ExpungerFactory:
+
+    @staticmethod
+    def create():
+        return Expunger(Record([]))

--- a/src/backend/tests/functional_tests/test_crawler_expunger.py
+++ b/src/backend/tests/functional_tests/test_crawler_expunger.py
@@ -50,49 +50,7 @@ class TestCrawlerAndExpunger(unittest.TestCase):
         assert len(expunger.acquittals) == 5
         assert len(expunger._convictions) == 4
 
-    def test_expunger_calls_time_analyzer(self):
-        record = CrawlerFactory.create(self.crawler,
-                              cases={'X0001': CaseDetails.case_x(arrest_date=self.FIFTEEN_YEARS_AGO.strftime('%m/%d/%Y'),
-                                                                 dispo_ruling_1='Dismissed',
-                                                                 dispo_ruling_2='Dismissed',
-                                                                 dispo_ruling_3='Acquitted'),
-                                     'X0002': CaseDetails.case_x(arrest_date=self.TWO_YEARS_AGO.strftime('%m/%d/%Y'),
-                                                                 dispo_ruling_1='Dismissed',
-                                                                 dispo_ruling_2='Convicted',
-                                                                 dispo_ruling_3='Dismissed'),
-                                     'X0003': CaseDetails.case_x(arrest_date=self.ONE_YEAR_AGO.strftime('%m/%d/%Y'),
-                                                                 dispo_ruling_1='No Complaint',
-                                                                 dispo_ruling_2='Convicted',
-                                                                 dispo_ruling_3='No Complaint')})
-        expunger = Expunger(record)
-
-        assert expunger.run() is True
-
-        assert expunger._time_analyzer._expunger.most_recent_conviction.date == self.ONE_YEAR_AGO
-        assert expunger._time_analyzer._expunger.second_most_recent_conviction.date == self.TWO_YEARS_AGO
-        assert expunger._time_analyzer._expunger.most_recent_dismissal.date == self.ONE_YEAR_AGO
-        assert expunger._time_analyzer._expunger.num_acquittals == 4
-
-    def test_expunger_invokes_time_analyzer_with_most_recent_charge(self):
-        record = CrawlerFactory.create(self.crawler,
-                              cases={'X0001': CaseDetails.case_x(arrest_date=self.FIFTEEN_YEARS_AGO.strftime('%m/%d/%Y'),
-                                                                 charge1_name='Aggravated theft in the first degree',
-                                                                 charge1_statute='164.057',
-                                                                 charge1_level='Felony Class B',
-                                                                 dispo_ruling_1='Convicted',
-                                                                 dispo_date=self.FIFTEEN_YEARS_AGO.strftime('%m/%d/%Y')),
-                                     'X0002': CaseDetails.case_x(),
-                                     'X0003': CaseDetails.case_x()})
-
-        expunger = Expunger(record)
-        expunger.run()
-
-        assert len(expunger.class_b_felonies) == 1
-        assert expunger.class_b_felonies[0].name == 'Aggravated theft in the first degree'
-        assert expunger._time_analyzer._expunger.class_b_felonies[0].name == 'Aggravated theft in the first degree'
-        assert expunger._time_analyzer._expunger.most_recent_charge.name == 'Aggravated theft in the first degree'
-
-    def test_expunger_expunges(self):
+    def test_expunger_runs_time_analyzer(self):
         record = CrawlerFactory.create(self.crawler,
                               cases={'X0001': CaseDetails.case_x(arrest_date=self.FIFTEEN_YEARS_AGO.strftime('%m/%d/%Y'),
                                                                  dispo_date=self.FIFTEEN_YEARS_AGO.strftime('%m/%d/%Y'),

--- a/src/backend/tests/functional_tests/test_crawler_expunger.py
+++ b/src/backend/tests/functional_tests/test_crawler_expunger.py
@@ -30,8 +30,8 @@ class TestCrawlerAndExpunger(unittest.TestCase):
         expunger = Expunger(record)
 
         assert expunger.run() is True
-        assert expunger._most_recent_dismissal is None
-        assert expunger._most_recent_conviction is None
+        assert expunger.most_recent_dismissal is None
+        assert expunger.most_recent_conviction is None
 
     def test_expunger_categorizes_charges(self):
         record = CrawlerFactory.create(self.crawler,
@@ -47,7 +47,7 @@ class TestCrawlerAndExpunger(unittest.TestCase):
         expunger = Expunger(record)
 
         assert expunger.run() is True
-        assert len(expunger._acquittals) == 5
+        assert len(expunger.acquittals) == 5
         assert len(expunger._convictions) == 4
 
     def test_expunger_calls_time_analyzer(self):
@@ -87,8 +87,8 @@ class TestCrawlerAndExpunger(unittest.TestCase):
         expunger = Expunger(record)
         expunger.run()
 
-        assert len(expunger._class_b_felonies) == 1
-        assert expunger._class_b_felonies[0].name == 'Aggravated theft in the first degree'
+        assert len(expunger.class_b_felonies) == 1
+        assert expunger.class_b_felonies[0].name == 'Aggravated theft in the first degree'
         assert expunger._time_analyzer._class_b_felonies[0].name == 'Aggravated theft in the first degree'
         assert expunger._time_analyzer._most_recent_charge.name == 'Aggravated theft in the first degree'
 
@@ -111,10 +111,10 @@ class TestCrawlerAndExpunger(unittest.TestCase):
 
         assert expunger.run() is True
 
-        assert expunger._most_recent_conviction is None
-        assert expunger._second_most_recent_conviction is None
-        assert expunger._most_recent_dismissal.disposition.ruling == 'No Complaint'
-        assert len(expunger._acquittals) == 8
+        assert expunger.most_recent_conviction is None
+        assert expunger.second_most_recent_conviction is None
+        assert expunger.most_recent_dismissal.disposition.ruling == 'No Complaint'
+        assert len(expunger.acquittals) == 8
 
         assert record.cases[0].charges[0].expungement_result.time_eligibility is False
         assert record.cases[0].charges[1].expungement_result.time_eligibility is False

--- a/src/backend/tests/functional_tests/test_crawler_expunger.py
+++ b/src/backend/tests/functional_tests/test_crawler_expunger.py
@@ -68,10 +68,10 @@ class TestCrawlerAndExpunger(unittest.TestCase):
 
         assert expunger.run() is True
 
-        assert expunger._time_analyzer._most_recent_conviction.date == self.ONE_YEAR_AGO
-        assert expunger._time_analyzer._second_most_recent_conviction.date == self.TWO_YEARS_AGO
-        assert expunger._time_analyzer._most_recent_dismissal.date == self.ONE_YEAR_AGO
-        assert expunger._time_analyzer._num_acquittals == 4
+        assert expunger._time_analyzer._expunger.most_recent_conviction.date == self.ONE_YEAR_AGO
+        assert expunger._time_analyzer._expunger.second_most_recent_conviction.date == self.TWO_YEARS_AGO
+        assert expunger._time_analyzer._expunger.most_recent_dismissal.date == self.ONE_YEAR_AGO
+        assert expunger._time_analyzer._expunger.num_acquittals == 4
 
     def test_expunger_invokes_time_analyzer_with_most_recent_charge(self):
         record = CrawlerFactory.create(self.crawler,
@@ -89,8 +89,8 @@ class TestCrawlerAndExpunger(unittest.TestCase):
 
         assert len(expunger.class_b_felonies) == 1
         assert expunger.class_b_felonies[0].name == 'Aggravated theft in the first degree'
-        assert expunger._time_analyzer._class_b_felonies[0].name == 'Aggravated theft in the first degree'
-        assert expunger._time_analyzer._most_recent_charge.name == 'Aggravated theft in the first degree'
+        assert expunger._time_analyzer._expunger.class_b_felonies[0].name == 'Aggravated theft in the first degree'
+        assert expunger._time_analyzer._expunger.most_recent_charge.name == 'Aggravated theft in the first degree'
 
     def test_expunger_expunges(self):
         record = CrawlerFactory.create(self.crawler,


### PR DESCRIPTION
Refactored time analyzer: 

- Time analyzer now only takes one argument, an expunger like object.
- Time analyzer is now a static class

The main goal of the refactoring was to inject the expunger into the time analyzer, after doing this it made instantiating the time analyzer no longer necessary since it doesn't contain any state. This was done because of the large number of parameters being passed to the time analyzer.

Closes #235 