### PR TITLE
added .dockerignore

### DIFF
--- a/config/nginx/.dockerignore
+++ b/config/nginx/.dockerignore
@@ -1,0 +1,1 @@
+/frontend/node_modules


### PR DESCRIPTION
Added:

 /config/nginx/.dockerignore
   |-/frontend/node_modules

To help avoid errors during docker build process stemming from conflicting node_modules information.