### PR TITLE
Endpoint logging and paths fix 

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,27 @@ Run all tests with the following command:
 $ make test
 ```
 
-If all of these tests pass, you have successfully set up the backend dev environment!
+All of these tests should pass if you have correctly set up the backend dev environment.
+
+### Create a Local User
+
+In order to call API endpoints locally, e.g. while working on the frontend, you will need login credentials already stored in the local database. These are needed to obtain a JWT auth token (required for most endpoints). To do so:
+
+1. Choose a password and compute its bcrypt hash:
+
+In the project directory, run
+```pipenv run python
+$ from werkzeug.security import generate_password_hash
+$ generate_password_hash('your-password')
+```
+
+2. Choose an email address and insert it and your password hash into the database:
+
+In the project directory, run
+```
+make dev_psql
+=# SELECT * FROM CREATE_USER('your_email', 'your_hashed_password', true);
+```
 
 ## Project Layout
 

--- a/README.md
+++ b/README.md
@@ -175,25 +175,6 @@ $ make test
 
 All of these tests should pass if you have correctly set up the backend dev environment.
 
-### Create a Local User
-
-In order to call API endpoints locally, e.g. while working on the frontend, you will need login credentials already stored in the local database. These are needed to obtain a JWT auth token (required for most endpoints). To do so:
-
-1. Choose a password and compute its bcrypt hash:
-
-In the project directory, run
-```pipenv run python
-$ from werkzeug.security import generate_password_hash
-$ generate_password_hash('your-password')
-```
-
-2. Choose an email address and insert it and your password hash into the database:
-
-In the project directory, run
-```
-make dev_psql
-=# SELECT * FROM CREATE_USER('your_email', 'your_hashed_password', true);
-```
 
 ## Project Layout
 

--- a/doc/design.md
+++ b/doc/design.md
@@ -4,14 +4,28 @@ Record Expunge System
 Some thoughts on the Record Expunge System.
 
 
-Stack
------
+Table of Contents
+-----------------
+- [Project Stack](#project-stack)
+- [User Flow](#user-flow)
+- [Frontend Routes](#frontend-routes)
+- [Backend Endpoints](#backend-endpoints)
+- [Data Model](#data-model)
+- [Database Schema](#database)
+- [Database Functions](#database-functions)
 
-[ Web Server ]  -- Apache or Nginx, https enabled
+- [License](#license)
 
-[ Application ] -- JavaScript/ReactJS
+Project Stack
+-------------
 
-[ Micro Service ] [ Database ] -- Python, Flask, Requests, PostgreSQL, Psycopg, Swagger
+The app stack is deployed as three services in a Docker stack:
+
+[ Web Server ]  -- Nginx, https enabled. Serves static pages and proxies API calls
+
+[ Backend API ] -- Python, Flask, Psycopg
+
+[ Database ] -- PostgreSQL
 
 
 User Flow
@@ -61,8 +75,8 @@ If user chooses log out:
 - User is directed to login page
 
 
-Application Routes
-------------------
+Frontend Routes
+---------------
 
 These routes are set up in the front-end application for navigating between the different views.
 
@@ -106,8 +120,8 @@ Admin page for creating users
 - admin permissions (T/F)
 
 
-Back-End Endpoints
-------------------
+Backend Endpoints
+-----------------
 
 These endpoints comprise our API. All requests of these endpoints go through the web server.
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -1,0 +1,54 @@
+Project Development Tips
+========================
+
+A few things to do when developing the frontend or backend.
+
+## Create a Local User
+
+In order to call API endpoints locally, e.g. while working on the frontend, you will need login credentials already stored in the local database. These are needed to obtain a JWT auth token (required for most endpoints). To do so:
+
+1. Choose a password and compute its bcrypt hash:
+
+In the project directory, run
+```pipenv run python
+$ from werkzeug.security import generate_password_hash
+$ generate_password_hash('your_password')
+```
+
+2. Choose an email address and insert it and your password hash into the database:
+
+In the project directory, run
+```
+make dev_psql
+=# SELECT * FROM CREATE_USER('your_email', 'your_hashed_password', true);
+```
+
+## Test Backend API calls
+
+To test the endpoint calls for /auth_token and /users respectively, run:
+
+```
+$ curl -X GET -i -H "Content-Type: application/json" "localhost:5000/api/auth_token" --data '{"email":"your_email", "password":"your_password"}'
+```
+
+which should return something like this:
+
+```
+{
+  "auth_token": "[long hash string]"
+}
+```
+
+and then run
+
+```
+$ curl -X POST -i -H "Content-Type: application/json" -H "Authorization: Bearer [auth-string]" localhost:5000/api/users --data '{"email":"new_email", "password":"new_password", "admin":false}'
+```
+
+replacing `[auth-string]` with the auth_token value you just received. This should return:
+
+{
+  "admin": false,
+  "email": "new_email",
+  "timestamp": "[timestamp]"
+}

--- a/doc/development.md
+++ b/doc/development.md
@@ -11,6 +11,10 @@ In order to call API endpoints locally, e.g. while working on the frontend, you 
 
 In the project directory, run
 ```pipenv run python
+```
+to open the python interactive terminal with the project's dependencies loaded. Then run
+
+```
 $ from werkzeug.security import generate_password_hash
 $ generate_password_hash('your_password')
 ```
@@ -20,10 +24,22 @@ $ generate_password_hash('your_password')
 In the project directory, run
 ```
 make dev_psql
-=# SELECT * FROM CREATE_USER('your_email', 'your_hashed_password', true);
 ```
 
+This launches the PSQL interactive environment in the project's postgres docker container. In this terminal, run:
+
+```
+$ SELECT * FROM CREATE_USER('your_email', 'your_hashed_password', true);
+```
+
+providing your actual email and hashed password each in the single-quotes.
+
+This runs a custom SQL function which inserts your user credentials.
+
+
 ## Test Backend API calls
+
+See design.md for the specifications of each API endpoint.
 
 To test the endpoint calls for /auth_token and /users respectively, run:
 
@@ -39,7 +55,9 @@ which should return something like this:
 }
 ```
 
-and then run
+the auth_token string provides the proof that a particular user is logged in. Subsequent endpoints that require authorization will read the auth_token string to verify the logged-in user's credentials.
+
+To run the /users/ POST endpoint, run
 
 ```
 $ curl -X POST -i -H "Content-Type: application/json" -H "Authorization: Bearer [auth-string]" localhost:5000/api/users --data '{"email":"new_email", "password":"new_password", "admin":false}'

--- a/doc/development.md
+++ b/doc/development.md
@@ -10,7 +10,8 @@ In order to call API endpoints locally, e.g. while working on the frontend, you 
 1. Choose a password and compute its bcrypt hash:
 
 In the project directory, run
-```pipenv run python
+```
+pipenv run python
 ```
 to open the python interactive terminal with the project's dependencies loaded. Then run
 

--- a/src/backend/expungeservice/app.py
+++ b/src/backend/expungeservice/app.py
@@ -16,8 +16,8 @@ def create_app(env_name):
     app = Flask(__name__)
     app.config.from_object(app_config[env_name])
 
-    logHandler = logging.StreamHandler()
-    app.logger.addHandler(logHandler)
+    log_handler = logging.StreamHandler()
+    app.logger.addHandler(log_handler)
     app.logger.setLevel(logging.INFO)
 
     # Register endpoint routes here:

--- a/src/backend/expungeservice/app.py
+++ b/src/backend/expungeservice/app.py
@@ -5,6 +5,7 @@ from .config import app_config
 # Add new endpoint imports here:
 from .endpoints import hello, auth, users
 from .request import before, teardown
+import logging
 
 def create_app(env_name):
     """
@@ -14,6 +15,10 @@ def create_app(env_name):
     # app initiliazation
     app = Flask(__name__)
     app.config.from_object(app_config[env_name])
+
+    logHandler = logging.StreamHandler()
+    app.logger.addHandler(logHandler)
+    app.logger.setLevel(logging.INFO)
 
     # Register endpoint routes here:
     hello.register(app)

--- a/src/backend/expungeservice/config.py
+++ b/src/backend/expungeservice/config.py
@@ -8,7 +8,7 @@ class Development(object):
     DEBUG = True
     TESTING = False
     JWT_SECRET_KEY = os.urandom(24)
-    JWT_EXPIRY_TIMER = datetime.timedelta(seconds=60)
+    JWT_EXPIRY_TIMER = datetime.timedelta(minutes=10)
     SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL')
 
 class Production(object):

--- a/src/backend/expungeservice/config.py
+++ b/src/backend/expungeservice/config.py
@@ -8,7 +8,7 @@ class Development(object):
     DEBUG = True
     TESTING = False
     JWT_SECRET_KEY = os.urandom(24)
-    JWT_EXPIRY_TIMER = datetime.timedelta(minutes=10)
+    JWT_EXPIRY_TIMER = datetime.timedelta(minutes=60)
     SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL')
 
 class Production(object):
@@ -19,7 +19,7 @@ class Production(object):
     TESTING = False
     SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL')
     JWT_SECRET_KEY = os.getenv('JWT_SECRET_KEY')
-    JWT_EXPIRY_TIMER = datetime.timedelta(minutes=10)
+    JWT_EXPIRY_TIMER = datetime.timedelta(minutes=60)
 
 app_config = {
     'development': Development,

--- a/src/backend/expungeservice/endpoints/users.py
+++ b/src/backend/expungeservice/endpoints/users.py
@@ -7,6 +7,7 @@ from expungeservice.database.user import create_user, get_user_by_email
 from expungeservice.endpoints.auth import admin_auth_required
 from expungeservice.request import check_data_fields
 from psycopg2.errors import UniqueViolation
+from expungeservice.request.error import error
 
 
 class Users(MethodView):
@@ -23,12 +24,12 @@ class Users(MethodView):
         data = request.get_json()
 
         if data == None:
-            abort(400)
+            error(400, "No json data in request body")
 
         check_data_fields(data, ['email', 'password', 'admin'])
 
         if len(data['password']) <8:
-            return 'New password is less than 8 characters long!', 422
+            error(422, 'New password is less than 8 characters long!')
 
         password_hash = generate_password_hash(data['password'])
 
@@ -38,7 +39,7 @@ class Users(MethodView):
                                              password_hash = password_hash,
                                              admin = data['admin'])
         except UniqueViolation:
-            return 'User with that email address already exists!', 422
+            error(422, 'User with that email address already exists')
 
         response_data = {
             'email': create_user_result['email'],
@@ -51,4 +52,4 @@ class Users(MethodView):
         return jsonify(response_data), 201
 
 def register(app):
-    app.add_url_rule('/api/v0.1/users', view_func=Users.as_view('users'))
+    app.add_url_rule('/api/users', view_func=Users.as_view('users'))

--- a/src/backend/expungeservice/request/__init__.py
+++ b/src/backend/expungeservice/request/__init__.py
@@ -1,1 +1,2 @@
 from .request import *
+from . import error

--- a/src/backend/expungeservice/request/error.py
+++ b/src/backend/expungeservice/request/error.py
@@ -1,0 +1,6 @@
+from flask import abort
+import logging
+
+def error(code, message):
+    logging.error("code %i %s" % (code, message), stack_info = True)
+    abort(code, message)

--- a/src/backend/expungeservice/request/request.py
+++ b/src/backend/expungeservice/request/request.py
@@ -1,9 +1,9 @@
 from flask import g, abort
 import os
 from expungeservice.database import Database
+from expungeservice.request.error import error
 
 def before():
-
     host = os.environ['PGHOST']
     port = os.environ['PGPORT']
     name = os.environ['PGDATABASE']
@@ -23,4 +23,4 @@ def teardown(exception):
 def check_data_fields(request_json, required_fields):
 
     if not all([field in request_json.keys() for field in required_fields]):
-        abort(400)
+        error(400, "missing one or more required fields: " + str(required_fields))

--- a/src/backend/tests/endpoints/test_auth.py
+++ b/src/backend/tests/endpoints/test_auth.py
@@ -34,8 +34,8 @@ class TestAuth(unittest.TestCase):
         self.app = expungeservice.create_app('development')
         self.client = self.app.test_client()
 
-        self.app.add_url_rule('/api/v0.1/test/user_protected', view_func=UserProtectedView.as_view('user_protected'))
-        self.app.add_url_rule('/api/v0.1/test/admin_protected', view_func=AdminProtectedView.as_view('admin_protected'))
+        self.app.add_url_rule('/api/test/user_protected', view_func=UserProtectedView.as_view('user_protected'))
+        self.app.add_url_rule('/api/test/admin_protected', view_func=AdminProtectedView.as_view('admin_protected'))
 
         with self.app.app_context():
             expungeservice.request.before()
@@ -60,7 +60,7 @@ class TestAuth(unittest.TestCase):
 
 
     def get_auth_token(self, email, password):
-        return self.client.get('/api/v0.1/auth_token', json={
+        return self.client.get('/api/auth_token', json={
             'email': email,
             'password': password,
         })
@@ -84,14 +84,14 @@ class TestAuth(unittest.TestCase):
 
     def test_access_valid_auth_token(self):
         response = self.get_auth_token(self.email, self.password)
-        response = self.client.get('/api/v0.1/test/user_protected', headers={
+        response = self.client.get('/api/test/user_protected', headers={
             'Authorization': 'Bearer {}'.format(response.get_json()['auth_token'])
         })
         assert(response.status_code == 200)
 
     def test_access_invalid_auth_token(self):
         response = self.get_auth_token(self.email, self.password)
-        response = self.client.get('/api/v0.1/test/user_protected', headers={
+        response = self.client.get('/api/test/user_protected', headers={
             'Authorization': 'Bearer {}'.format('Invalid auth token')
         })
         assert(response.status_code == 401)
@@ -102,7 +102,7 @@ class TestAuth(unittest.TestCase):
 
         response = self.get_auth_token(self.email, self.password)
         time.sleep(1)
-        response = self.client.get('/api/v0.1/test/user_protected', headers={
+        response = self.client.get('/api/test/user_protected', headers={
             'Authorization': 'Bearer {}'.format(response.get_json()['auth_token'])
         })
         assert(response.status_code == 401)
@@ -120,7 +120,7 @@ class TestAuth(unittest.TestCase):
             expungeservice.request.teardown(None)
 
         response = self.get_auth_token(admin_email, admin_password)
-        response = self.client.get('/api/v0.1/test/admin_protected', headers={
+        response = self.client.get('/api/test/admin_protected', headers={
             'Authorization': 'Bearer {}'.format(response.get_json()['auth_token'])
         })
         assert(response.status_code == 200)
@@ -128,7 +128,7 @@ class TestAuth(unittest.TestCase):
     def test_is_not_admin_auth_token(self):
 
         response = self.get_auth_token(self.email, self.password)
-        response = self.client.get('/api/v0.1/test/admin_protected', headers={
+        response = self.client.get('/api/test/admin_protected', headers={
             'Authorization': 'Bearer {}'.format(response.get_json()['auth_token'])
         })
         assert(response.status_code == 403)

--- a/src/backend/tests/endpoints/test_users.py
+++ b/src/backend/tests/endpoints/test_users.py
@@ -48,7 +48,7 @@ class TestUsers(unittest.TestCase):
         g.database.connection.commit()
 
     def get_auth_token(self, email, password):
-        return self.client.get('/api/v0.1/auth_token', json={
+        return self.client.get('/api/auth_token', json={
             'email': email,
             'password': password,
         })
@@ -62,7 +62,7 @@ class TestUsers(unittest.TestCase):
 
         get_auth_response = self.get_auth_token(self.admin_email, self.admin_password)
 
-        response = self.client.post('/api/v0.1/users', headers={
+        response = self.client.post('/api/users', headers={
             'Authorization': 'Bearer {}'.format(get_auth_response.get_json()['auth_token'])},
                 json = {'email':new_email,
                         'password': new_password,
@@ -82,7 +82,7 @@ class TestUsers(unittest.TestCase):
         new_email = "pytest_create_user@endpoint_test.com"
         new_password = "new_password"
 
-        response = self.client.post('/api/v0.1/users', headers={
+        response = self.client.post('/api/users', headers={
             'Authorization': '' },
             json = {'email':new_email,
                     'password': new_password,
@@ -96,7 +96,7 @@ class TestUsers(unittest.TestCase):
 
         get_auth_response = self.get_auth_token(self.admin_email, self.admin_password)
 
-        response = self.client.post('/api/v0.1/users', headers={
+        response = self.client.post('/api/users', headers={
             'Authorization': 'Bearer {}'.format(get_auth_response.get_json()['auth_token'])},
                 json = {'email':new_email,
                         #'password': new_password,
@@ -113,7 +113,7 @@ class TestUsers(unittest.TestCase):
 
         get_auth_response = self.get_auth_token(self.admin_email, self.admin_password)
 
-        response = self.client.post('/api/v0.1/users', headers={
+        response = self.client.post('/api/users', headers={
             'Authorization': 'Bearer {}'.format(get_auth_response.get_json()['auth_token'])},
             json = {'email':new_email,
                     'password': new_password,
@@ -121,7 +121,7 @@ class TestUsers(unittest.TestCase):
 
         assert(response.status_code == 201)
 
-        response = self.client.post('/api/v0.1/users', headers={
+        response = self.client.post('/api/users', headers={
             'Authorization': 'Bearer {}'.format(get_auth_response.get_json()['auth_token'])},
             json = {'email':new_email,
                     'password': new_password,
@@ -136,7 +136,7 @@ class TestUsers(unittest.TestCase):
 
         get_auth_response = self.get_auth_token(self.admin_email, self.admin_password)
 
-        response = self.client.post('/api/v0.1/users', headers={
+        response = self.client.post('/api/users', headers={
             'Authorization': 'Bearer {}'.format(get_auth_response.get_json()['auth_token'])},
             json = {'email':new_email,
                     'password': short_password,
@@ -152,7 +152,7 @@ class TestUsers(unittest.TestCase):
 
         get_auth_response = self.get_auth_token(self.email, self.password)
 
-        response = self.client.post('/api/v0.1/users', headers={
+        response = self.client.post('/api/users', headers={
             'Authorization': 'Bearer {}'.format(get_auth_response.get_json()['auth_token'])},
             json = {'email':new_email,
                     'password': new_password,


### PR DESCRIPTION
I added an error logging function that prints a stack trace in the backend's stdErr, which gets captured automatically by Docker and Heroku logging. I added more informative error messages that return to the client so it should be easier to get api calls working.  

The endpoint paths are updated to match the design doc, namely the `v0.1` has been removed.

The new docfile `development.md` includes steps to test that the endpoints work locally.

Remember that now we rely on Docker, whenever we do a pull we need to stop and rebuild the stack:
```
make dev_stop
make dev
```
