### PR TITLE
Update 800 level charge definitions

### DIFF
--- a/src/backend/expungeservice/models/charge_types/level_800_traffic_crime.py
+++ b/src/backend/expungeservice/models/charge_types/level_800_traffic_crime.py
@@ -5,7 +5,7 @@ class Level800TrafficCrime(BaseCharge):
 
     def __init__(self, **kwargs):
         super(Level800TrafficCrime, self).__init__(**kwargs)
-        if self._expungeable(**kwargs):
+        if self._expungeable():
             self.expungement_result.set_type_eligibility(True)
             self.expungement_result.set_reason('Eligible under 137.225(1)(b)')
         else:
@@ -13,10 +13,13 @@ class Level800TrafficCrime(BaseCharge):
             self.expungement_result.set_reason('Ineligible under 137.225(5)')
 
     def skip_analysis(self):
-        if self.expungement_result.type_eligibility is True:
+        if self._affects_time_analysis():
             return False
         else:
             return True
 
-    def _expungeable(self, **kwargs):
-        return 'misdemeanor' in kwargs['level'].lower() or 'felony' in kwargs['level'].lower()
+    def _expungeable(self):
+        return self.acquitted() and self._affects_time_analysis()
+
+    def _affects_time_analysis(self):
+        return 'misdemeanor' in self.level.lower() or 'felony' in self.level.lower()

--- a/src/backend/tests/models/charge_types/test_level_800_traffic_crime.py
+++ b/src/backend/tests/models/charge_types/test_level_800_traffic_crime.py
@@ -1,3 +1,14 @@
+"""
+Rules for 800 Level charges are as follows:
+
+800 level misdemeanors and felonies are eligible Only If the case was dismissed
+800 level cases of any kind that are convicted are not eligible
+800 level infractions do not block other cases
+800 level misdemeanor and felony convictions do block
+800 level misdemeanor and felony arrests block like other arrests
+800 level convictions of any kind are not type eligible
+"""
+
 import unittest
 
 from datetime import datetime, timedelta
@@ -6,11 +17,6 @@ from expungeservice.models.disposition import Disposition
 
 
 class TestLevel800Charges(unittest.TestCase):
-    """
-    Level 800 traffic charges expungeability are determined by the level of the charge and disposition.
-    If the level contains the word violation then it is not expungeable (Violations are not type eligible).
-    If the charge level is something other than a violation then it is type eligible.
-    """
 
     def setUp(self):
         last_week = (datetime.today() - timedelta(days=7)).strftime('%m/%d/%Y')
@@ -37,78 +43,113 @@ class TestLevel800Charges(unittest.TestCase):
 
         assert charge.__class__.__name__ == 'Level800TrafficCrime'
 
-    def test_traffic_violation_801_000(self):
-        self.single_charge['name'] = 'Traffic Violation'
-        self.single_charge['statute'] = '801.000'
-        self.single_charge['level'] = 'Class C Traffic Violation'
-        traffic_violation_min = self.create_recent_charge()
-        self.charges.append(traffic_violation_min)
 
-        assert traffic_violation_min.expungement_result.type_eligibility is False
-        assert traffic_violation_min.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+class TestLevel800MisdemeanorFelonyEligibility(unittest.TestCase):
+    """
+    800 level misdemeanors and felonies are eligible Only If the case was dismissed
+    """
 
-    def test_traffic_violation_825_999(self):
-        self.single_charge['name'] = 'Traffic Violation'
-        self.single_charge['statute'] = '825.999'
-        self.single_charge['level'] = 'Class C Traffic Violation'
-        traffic_violation_max = self.create_recent_charge()
-        self.charges.append(traffic_violation_max)
+    def setUp(self):
+        last_week = (datetime.today() - timedelta(days=7)).strftime('%m/%d/%Y')
+        self.convicted = ['Convicted', last_week]
+        self.dismissed= ['Dismissed', last_week]
 
-        assert traffic_violation_max.expungement_result.type_eligibility is False
-        assert traffic_violation_max.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+    def test_misdemeanor_conviction_is_not_eligible(self):
+        charge = ChargeFactory.create(statute='813.010(4)', level='Misdemeanor Class A', disposition=self.convicted)
 
-    def test_felony_class_c(self):
-        self.single_charge['name'] = 'Possession of a Stolen Vehicle'
-        self.single_charge['statute'] = '819.300'
-        self.single_charge['level'] = 'Felony Class C'
-        charge = self.create_recent_charge()
-        self.charges.append(charge)
+        assert charge.expungement_result.type_eligibility is False
+        assert charge.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+
+    def test_misdemeanor_dismissal_is_eligible(self):
+        charge = ChargeFactory.create(statute='813.010(4)', level='Misdemeanor Class A', disposition=self.dismissed)
 
         assert charge.expungement_result.type_eligibility is True
         assert charge.expungement_result.type_eligibility_reason == 'Eligible under 137.225(1)(b)'
 
-    def test_misdemeanor(self):
-        self.single_charge['name'] = 'Driving Under the Influence of Intoxicants'
-        self.single_charge['statute'] = '813.010(4)'
-        self.single_charge['level'] = 'Misdemeanor Class A'
-        charge = self.create_recent_charge()
-        self.charges.append(charge)
+    def test_felony_conviction_is_not_eligible(self):
+        charge = ChargeFactory.create(statute='819.300', level='Felony Class C', disposition=self.convicted)
+
+        assert charge.expungement_result.type_eligibility is False
+        assert charge.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+
+    def test_felony_dismissal_is_eligible(self):
+        charge = ChargeFactory.create(statute='819.300', level='Felony Class C', disposition=self.dismissed)
 
         assert charge.expungement_result.type_eligibility is True
         assert charge.expungement_result.type_eligibility_reason == 'Eligible under 137.225(1)(b)'
 
-    def test_level_800_midemeanor_does_not_skip_time_analysis(self):
-        self.single_charge['name'] = 'Driving Under the Influence of Intoxicants'
-        self.single_charge['statute'] = '813.010(4)'
-        self.single_charge['level'] = 'Misdemeanor Class A'
-        charge = self.create_recent_charge()
-        self.charges.append(charge)
 
-        assert charge.skip_analysis() is False
+class TestLevel800ViolationsInfractionsAreNotTypeEligible(unittest.TestCase):
 
-    def test_level_800_felony_does_not_skip_time_analysis(self):
-        self.single_charge['name'] = 'Driving Under the Influence of Intoxicants'
-        self.single_charge['statute'] = '813.010(4)'
-        self.single_charge['level'] = 'Felony Class A'
-        charge = self.create_recent_charge()
-        self.charges.append(charge)
+    def setUp(self):
+        last_week = (datetime.today() - timedelta(days=7)).strftime('%m/%d/%Y')
+        self.convicted = ['Convicted', last_week]
+        self.dismissed= ['Dismissed', last_week]
 
-        assert charge.skip_analysis() is False
+    def test_convicted_violation_is_not_type_eligible(self):
+        charge = ChargeFactory.create(statute='801.000', level='Class C Traffic Violation', disposition=self.convicted)
 
-    def test_level_800_violations_skip_analysis(self):
-        self.single_charge['name'] = 'Traffic Violation'
-        self.single_charge['statute'] = '825.999'
-        self.single_charge['level'] = 'Class C Traffic Violation'
-        traffic_violation = self.create_recent_charge()
-        self.charges.append(traffic_violation)
+        assert charge.expungement_result.type_eligibility is False
+        assert charge.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
 
-        assert traffic_violation.skip_analysis() is True
+    def test_dismissed_violation_is_not_type_eligible(self):
+        charge = ChargeFactory.create(statute='801.000', level='Class C Traffic Violation', disposition=self.dismissed)
+
+        assert charge.expungement_result.type_eligibility is False
+        assert charge.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+
+    def test_convicted_infraction_is_not_type_eligible(self):
+        charge = ChargeFactory.create(statute='811135', level='Infraction Class B', disposition=self.convicted)
+
+        assert charge.expungement_result.type_eligibility is False
+        assert charge.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+
+    def test_dismissed_infraction_is_not_type_eligible(self):
+        charge = ChargeFactory.create(statute='811135', level='Infraction Class B', disposition=self.dismissed)
+
+        assert charge.expungement_result.type_eligibility is False
+        assert charge.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+
+
+class TestViolationsInfractionsSkipAnalysis(unittest.TestCase):
+
+    def setUp(self):
+        self.convicted = ['Convicted', '05/05/2018']
+
+    def test_violation_level_charge_skips_analysis(self):
+        charge = ChargeFactory.create(statute='801.000', level='Class C Traffic Violation', disposition=self.convicted)
+
+        assert charge.skip_analysis() is True
 
     def test_level_800_infractions_skip_analysis(self):
-        self.single_charge['name'] = 'Careless Driving'
-        self.single_charge['statute'] = '811135'
-        self.single_charge['level'] = 'Infraction Class B'
-        traffic_violation = self.create_recent_charge()
-        self.charges.append(traffic_violation)
+        charge = ChargeFactory.create(statute='811135', level='Infraction Class B', disposition=self.convicted)
 
-        assert traffic_violation.skip_analysis() is True
+        assert charge.skip_analysis() is True
+
+
+class TestMisdemeanorFeloniesDoNotSkipAnalysis(unittest.TestCase):
+
+    def setUp(self):
+        last_week = (datetime.today() - timedelta(days=7)).strftime('%m/%d/%Y')
+        self.convicted = ['Convicted', last_week]
+        self.dismissed= ['Dismissed', last_week]
+
+    def test_misdemeanor_dismissal_does_not_skip_analysis(self):
+        charge = ChargeFactory.create(statute='813.010(4)', level='Misdemeanor Class A', disposition=self.dismissed)
+
+        assert charge.skip_analysis() is False
+
+    def test_misdemeanor_conviction_does_not_skip_analysis(self):
+        charge = ChargeFactory.create(statute='813.010(4)', level='Misdemeanor Class A', disposition=self.convicted)
+
+        assert charge.skip_analysis() is False
+
+    def test_felony_dismissal_does_not_skip_analysis(self):
+        charge = ChargeFactory.create(statute='819.300', level='Felony Class C', disposition=self.dismissed)
+
+        assert charge.skip_analysis() is False
+
+    def test_felony_conviction_does_not_skip_analysis(self):
+        charge = ChargeFactory.create(statute='819.300', level='Felony Class C', disposition=self.convicted)
+
+        assert charge.skip_analysis() is False


### PR DESCRIPTION
An 800 level (driving charges) misdemeanor or felony is only expungeable if it is acquitted (convictions are not expungeable). All other 800 level charge types are not eligible.

All 800 level misdemeanor and felonies affect the time analysis. All other 800 level charge types should not be included in the time analysis.

Fixes #306