### PR TITLE
Do not analyze charges without a disposition

### DIFF
--- a/src/backend/expungeservice/expunger/expunger.py
+++ b/src/backend/expungeservice/expunger/expunger.py
@@ -67,7 +67,7 @@ class Expunger:
 
     def _tag_skipped_charges(self):
         for charge in self.charges:
-            if charge.skip_analysis() or Expunger._dispositionless(charge):
+            if Expunger._dispositionless(charge) or charge.skip_analysis():
                 self._skipped_charges.append(charge)
 
     @staticmethod

--- a/src/backend/expungeservice/expunger/expunger.py
+++ b/src/backend/expungeservice/expunger/expunger.py
@@ -67,7 +67,7 @@ class Expunger:
 
     def _tag_skipped_charges(self):
         for charge in self.charges:
-            if charge.skip_analysis():
+            if charge.skip_analysis() or charge.disposition is None:
                 self._skipped_charges.append(charge)
 
     def _remove_skipped_charges(self):
@@ -94,7 +94,7 @@ class Expunger:
             self.second_most_recent_conviction = self.convictions[-2]
 
     def _assign_most_recent_charge(self):
-        self.charges.sort(key=lambda charge: charge.disposition.date if charge.disposition.date else (date_class.today() + relativedelta(years=-1000)), reverse=True)
+        self.charges.sort(key=lambda charge: charge.disposition.date, reverse=True)
         if self.charges:
             self.most_recent_charge = self.charges[0]
 

--- a/src/backend/expungeservice/expunger/expunger.py
+++ b/src/backend/expungeservice/expunger/expunger.py
@@ -67,8 +67,14 @@ class Expunger:
 
     def _tag_skipped_charges(self):
         for charge in self.charges:
-            if charge.skip_analysis() or charge.disposition is None:
+            if charge.skip_analysis() or Expunger._dispositionless(charge):
                 self._skipped_charges.append(charge)
+
+    @staticmethod
+    def _dispositionless(charge):
+        if charge.disposition is None:
+            charge.expungement_result.type_eligibility_reason = "Disposition not found. Needs further analysis"
+            return True
 
     def _remove_skipped_charges(self):
         for charge in self._skipped_charges:

--- a/src/backend/expungeservice/models/charge_types/base_charge.py
+++ b/src/backend/expungeservice/models/charge_types/base_charge.py
@@ -31,10 +31,10 @@ class BaseCharge:
 
     def recent_conviction(self):
         ten_years_ago = (date_class.today() + relativedelta(years=-10))
-        if not self.convicted():
-            return False
-        else:
+        if self.convicted():
             return self.disposition.date > ten_years_ago
+        else:
+            return False
 
     def recent_acquittal(self):
         three_years_ago = (date_class.today() + relativedelta(years=-3))

--- a/src/backend/expungeservice/models/charge_types/base_charge.py
+++ b/src/backend/expungeservice/models/charge_types/base_charge.py
@@ -24,11 +24,11 @@ class BaseCharge:
         return self._case
 
     def acquitted(self):
-        return self.disposition.ruling and self.disposition.ruling[0:9].lower() != 'convicted'
+        return self.disposition and self.disposition.ruling[0:9].lower() != 'convicted'
 
     def convicted(self):
-        return self.disposition.ruling and not self.acquitted()
-        
+        return self.disposition and not self.acquitted()
+
     def recent_conviction(self):
         ten_years_ago = (date_class.today() + relativedelta(years=-10))
         if not self.convicted():
@@ -41,7 +41,7 @@ class BaseCharge:
         return self.acquitted() and self.date > three_years_ago
 
     def skip_analysis(self):
-        if not self.disposition.ruling:
+        if not self.disposition:
             self.expungement_result.type_eligibility_reason = "Disposition not found. Needs further analysis"
             return True
         else:

--- a/src/backend/expungeservice/models/charge_types/base_charge.py
+++ b/src/backend/expungeservice/models/charge_types/base_charge.py
@@ -9,7 +9,7 @@ from expungeservice.models.expungement_result import ExpungementResult
 
 class BaseCharge:
 
-    def __init__(self, case, name, statute, level, date, chapter, section, disposition=Disposition()):
+    def __init__(self, case, name, statute, level, date, chapter, section, disposition=None):
         self.name = name
         self.statute = statute
         self.level = level

--- a/src/backend/expungeservice/models/charge_types/base_charge.py
+++ b/src/backend/expungeservice/models/charge_types/base_charge.py
@@ -41,11 +41,7 @@ class BaseCharge:
         return self.acquitted() and self.date > three_years_ago
 
     def skip_analysis(self):
-        if not self.disposition:
-            self.expungement_result.type_eligibility_reason = "Disposition not found. Needs further analysis"
-            return True
-        else:
-            return False
+        return False
 
     def set_time_ineligible(self, reason, date_of_eligibility):
         self.expungement_result.time_eligibility = False

--- a/src/backend/tests/crawler/test_crawler.py
+++ b/src/backend/tests/crawler/test_crawler.py
@@ -34,12 +34,12 @@ class TestCrawler(unittest.TestCase):
         assert record.cases[1].charges[0].disposition.ruling == 'Dismissed'
         assert record.cases[1].charges[0].disposition.date == datetime.date(datetime.strptime('04/30/1992', '%m/%d/%Y'))
 
-        assert record.cases[2].charges[0].disposition.ruling is None
-        assert record.cases[2].charges[0].disposition.date is None
-        assert record.cases[2].charges[1].disposition.ruling is None
-        assert record.cases[2].charges[1].disposition.date is None
-        assert record.cases[2].charges[2].disposition.ruling is None
-        assert record.cases[2].charges[2].disposition.date is None
+        assert record.cases[2].charges[0].disposition is None
+        assert record.cases[2].charges[0].disposition is None
+        assert record.cases[2].charges[1].disposition is None
+        assert record.cases[2].charges[1].disposition is None
+        assert record.cases[2].charges[2].disposition is None
+        assert record.cases[2].charges[2].disposition is None
 
     def test_a_blank_search_response(self):
         record = CrawlerFactory.create(self.crawler, JohnDoe.BLANK_RECORD, {})

--- a/src/backend/tests/expunger/test_expunger.py
+++ b/src/backend/tests/expunger/test_expunger.py
@@ -209,3 +209,19 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         assert expunger.run()
         assert expunger._skipped_charges[0] == juvenile_charge
         assert expunger.charges == []
+
+
+class TestDispositionlessCharge(unittest.TestCase):
+
+    def test_charge_is_marked_as_missing_disposition(self):
+        case = CaseFactory.create()
+        charge = ChargeFactory.create(case=case, statute='825.999', level='Class C traffic violation')
+        print(charge.skip_analysis())
+        print(charge.expungement_result.type_eligibility_reason)
+
+        case.charges = [charge]
+        expunger = Expunger(Record([case]))
+
+        expunger.run()
+
+        assert charge.expungement_result.type_eligibility_reason == "Disposition not found. Needs further analysis"

--- a/src/backend/tests/factories/charge_factory.py
+++ b/src/backend/tests/factories/charge_factory.py
@@ -7,14 +7,14 @@ from tests.factories.case_factory import CaseFactory
 class ChargeFactory:
 
     @staticmethod
-    def build():
+    def build(disposition=None):
         return {
                   'case': CaseFactory.create(),
                   'name': 'Theft of services',
                   'statute': '164.125',
                   'level': 'Misdemeanor Class A',
                   'date': '1/1/0001',
-                  'disposition': Disposition()
+                  'disposition': disposition
                 }
 
     @staticmethod
@@ -31,8 +31,6 @@ class ChargeFactory:
         if disposition:
             ruling, date = disposition
             disposition = Disposition(date=date, ruling=ruling)
-        else:
-            disposition = Disposition()
         kwargs = {'case': case, 'name': name, 'statute': statute, 'level': level, 'date': date, 'disposition': disposition}
 
         return Charge.create(**kwargs)

--- a/src/backend/tests/functional_tests/test_crawler_expunger.py
+++ b/src/backend/tests/functional_tests/test_crawler_expunger.py
@@ -40,6 +40,13 @@ class TestCrawlerAndExpunger(unittest.TestCase):
         expunger = Expunger(record)
         expunger.run()
 
+    def test_case_without_dispos(self):
+        crawler = CrawlerFactory.setup()
+        record = CrawlerFactory.create(crawler, JohnDoe.SINGLE_CASE_RECORD, {'CASEJD1': CaseDetails.CASE_WITHOUT_DISPOS})
+
+        expunger = Expunger(record)
+        expunger.run()
+
     def test_expunger_categorizes_charges(self):
         record = CrawlerFactory.create(self.crawler,
                               cases={'X0001': CaseDetails.case_x(dispo_ruling_1='Convicted - Failure to show',

--- a/src/backend/tests/models/charge_types/test_type_analyzer_convicted_charges.py
+++ b/src/backend/tests/models/charge_types/test_type_analyzer_convicted_charges.py
@@ -9,13 +9,11 @@ class TestSingleChargeConvictions(unittest.TestCase):
 
     def setUp(self):
         last_week = (datetime.today() - timedelta(days=7)).strftime('%m/%d/%Y')
-        self.single_charge = ChargeFactory.build()
-        self.convicted_disposition = {'ruling': 'Convicted', 'date': last_week}
+        self.single_charge = ChargeFactory.build(disposition=Disposition(ruling='Convicted', date=last_week))
         self.charges = []
 
     def create_recent_charge(self):
         charge = ChargeFactory.save(self.single_charge)
-        charge.disposition = Disposition(**self.convicted_disposition)
         return charge
 
     def test_felony_class_a_charge(self):
@@ -465,13 +463,12 @@ class TestMultipleCharges(unittest.TestCase):
 
     def setUp(self):
         last_week = (datetime.today() - timedelta(days=7)).strftime('%m/%d/%Y')
-        self.charge = ChargeFactory.build()
-        self.convicted_disposition = {'ruling': 'Convicted', 'date': last_week}
+        disposition = Disposition(ruling='Convicted', date=last_week)
+        self.charge = ChargeFactory.build(disposition=disposition)
         self.charges = []
 
     def create_charge(self):
         charge = ChargeFactory.save(self.charge)
-        charge.disposition = Disposition(**self.convicted_disposition)
         return charge
 
     def test_two_charges(self):


### PR DESCRIPTION
## Description

Excluding charges without a disposition from the analyzer and marking them as needs further investigation. This is being done because the disposition date cannot be used to run a time analysis when there is no disposition.

Sometimes cases that are closed will not have charges with dispositions for various reasons.

- They can be improperly labeled
- They can be withheld
- Simply not added, because "everyone" knows that the charge is not eligible therefore disposition does not matter.... and possibly other f-reasons

Added additional test case to expose main issue, and removed default disposition class from initializer as it returns a singleton class in python which can cause unintended behaviors.

This could "possibly" be further improved by using the null object pattern or if you want to get fancy? NLP.

### Changes made

Adding one commit at a time so that you can see the failure/passes on CI

Added test case for when a record only contains charges without a disposition.

Removed mutable object from base_charge initializer.

Updated test to conform to the new base_charge initializer.

Check if there is a `disposition` instead of a `disposition.date` or `disposition.ruling` since disposition is now `None` as it should be when there is not a disposition.

This fixes #291 