### PR TITLE
Backend Users object: add Name and Group_name fields 

### DIFF
--- a/src/backend/expungeservice/database/user.py
+++ b/src/backend/expungeservice/database/user.py
@@ -62,6 +62,3 @@ def get_all_users(database):
     else:
         return res
 
-        return res._asdict()
-    else:
-        return res

--- a/src/backend/expungeservice/database/user.py
+++ b/src/backend/expungeservice/database/user.py
@@ -7,12 +7,15 @@ from expungeservice.database.db_util import rollback_errors
 from psycopg2 import sql
 
 @rollback_errors
-def create_user(database, email, password_hash, admin):
+def create_user(database, email, name,
+        group_name, password_hash, admin):
 
     database.cursor.execute(
         """
-        SELECT * FROM CREATE_USER( %(em)s, %(pass)s, %(adm)s );
-        """, {'em':email, 'pass':password_hash, 'adm': admin})
+        SELECT * FROM CREATE_USER( %(em)s, %(pass)s, %(name)s, %(group_name)s, %(adm)s );
+        """, {'em':email, 'pass':password_hash, 'name':name,
+              'group_name':group_name,
+              'adm': admin})
 
     result = database.cursor.fetchone()
     database.connection.commit()
@@ -50,8 +53,8 @@ def get_all_users(database):
 
     database.cursor.execute(
         sql.SQL("""
-            SELECT USERS.user_id::text user_id, email, admin, hashed_password, auth_id::text, date_created, date_modified
 
+            SELECT USERS.user_id::text user_id, email, name, group_name, admin, hashed_password, auth_id::text, date_created, date_modified
             FROM USERS JOIN AUTH ON USERS.user_id = AUTH.user_id
         ;
         """), {})

--- a/src/backend/expungeservice/database/user.py
+++ b/src/backend/expungeservice/database/user.py
@@ -51,6 +51,7 @@ def get_all_users(database):
     database.cursor.execute(
         sql.SQL("""
             SELECT USERS.user_id::text user_id, email, admin, hashed_password, auth_id::text, date_created, date_modified
+
             FROM USERS JOIN AUTH ON USERS.user_id = AUTH.user_id
         ;
         """), {})
@@ -61,3 +62,6 @@ def get_all_users(database):
     else:
         return res
 
+        return res._asdict()
+    else:
+        return res

--- a/src/backend/expungeservice/endpoints/users.py
+++ b/src/backend/expungeservice/endpoints/users.py
@@ -26,7 +26,8 @@ class Users(MethodView):
         if data == None:
             error(400, "No json data in request body")
 
-        check_data_fields(data, ['email', 'password', 'admin'])
+        #print("data received by Users.post():", data)
+        check_data_fields(data, ['email', 'name', 'group_name', 'password', 'admin'])
 
         if len(data['password']) <8:
             error(422, 'New password is less than 8 characters long!')
@@ -36,6 +37,8 @@ class Users(MethodView):
         try:
             create_user_result = create_user(g.database,
                                              email = data['email'],
+                                             name = data['name'],
+                                             group_name = data['group_name'],
                                              password_hash = password_hash,
                                              admin = data['admin'])
         except UniqueViolation:
@@ -63,6 +66,8 @@ class Users(MethodView):
         for user_entry in user_db_data:
             response_data['users'].append({
                 'email':user_entry['email'],
+                'name' :user_entry['name'],
+                'group_name' :user_entry['group_name'],
                 'admin':user_entry['admin'],
                 'timestamp': user_entry['date_created']
                 })

--- a/src/backend/tests/database/test_database.py
+++ b/src/backend/tests/database/test_database.py
@@ -31,40 +31,48 @@ class TestDatabaseOperations(unittest.TestCase):
     def test_create_user_success(self):
 
         email = "pytest_create@example.com"
+        name = "Ima Test"
+        group_name = "Ima Test Group"
         hashed_password = "examplepasswordhash3"
         admin = True
-        create_result = user.create_user(self.database, email, hashed_password, admin)
+        create_result = user.create_user(self.database, email, name, group_name, hashed_password, admin)
 
         assert create_result['email'] == email
         assert create_result['hashed_password'] == hashed_password
+        assert create_result['name'] == name
+        assert create_result['group_name'] == group_name
         assert create_result['admin'] == admin
         assert create_result['user_id']
         assert create_result['auth_id']
         assert create_result['date_created']
         assert create_result['date_modified']
 
-        self.verify_user_data(email, hashed_password, admin)
+        self.verify_user_data(email, name, group_name, hashed_password, admin)
 
     def test_create_user_duplicate_fail(self):
 
         email = "pytest_create_duplicate@example.com"
+        name = "Ima Test",
+        group_name = "Ima Test Group",
         hashed_password = 'examplepasswordhash'
         admin = True
-        user.create_user(self.database, email, hashed_password, admin)
+        user.create_user(self.database, email, name, group_name, hashed_password, admin)
 
         with pytest.raises(psycopg2.errors.UniqueViolation):
-            user.create_user(self.database, email, hashed_password, admin)
+            user.create_user(self.database, email, name, group_name, hashed_password, admin)
 
     def test_get_user(self):
         email = "pytest_get_user@example.com"
+        name = "Ima Test"
+        group_name = "Ima Test Group"
         hashed_password = 'examplepasswordhash2'
         admin = True
 
-        self.create_example_user(email, hashed_password, admin)
+        self.create_example_user(email, name, group_name, hashed_password, admin)
 
         user_result = user.get_user_by_email(self.database, email)
 
-        self.verify_user_data(email, hashed_password, admin)
+        self.verify_user_data(email, name, group_name, hashed_password, admin)
 
 
     def test_get_all_users(self):
@@ -76,13 +84,17 @@ class TestDatabaseOperations(unittest.TestCase):
 
         email1 = "pytest_get_user@example.com"
         hashed_password = 'examplepasswordhash2'
+        name1 = "Ima Test1"
+        group_name1 = "Ima Test Group1"
         admin = True
-        self.create_example_user(email1, hashed_password, admin)
+        self.create_example_user(email1, name1, group_name1, hashed_password, admin)
 
         email2 = "pytest_get_user_2@example.com"
+        name2 = "Ima Tes2t"
+        group_name2 = "Ima Test Group2"
         hashed_password = 'examplepasswordhash3'
         admin = True
-        self.create_example_user(email2, hashed_password, admin)
+        self.create_example_user(email2, name2, group_name2, hashed_password, admin)
 
         users_get_endpoint_result = user.get_all_users(self.database)
 
@@ -94,9 +106,10 @@ class TestDatabaseOperations(unittest.TestCase):
 
         assert len(verify_rows) == len(users_get_endpoint_result)
 
-        for (email, hashed_password, admin) in [
-        (r['email'], r['hashed_password'], r['admin']) for r in users_get_endpoint_result]:
-            self.verify_user_data(email, hashed_password, admin)
+        for (email, name, group_name, hashed_password, admin) in [
+            (r['email'], r['name'], r['group_name'], r['hashed_password'], r['admin']) for r in users_get_endpoint_result]:
+            self.verify_user_data(email, name, group_name, hashed_password, admin)
+
     def test_get_missing_user(self):
 
         email = "pytest_get_user_does_not_exist@example.com"
@@ -106,28 +119,32 @@ class TestDatabaseOperations(unittest.TestCase):
         assert user_result == None
 
     #Helper function
-    def create_example_user(self, email, hashed_password, admin):
+    def create_example_user(self, email, name, group_name, hashed_password, admin):
 
         self.database.cursor.execute(
         """
         WITH USER_INSERT_RESULT AS
             (
-            INSERT INTO USERS (user_id, email, admin)
-            VALUES ( uuid_generate_v4(), %(email)s, %(adm)s)
+            INSERT INTO USERS (user_id, email, name, group_name, admin)
+            VALUES ( uuid_generate_v4(),
+                %(email)s,
+                %(name)s,
+                %(group_name)s,
+                %(adm)s)
             RETURNING user_id)
             INSERT INTO AUTH (auth_id, hashed_password, user_id)
             SELECT uuid_generate_v4(), %(pass)s, user_id FROM USER_INSERT_RESULT;
-        """, {'email':email, 'pass':hashed_password, 'adm': admin})
+        """, {'email':email, 'pass':hashed_password, 'name':name, 'group_name': group_name, 'adm': admin})
 
         self.database.connection.commit()
 
     #Helper function
-    def verify_user_data(self, email, hashed_password, admin):
-    # is passed the data obtained from the app feature e.g. a database function,
-    # and checks the fields match a second, raw SQL query.
+    def verify_user_data(self, email, name, group_name, hashed_password, admin):
+    # is passed the data obtained from the app function to be tested, e.g. a database function or endpoint,
+    # and checks that the fields match a second, raw SQL query.
 
         verify_query = """
-            SELECT USERS.user_id::text, email, admin, hashed_password, auth_id::text, date_created, date_modified
+            SELECT USERS.user_id::text, email, name, group_name, admin, hashed_password, auth_id::text, date_created, date_modified
             FROM USERS JOIN
             AUTH ON USERS.user_id = AUTH.user_id
             WHERE email = %(email)s;"""
@@ -138,6 +155,8 @@ class TestDatabaseOperations(unittest.TestCase):
         assert len(rows) == 1
         user_result = rows[0]._asdict()
         assert user_result['email'] == email
+        assert user_result['name'] == name
+        assert user_result['group_name'] == group_name
         assert user_result['hashed_password'] == hashed_password
         assert user_result['admin'] == admin
         assert user_result['user_id']

--- a/src/backend/tests/endpoints/test_auth.py
+++ b/src/backend/tests/endpoints/test_auth.py
@@ -30,6 +30,8 @@ class UserProtectedView(MethodView):
 class TestAuth(unittest.TestCase):
 
     email = 'pytest_user@auth_test.com'
+    name= 'AuthTest Name'
+    group_name= 'AuthTest Group Name'
     password = 'pytest_password'
     hashed_password = generate_password_hash(password)
 
@@ -45,7 +47,7 @@ class TestAuth(unittest.TestCase):
             expungeservice.request.before()
 
             self.db_cleanup()
-            user.create_user(g.database, self.email, self.hashed_password, False)
+            user.create_user(g.database, self.email, self.name, self.group_name, self.hashed_password, False)
             expungeservice.request.teardown(None)
 
 
@@ -115,13 +117,15 @@ class TestAuth(unittest.TestCase):
     def test_is_admin_auth_token(self):
 
         admin_email = 'pytest_admin_user@auth_test.com'
+        admin_name= 'AuthTest Name'
+        admin_group_name= 'AuthTest Group Name'
         admin_password = 'pytest_admin_password'
         hashed_admin_password = generate_password_hash(admin_password)
 
         with self.app.app_context():
             expungeservice.request.before()
 
-            user.create_user(g.database, admin_email, hashed_admin_password, True)
+            user.create_user(g.database, admin_email, admin_name, admin_group_name, hashed_admin_password, True)
             expungeservice.request.teardown(None)
 
         response = self.generate_auth_token(admin_email, admin_password)

--- a/src/backend/tests/endpoints/test_users.py
+++ b/src/backend/tests/endpoints/test_users.py
@@ -14,11 +14,17 @@ import expungeservice
 class TestUsers(unittest.TestCase):
 
     email = 'pytest_user@auth_test.com'
+    name = 'Endpoint Test'
+    group_name = 'Endpoint Test Group'
     password = 'pytest_password'
+
     hashed_password = generate_password_hash(password)
 
     admin_email = 'pytest_admin@auth_test.com'
     admin_password = 'pytest_password_admin'
+    admin_name = 'Endpoint AdminTest'
+    admin_group_name = 'Endpoint AdminTest Group'
+
     hashed_admin_password = generate_password_hash(admin_password)
 
     def setUp(self):
@@ -30,8 +36,8 @@ class TestUsers(unittest.TestCase):
             expungeservice.request.before()
 
             self.db_cleanup()
-            user.create_user(g.database, self.email, self.hashed_password, False)
-            user.create_user(g.database, self.admin_email, self.hashed_admin_password, True)
+            user.create_user(g.database, self.email, self.name, self.group_name, self.hashed_password, False)
+            user.create_user(g.database, self.admin_email, self.admin_name, self.admin_group_name, self.hashed_admin_password, True)
             expungeservice.request.teardown(None)
 
     def tearDown(self):
@@ -66,12 +72,15 @@ class TestUsers(unittest.TestCase):
             'Authorization': 'Bearer {}'.format(generate_auth_response.get_json()['auth_token'])},
                 json = {'email':new_email,
                         'password': new_password,
+                        'name': self.name,
+                        'group_name': self.group_name,
                         'admin': True})
 
 
         assert(response.status_code == 201)
 
         data = response.get_json()
+        print("data fron JSON response: ", data)
         assert data['email'] == new_email
         assert data['admin'] == True
         assert data['timestamp']
@@ -85,6 +94,8 @@ class TestUsers(unittest.TestCase):
         response = self.client.post('/api/users', headers={
             'Authorization': '' },
             json = {'email':new_email,
+                    'name': self.name,
+                    'group_name': self.group_name,
                     'password': new_password,
                     'admin': False})
 
@@ -99,6 +110,9 @@ class TestUsers(unittest.TestCase):
         response = self.client.post('/api/users', headers={
             'Authorization': 'Bearer {}'.format(generate_auth_response.get_json()['auth_token'])},
                 json = {'email':new_email,
+                        'name': self.name,
+                        'group_name': self.group_name,
+
                         #'password': new_password,
                         'admin': True})
 
@@ -116,6 +130,8 @@ class TestUsers(unittest.TestCase):
         response = self.client.post('/api/users', headers={
             'Authorization': 'Bearer {}'.format(generate_auth_response.get_json()['auth_token'])},
             json = {'email':new_email,
+                    'name': self.name,
+                    'group_name': self.group_name,
                     'password': new_password,
                     'admin': False})
 
@@ -124,6 +140,8 @@ class TestUsers(unittest.TestCase):
         response = self.client.post('/api/users', headers={
             'Authorization': 'Bearer {}'.format(generate_auth_response.get_json()['auth_token'])},
             json = {'email':new_email,
+                    'name': self.name,
+                    'group_name': self.group_name,
                     'password': new_password,
                     'admin': False})
 
@@ -139,6 +157,8 @@ class TestUsers(unittest.TestCase):
         response = self.client.post('/api/users', headers={
             'Authorization': 'Bearer {}'.format(generate_auth_response.get_json()['auth_token'])},
             json = {'email':new_email,
+                    'name': self.name,
+                    'group_name': self.group_name,
                     'password': short_password,
                     'admin': False}
         )
@@ -155,6 +175,9 @@ class TestUsers(unittest.TestCase):
         response = self.client.post('/api/users', headers={
             'Authorization': 'Bearer {}'.format(generate_auth_response.get_json()['auth_token'])},
             json = {'email':new_email,
+                    'name': self.name,
+                    'group_name': self.group_name,
+
                     'password': new_password,
                     'admin': False})
 
@@ -175,7 +198,7 @@ class TestUsers(unittest.TestCase):
         data = response.get_json()
 
         assert data['users'][0]['email']
-        assert data['users'][0]['admin']
+        assert data['users'][0]['admin'] in [True, False]
         assert data['users'][0]['timestamp']
 
 


### PR DESCRIPTION
Just adds the two columns "name" and "group_name" to the Users table and the endpoints that read/insert Users.  