### PR TITLE
fix the default credentials insert into DB

### DIFF
--- a/config/postgres/initdb/scripts/initial_credentials.dev.sql
+++ b/config/postgres/initdb/scripts/initial_credentials.dev.sql
@@ -1,1 +1,2 @@
-SELECT * FROM CREATE_USER( 'admin', 'pbkdf2:sha256:150000$c30CjWVB$d1d6d544dfffd2dee5488cfe89cc2f965a8c4cddbf9180ad206f272237a5fa1a', true);
+SELECT * FROM CREATE_USER( 'admin', 'pbkdf2:sha256:150000$c30CjWVB$d1d6d544dfffd2dee5488cfe89cc2f965a8c4cddbf9180ad206f272237a5fa1a', 'Ima Admin', 'Ima Group', true);
+SELECT * FROM CREATE_USER('user', 'pbkdf2:sha256:150000$K5efuBwy$fcaa41a3203fd8f64b5d4aee241365ffa35e0a3a1c02f605bbc20cbea701cf89', 'Ima User', 'Ima Group' , true);


### PR DESCRIPTION
Fixed to match recent DB change.

Now the dev environment has an initial admin and regular user for testing:
email: `user` , password: `user`
email: `admin` , password: `admin`
