### PR TITLE
oeci_login endpoint

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ requests-mock = "*"
 requests = "*"
 python-dateutil = "*"
 uwsgi = "*"
+cryptography = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bdc9d141f4b39f0169c3409b3eb94e057110253eb0fc936b50909f4c40606aa2"
+            "sha256": "1ac12be48b482c758da2a9de33384db6205a292b62d75c99d0fea08afbba38b9"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,13 @@
         ]
     },
     "default": {
+        "asn1crypto": {
+            "hashes": [
+                "sha256:2f1adbb7546ed199e3c90ef23ec95c5cf3585bac7d11fb7eb562a3fe89c64e87",
+                "sha256:9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49"
+            ],
+            "version": "==0.24.0"
+        },
         "atomicwrites": {
             "hashes": [
                 "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
@@ -104,6 +111,28 @@
                 "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
             ],
             "version": "==7.0"
+        },
+        "cryptography": {
+            "hashes": [
+                "sha256:24b61e5fcb506424d3ec4e18bca995833839bf13c59fc43e530e488f28d46b8c",
+                "sha256:25dd1581a183e9e7a806fe0543f485103232f940fcfc301db65e630512cce643",
+                "sha256:3452bba7c21c69f2df772762be0066c7ed5dc65df494a1d53a58b683a83e1216",
+                "sha256:41a0be220dd1ed9e998f5891948306eb8c812b512dc398e5a01846d855050799",
+                "sha256:5751d8a11b956fbfa314f6553d186b94aa70fdb03d8a4d4f1c82dcacf0cbe28a",
+                "sha256:5f61c7d749048fa6e3322258b4263463bfccefecb0dd731b6561cb617a1d9bb9",
+                "sha256:72e24c521fa2106f19623a3851e9f89ddfdeb9ac63871c7643790f872a305dfc",
+                "sha256:7b97ae6ef5cba2e3bb14256625423413d5ce8d1abb91d4f29b6d1a081da765f8",
+                "sha256:961e886d8a3590fd2c723cf07be14e2a91cf53c25f02435c04d39e90780e3b53",
+                "sha256:96d8473848e984184b6728e2c9d391482008646276c3ff084a1bd89e15ff53a1",
+                "sha256:ae536da50c7ad1e002c3eee101871d93abdc90d9c5f651818450a0d3af718609",
+                "sha256:b0db0cecf396033abb4a93c95d1602f268b3a68bb0a9cc06a7cff587bb9a7292",
+                "sha256:cfee9164954c186b191b91d4193989ca994703b2fff406f71cf454a2d3c7327e",
+                "sha256:e6347742ac8f35ded4a46ff835c60e68c22a536a8ae5c4422966d06946b6d4c6",
+                "sha256:f27d93f0139a3c056172ebb5d4f9056e770fdf0206c2f422ff2ebbad142e09ed",
+                "sha256:f57b76e46a58b63d1c6375017f4564a28f19a5ca912691fd2e4261b3414b618d"
+            ],
+            "index": "pypi",
+            "version": "==2.7"
         },
         "expungeservice": {
             "editable": true,
@@ -312,10 +341,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:2f3eadfea5d92bc7899e75b5968410b749a054b492d5a6379c1344a1481bc2cb",
-                "sha256:9c6c593cb28f52075016307fc26b0a0f8e82bc7d1ff19aaaa959b91710a56c47"
+                "sha256:3de946ffbed6e6746608990594d08faac602528ac7015ac28d33cee6a45b7398",
+                "sha256:9a107b99a5393caf59c7aa3c1249c16e6879447533d0887f4336dde834c7be86"
             ],
-            "version": "==1.25.5"
+            "version": "==1.25.6"
         },
         "uwsgi": {
             "hashes": [

--- a/src/backend/expungeservice/app.py
+++ b/src/backend/expungeservice/app.py
@@ -3,7 +3,7 @@ from flask import Flask
 from .config import app_config
 
 # Add new endpoint imports here:
-from .endpoints import hello, auth, users
+from .endpoints import hello, auth, users, oeci_login
 from .request import before, teardown
 import logging
 
@@ -26,6 +26,7 @@ def create_app(env_name):
     hello.register(app)
     auth.register(app)
     users.register(app)
+    oeci_login.register(app)
 
     app.before_request(before)
     app.teardown_request(teardown)

--- a/src/backend/expungeservice/config.py
+++ b/src/backend/expungeservice/config.py
@@ -7,7 +7,7 @@ class Development(object):
     """
     DEBUG = True
     TESTING = False
-    JWT_SECRET_KEY = os.urandom(24)
+    JWT_SECRET_KEY = os.urandom(32)
     JWT_EXPIRY_TIMER = datetime.timedelta(minutes=60)
     SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL')
 

--- a/src/backend/expungeservice/crawler/crawler.py
+++ b/src/backend/expungeservice/crawler/crawler.py
@@ -17,11 +17,15 @@ class Crawler:
         self.response = requests.Response
         self.result = RecordParser()
 
-    def login(self, username, password):
+    def login(self, username, password, close=False):
         url = URL.login_url()
         payload = Payload.login_payload(username, password)
 
         self.response = self.session.post(url, data=payload)
+
+        if close:
+            self.session.close()
+
         return Crawler.__login_validation(self.response, url)
 
     def search(self, first_name, last_name, middle_name='', birth_date=''):

--- a/src/backend/expungeservice/endpoints/oeci_login.py
+++ b/src/backend/expungeservice/endpoints/oeci_login.py
@@ -1,0 +1,62 @@
+from flask.views import MethodView
+from flask import request, make_response, current_app
+import time
+from cryptography.fernet import Fernet
+import json
+import base64
+
+from expungeservice.crawler.crawler import Crawler
+from expungeservice.endpoints.auth import user_auth_required
+from expungeservice.request import check_data_fields
+from expungeservice.request.error import error
+
+
+class OeciLogin(MethodView):
+
+    @user_auth_required
+    def post(self):
+        """
+        Attempts to log in to the OECI web site using the provided username
+        and password if successful, encrypt those credentials and return them
+        in a cookie. If the credentials
+        """
+
+        data = request.get_json()
+
+        if data is None:
+            error(400, "No json data in request body")
+
+        check_data_fields(data, ['oeci_username', 'oeci_password'])
+
+        login_result = Crawler().login(
+            data["oeci_username"],
+            data["oeci_password"])
+
+        if not login_result:
+            error(401, "Invalid OECI username or password.")
+
+        key = base64.encodebytes(current_app.config.get('JWT_SECRET_KEY'))
+
+        credentials = json.dumps({
+            "oeci_username": data["oeci_username"],
+            "oeci_password": data["oeci_password"]}).encode("utf-8")
+
+        cipher = Fernet(key=key)
+        encrypted = cipher.encrypt(bytes(credentials))
+
+        response = make_response()
+
+        response.set_cookie(
+            "oeci_token",
+            secure=True,
+            httponly=True,
+            samesite='strict',
+            expires=time.time() + 15 * 60,
+            value=encrypted)
+
+        return response, 201
+
+
+def register(app):
+    app.add_url_rule('/api/oeci_login',
+                     view_func=OeciLogin.as_view('oeci_login'))

--- a/src/backend/expungeservice/endpoints/oeci_login.py
+++ b/src/backend/expungeservice/endpoints/oeci_login.py
@@ -30,7 +30,8 @@ class OeciLogin(MethodView):
 
         login_result = Crawler().login(
             data["oeci_username"],
-            data["oeci_password"])
+            data["oeci_password"],
+            True)
 
         if not login_result:
             error(401, "Invalid OECI username or password.")

--- a/src/backend/tests/endpoints/endpoint_util.py
+++ b/src/backend/tests/endpoints/endpoint_util.py
@@ -1,10 +1,7 @@
 import unittest
 from werkzeug.security import generate_password_hash
-from flask import g
-from flask.views import MethodView
 
 import expungeservice
-from expungeservice.database import user
 from expungeservice.endpoints.auth import *
 
 

--- a/src/backend/tests/endpoints/test_oeci_login.py
+++ b/src/backend/tests/endpoints/test_oeci_login.py
@@ -16,7 +16,7 @@ class TestOeciLogin(EndpointShared):
         oeci_login.Crawler.login = self.login
 
     def mock_login(self, value):
-        return lambda a, b, c: value
+        return lambda a, b, c, d: value
 
     def test_oeci_login_success(self):
 

--- a/src/backend/tests/endpoints/test_oeci_login.py
+++ b/src/backend/tests/endpoints/test_oeci_login.py
@@ -8,6 +8,13 @@ from tests.endpoints.endpoint_util import EndpointShared
 
 class TestOeciLogin(EndpointShared):
 
+    def setUp(self):
+        EndpointShared.setUp(self)
+        self.login = oeci_login.Crawler.login
+
+    def tearDown(self):
+        oeci_login.Crawler.login = self.login
+
     def mock_login(self, value):
         return lambda a, b, c: value
 
@@ -41,3 +48,4 @@ class TestOeciLogin(EndpointShared):
                   "oeci_password": "wrongpwd"})
 
         assert(response.status_code == 401)
+

--- a/src/backend/tests/endpoints/test_oeci_login.py
+++ b/src/backend/tests/endpoints/test_oeci_login.py
@@ -1,0 +1,62 @@
+import pytest
+import unittest
+from flask import jsonify, current_app, g, request
+import base64
+import cryptography
+import json
+
+import expungeservice
+
+from expungeservice.endpoints import oeci_login
+from tests.endpoints.endpoint_util import EndpointShared
+
+
+class TestOeciLogin(EndpointShared):
+
+    def test_oeci_login_success(self):
+
+        def faked_login(a, b, c):
+            return True
+
+        actual_login = oeci_login.Crawler.login
+
+        oeci_login.Crawler.login = faked_login
+
+        response = self.client.post(
+            "/api/oeci_login", headers=self.admin_auth_header,
+            json={"oeci_username": "correctname",
+                  "oeci_password": "correctpwd"})
+
+        credentials_cookie_string = self.client.cookie_jar._cookies[
+            "localhost.local"]["/"]["oeci_token"].value
+
+        jwt_key = base64.encodebytes(self.app.config.get("JWT_SECRET_KEY"))
+        cipher = cryptography.fernet.Fernet(key=jwt_key)
+        creds = json.loads(cipher.decrypt(bytes(
+            credentials_cookie_string, "utf-8")))
+
+        print(creds)
+
+        assert creds["oeci_username"] == "correctname"
+        assert creds["oeci_password"] == "correctpwd"
+
+        oeci_login.Crawler.login = actual_login
+
+    def test_oeci_login_invalid_credentials(self):
+
+        def faked_login(a, b, c):
+            return False
+
+        actual_login = oeci_login.Crawler.login
+
+        oeci_login.Crawler.login = faked_login
+
+        response = self.client.post(
+            "/api/oeci_login", headers=self.admin_auth_header,
+            json={"oeci_username": "wrongname",
+                  "oeci_password": "wrongpwd"})
+
+        assert(response.status_code == 401)
+
+        oeci_login.Crawler.login = actual_login
+

--- a/src/backend/tests/endpoints/test_oeci_login.py
+++ b/src/backend/tests/endpoints/test_oeci_login.py
@@ -8,14 +8,12 @@ from tests.endpoints.endpoint_util import EndpointShared
 
 class TestOeciLogin(EndpointShared):
 
-    def test_oeci_login_success(self):
-
-        def faked_login(a, b, c):
-            return True
+    def mock_login(self, value):
+        return lambda a, b, c: value
 
     def test_oeci_login_success(self):
 
-        oeci_login.Crawler.login = faked_login
+        oeci_login.Crawler.login = self.mock_login(True)
 
         self.client.post(
             "/api/oeci_login", headers=self.admin_auth_header,
@@ -35,12 +33,7 @@ class TestOeciLogin(EndpointShared):
 
     def test_oeci_login_invalid_credentials(self):
 
-        def faked_login(a, b, c):
-            return False
-
-        actual_login = oeci_login.Crawler.login
-
-        oeci_login.Crawler.login = faked_login
+        oeci_login.Crawler.login = self.mock_login(False)
 
         response = self.client.post(
             "/api/oeci_login", headers=self.admin_auth_header,

--- a/src/backend/tests/endpoints/test_oeci_login.py
+++ b/src/backend/tests/endpoints/test_oeci_login.py
@@ -1,11 +1,6 @@
-import pytest
-import unittest
-from flask import jsonify, current_app, g, request
 import base64
 import cryptography
 import json
-
-import expungeservice
 
 from expungeservice.endpoints import oeci_login
 from tests.endpoints.endpoint_util import EndpointShared
@@ -18,11 +13,11 @@ class TestOeciLogin(EndpointShared):
         def faked_login(a, b, c):
             return True
 
-        actual_login = oeci_login.Crawler.login
+    def test_oeci_login_success(self):
 
         oeci_login.Crawler.login = faked_login
 
-        response = self.client.post(
+        self.client.post(
             "/api/oeci_login", headers=self.admin_auth_header,
             json={"oeci_username": "correctname",
                   "oeci_password": "correctpwd"})
@@ -35,12 +30,8 @@ class TestOeciLogin(EndpointShared):
         creds = json.loads(cipher.decrypt(bytes(
             credentials_cookie_string, "utf-8")))
 
-        print(creds)
-
         assert creds["oeci_username"] == "correctname"
         assert creds["oeci_password"] == "correctpwd"
-
-        oeci_login.Crawler.login = actual_login
 
     def test_oeci_login_invalid_credentials(self):
 
@@ -57,6 +48,3 @@ class TestOeciLogin(EndpointShared):
                   "oeci_password": "wrongpwd"})
 
         assert(response.status_code == 401)
-
-        oeci_login.Crawler.login = actual_login
-


### PR DESCRIPTION
API endpoint that accepts and validate's a user's oeci login credentials. #401 describes the feature implemented here. 

Other implementation notes:
 - added the cryptography package as a new dependency. the JWT package we're using for auth tokens doesn't support encryption features.
 - increased the size the app config's JWT secret key so that it's valid to be used for the Fernet symmetric encryption package. 
 - the test code stubs the crawler.login() call so that it doesn't attempt an actual log in to the remote site. 

I started the cookies portion of this code in PR #378  and incorporated @maxkwallace 's  feedback. 