### PR TITLE
Endpoint users get authorization fix

### DIFF
--- a/doc/design.md
+++ b/doc/design.md
@@ -186,7 +186,7 @@ Status codes:
 - `403 FORBIDDEN`: authorized user is not admin
 
 
-**`GET`** `/api/user/user_id`
+**`GET`** `/api/users/<user_id>`
 
 Required headers:
 
@@ -202,16 +202,16 @@ Returns: Requested user. requires admin authorization or that the logged-in user
     * group
     * admin
     * timestamp
-    
+
 
 Status codes:
 
 - `200 OK`
 - `401 UNAUTHORIZED`: authorization rejected; missing or invalid auth token
-- `403 FORBIDDEN`: authorized user is not admin or doesn't match the requested user_id 
+- `403 FORBIDDEN`: authorized user is not admin or doesn't match the requested user_id
 
 
-**`POST`** `/api/user/`
+**`POST`** `/api/users/`
 
 Creates a user
 

--- a/src/backend/expungeservice/endpoints/auth.py
+++ b/src/backend/expungeservice/endpoints/auth.py
@@ -71,9 +71,8 @@ def authorized(f, admin_required, *args, **kwargs):
         if admin_required and not user_data['admin']:
             error(403, 'Logged in user not admin')
 
-        # no endpoint code uses the logged in user_id so this is commented for
-        # now. This may change.
-        # g.logged_in_user_id = user_data['user_id']
+        g.logged_in_user_id = user_data['user_id']
+        g.logged_in_user_is_admin = user_data['admin']
 
         return f(*args, **kwargs)
 

--- a/src/backend/expungeservice/endpoints/users.py
+++ b/src/backend/expungeservice/endpoints/users.py
@@ -42,6 +42,7 @@ class Users(MethodView):
             return jsonify(response_data), 201
 
         else:
+            # No user_id given; this is a GET all users request.
             if not g.logged_in_user_is_admin:
                 error(403, "Logged in user not admin ")
 

--- a/src/backend/expungeservice/endpoints/users.py
+++ b/src/backend/expungeservice/endpoints/users.py
@@ -16,31 +16,35 @@ class Users(MethodView):
     @user_auth_required
     def get(self, user_id):
         """
-        Fetch the list of users, with their user_id, name, group name,
-        email, admin status, and date_created.
+        Fetch a single user's data if a user_id is specified.
+        Otherwise fetch the list of all users.
+        Returned info contains user_id, name, group name,email,
+        admin status, and date_created.
         """
 
-        print("in endpoint; getting with userid = ", user_id)
-
         if user_id:
+
             user_db_data = user.read(g.database, user_id)
 
-            print("user db read result: ", user_db_data)
-
-            if user_db_data:
-                response_data = {
-                    "user_id": user_db_data["user_id"],
-                    "email": user_db_data["email"],
-                    "name": user_db_data["name"],
-                    "group_name": user_db_data["group_name"],
-                    "admin": user_db_data["admin"],
-                    "timestamp": user_db_data["date_created"]}
-                return jsonify(response_data), 201
-
-            else:
+            if not user_db_data:
                 error(404, "User id not recognized")
 
+            if not g.logged_in_user_is_admin and g.logged_in_user_id != user_id:
+                error(403, "Logged in user not admin and doesn't match requested user id.")
+
+            response_data = {
+                "user_id": user_db_data["user_id"],
+                "email": user_db_data["email"],
+                "name": user_db_data["name"],
+                "group_name": user_db_data["group_name"],
+                "admin": user_db_data["admin"],
+                "timestamp": user_db_data["date_created"]}
+            return jsonify(response_data), 201
+
         else:
+            if not g.logged_in_user_is_admin:
+                error(403, "Logged in user not admin ")
+
             user_db_data = user.fetchall(g.database)
 
             response_data = {"users": []}

--- a/src/backend/tests/endpoints/endpoint_util.py
+++ b/src/backend/tests/endpoints/endpoint_util.py
@@ -24,21 +24,54 @@ class UserProtectedView(MethodView):
 
 class EndpointShared(unittest.TestCase):
 
-    email = "pytest_user@auth_test.com"
-    name = "Endpoint Test"
-    group_name = "Endpoint Test Group"
-    password = "pytest_password"
+    user_data = {
+        "user1":
+        {
+            "email": "pytest_user@auth_test.com",
+            "name": "Endpoint Test",
+            "group_name": "Endpoint Test Group",
+            "admin": False,
+            "password": "password",
+            "hashed_password": generate_password_hash("password"),
+        },
+        "user2":
+        {
+            "email": "pytest_user2@auth_test.com",
+            "name": "Endpoint Test2",
+            "group_name": "Endpoint Test Group2",
+            "admin": False,
+            "password": "password2",
+            "hashed_password": generate_password_hash("password2")
+        },
+        "admin": {
+            "email": "pytest_admin@auth_test.com",
+            "name": "Endpoint AdminTest",
+            "group_name": "Endpoint AdminTest Group",
+            "admin": True,
+            "password": "admin",
+            "hashed_password": generate_password_hash("admin")
+        }
+    }
 
-    hashed_password = generate_password_hash(password)
+    def create_test_user(self, user_key):
 
-    admin_email = "pytest_admin@auth_test.com"
-    admin_password = "pytest_password_admin"
-    admin_name = "Endpoint AdminTest"
-    admin_group_name = "Endpoint AdminTest Group"
+        create_result = user.create(
+            g.database,
+            self.user_data[user_key]["email"],
+            self.user_data[user_key]["name"],
+            self.user_data[user_key]["group_name"],
+            self.user_data[user_key]["hashed_password"],
+            self.user_data[user_key]["admin"]
+        )
+        self.user_data[user_key]["user_id"] = create_result["user_id"]
 
-    ids = {}
+        generate_auth_response = self.generate_auth_token(
+            self.user_data[user_key]["email"],
+            self.user_data[user_key]["password"]
+        )
 
-    hashed_admin_password = generate_password_hash(admin_password)
+        self.user_data[user_key]["auth_header"] = {"Authorization": "Bearer {}".format(
+                generate_auth_response.get_json()["auth_token"])}
 
     def setUp(self):
 
@@ -54,29 +87,23 @@ class EndpointShared(unittest.TestCase):
 
         with self.app.app_context():
             expungeservice.request.before()
-
             self.db_cleanup()
-            create_result = user.create(
-                g.database, self.email, self.name,
-                self.group_name, self.hashed_password, False)
-            self.ids[self.email] = create_result["user_id"]
-            create_result = user.create(
-                g.database, self.admin_email, self.admin_name,
-                self.admin_group_name, self.hashed_admin_password, True)
-            self.ids[self.admin_email] = create_result["user_id"]
             expungeservice.request.teardown(None)
 
-        generate_auth_response = self.generate_auth_token(
-            self.email, self.password)
+        with self.app.app_context():
+            expungeservice.request.before()
+            res = self.create_test_user("user1")
+            expungeservice.request.teardown(None)
 
-        self.user_auth_header = {"Authorization": "Bearer {}".format(
-                generate_auth_response.get_json()["auth_token"])}
+        with self.app.app_context():
+            expungeservice.request.before()
+            self.create_test_user("user2")
+            expungeservice.request.teardown(None)
 
-        generate_auth_response = self.generate_auth_token(
-            self.admin_email, self.admin_password)
-
-        self.admin_auth_header = {"Authorization": "Bearer {}".format(
-                generate_auth_response.get_json()["auth_token"])}
+        with self.app.app_context():
+            expungeservice.request.before()
+            self.create_test_user("admin")
+            expungeservice.request.teardown(None)
 
     def tearDown(self):
         with self.app.app_context():

--- a/src/backend/tests/endpoints/test_auth.py
+++ b/src/backend/tests/endpoints/test_auth.py
@@ -22,14 +22,14 @@ class TestAuth(EndpointShared):
         EndpointShared.setUp(self)
 
     def test_auth_token_valid_credentials(self):
-        response = self.generate_auth_token(self.email, self.password)
+        response = self.generate_auth_token(self.user_data["user1"]["email"], self.user_data["user1"]["password"])
 
         assert(response.status_code == 200)
-        assert(response.headers.get('Content-type') == 'application/json')
+        assert(response.headers.get("Content-type") == "application/json")
         data = response.get_json()
-        assert('auth_token' in data)
-        assert(len(data['auth_token']) > 0)
-        assert(data['user_id'] == self.ids[self.email])
+        assert("auth_token" in data)
+        assert(len(data["auth_token"]) > 0)
+        assert(data["user_id"] == self.user_data["user1"]["user_id"])
 
     def test_auth_token_invalid_username(self):
         response = self.generate_auth_token(
@@ -37,11 +37,11 @@ class TestAuth(EndpointShared):
         assert(response.status_code == 401)
 
     def test_login_invalid_pasword(self):
-        response = self.generate_auth_token(self.email, 'wrong_password')
+        response = self.generate_auth_token(self.user_data["user1"]["email"], "wrong_password")
         assert(response.status_code == 401)
 
     def test_access_valid_auth_token(self):
-        response = self.generate_auth_token(self.email, self.password)
+        response = self.generate_auth_token(self.user_data["user1"]["email"], self.user_data["user1"]["password"])
         response = self.client.get(
             '/api/test/user_protected',
             headers={
@@ -51,7 +51,6 @@ class TestAuth(EndpointShared):
         assert(response.status_code == 200)
 
     def test_access_invalid_auth_token(self):
-        response = self.generate_auth_token(self.email, self.password)
         response = self.client.get('/api/test/user_protected', headers={
             'Authorization': 'Bearer {}'.format('Invalid auth token')
         })
@@ -60,8 +59,7 @@ class TestAuth(EndpointShared):
     def test_access_expired_auth_token(self):
         self.app.config['JWT_EXPIRY_TIMER'] = datetime.timedelta(seconds=0)
 
-        response = self.generate_auth_token(self.email, self.password)
-        print(response)
+        response = self.generate_auth_token(self.user_data["user1"]["email"], self.user_data["user1"]["password"])
         time.sleep(1)
         response = self.client.get(
             '/api/test/user_protected',
@@ -98,7 +96,7 @@ class TestAuth(EndpointShared):
 
     def test_is_not_admin_auth_token(self):
 
-        response = self.generate_auth_token(self.email, self.password)
+        response = self.generate_auth_token(self.user_data["user1"]["email"], self.user_data["user1"]["password"])
         response = self.client.get(
             '/api/test/admin_protected',
             headers={

--- a/src/backend/tests/endpoints/test_oeci_login.py
+++ b/src/backend/tests/endpoints/test_oeci_login.py
@@ -29,7 +29,7 @@ class TestOeciLogin(EndpointShared):
         oeci_login.Crawler.login = self.mock_login(True)
 
         self.client.post(
-            "/api/oeci_login", headers=self.admin_auth_header,
+            "/api/oeci_login", headers=self.user_data["user1"]["auth_header"],
             json={"oeci_username": "correctname",
                   "oeci_password": "correctpwd"})
 
@@ -46,7 +46,7 @@ class TestOeciLogin(EndpointShared):
         oeci_login.Crawler.login = self.mock_login(False)
 
         response = self.client.post(
-            "/api/oeci_login", headers=self.admin_auth_header,
+            "/api/oeci_login", headers=self.user_data["user1"]["auth_header"],
             json={"oeci_username": "wrongname",
                   "oeci_password": "wrongpwd"})
 


### PR DESCRIPTION
This makes a small change to the /api/users GET endpoint: a user is now authorized to get a user's data only if the requesting and requested user ids match, or if the requesting user is an admin. This matches the design doc. 

Fixed the design doc to meet our recent design change, so that there is no "user" endpoint, only a "users" endpoint which covers all the relevant operations. 

Also tried to improve organization of the endpoint test code a bit. One problem though is that the unit tests are now even slower. I made a new issue for this: #441 