### PR TITLE
uWSGI die on SIGTERM

### DIFF
--- a/src/backend/expungeservice/Dockerfile.dev
+++ b/src/backend/expungeservice/Dockerfile.dev
@@ -14,4 +14,4 @@ COPY . /var/www/expungeservice
 WORKDIR /var/www
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
-CMD ["uwsgi", "--py-autoreload", "1",  "--http", "0.0.0.0:5000", "--module", "expungeservice.wsgi"]
+CMD ["uwsgi", "--py-autoreload", "1",  "--http", "0.0.0.0:5000", "--module", "expungeservice.wsgi", "--die-on-term"]


### PR DESCRIPTION
On receiving the SIGTERM signal, the default behavior for uWSGI is to reload it's workers and master process: [https://uwsgi-docs.readthedocs.io/en/latest/Management.html#signals-for-controlling-uwsgi](https://uwsgi-docs.readthedocs.io/en/latest/Management.html#signals-for-controlling-uwsgi). This conflicts with Docker's use of the signal; gracefully shutting down it's containers. Adding the `--die-on-term` flag to the uWSGI startup command overrides the default behavior, so that the processes will be killed rather than restarted. This results in quicker shutdown times when running the `make dev_down` command (from 10s to about 2s).