### PR TITLE
Db commit after request

### DIFF
--- a/src/backend/expungeservice/app.py
+++ b/src/backend/expungeservice/app.py
@@ -4,7 +4,7 @@ from .config import app_config
 
 # Add new endpoint imports here:
 from .endpoints import hello, auth, users, oeci_login, search
-from .request import before, teardown
+from .request import before, after, teardown
 import logging
 
 from .loggers import attach_logger
@@ -30,6 +30,7 @@ def create_app(env_name):
     search.register(app)
 
     app.before_request(before)
+    app.after_request(after)
     app.teardown_request(teardown)
 
     app.logger.debug("Flask app created!")

--- a/src/backend/expungeservice/database/user.py
+++ b/src/backend/expungeservice/database/user.py
@@ -20,7 +20,6 @@ def create(database, email, name,
               'adm': admin})
 
     result = database.cursor.fetchone()
-    database.connection.commit()
     return result._asdict()
 
 

--- a/src/backend/expungeservice/request/request.py
+++ b/src/backend/expungeservice/request/request.py
@@ -7,8 +7,10 @@ def before():
 
     g.database = get_database()
 
-def teardown(exception):
+def after():
     g.database.connection.commit()
+
+def teardown(exception):
     g.database.close_connection()
 
 def check_data_fields(request_json, required_fields):

--- a/src/backend/expungeservice/request/request.py
+++ b/src/backend/expungeservice/request/request.py
@@ -8,6 +8,7 @@ def before():
     g.database = get_database()
 
 def teardown(exception):
+    g.database.connection.commit()
     g.database.close_connection()
 
 def check_data_fields(request_json, required_fields):

--- a/src/backend/expungeservice/request/request.py
+++ b/src/backend/expungeservice/request/request.py
@@ -7,8 +7,9 @@ def before():
 
     g.database = get_database()
 
-def after():
+def after(response):
     g.database.connection.commit()
+    return response
 
 def teardown(exception):
     g.database.close_connection()

--- a/src/backend/tests/endpoints/endpoint_util.py
+++ b/src/backend/tests/endpoints/endpoint_util.py
@@ -1,5 +1,6 @@
 import unittest
 from werkzeug.security import generate_password_hash
+from flask import g
 
 import expungeservice
 from expungeservice.endpoints.auth import *
@@ -87,6 +88,8 @@ class EndpointShared(unittest.TestCase):
             self.create_test_user("user1")
             self.create_test_user("user2")
             self.create_test_user("admin")
+            g.database.connection.commit()
+
             expungeservice.request.teardown(None)
 
     def tearDown(self):
@@ -101,9 +104,3 @@ class EndpointShared(unittest.TestCase):
         cleanup_query = """DELETE FROM users where email like %(pattern)s;"""
         g.database.cursor.execute(cleanup_query, {"pattern": "%pytest%"})
         g.database.connection.commit()
-
-    def generate_auth_token(self, email, password):
-        return self.client.post("/api/auth_token", json={
-            "email": email,
-            "password": password,
-        })

--- a/src/backend/tests/endpoints/endpoint_util.py
+++ b/src/backend/tests/endpoints/endpoint_util.py
@@ -65,14 +65,9 @@ class EndpointShared(unittest.TestCase):
         )
         self.user_data[user_key]["user_id"] = create_result["user_id"]
 
-        generate_auth_response = self.generate_auth_token(
-            self.user_data[user_key]["email"],
-            self.user_data[user_key]["password"]
-        )
-
-        self.user_data[user_key]["auth_header"] = {"Authorization": "Bearer {}".format(
-                generate_auth_response.get_json()["auth_token"])}
-
+        self.user_data[user_key]["auth_header"] = {
+            "Authorization": "Bearer {}".format(
+                get_auth_token(self.app, create_result["user_id"]))}
     def setUp(self):
 
         self.app = expungeservice.create_app("development")
@@ -88,20 +83,9 @@ class EndpointShared(unittest.TestCase):
         with self.app.app_context():
             expungeservice.request.before()
             self.db_cleanup()
-            expungeservice.request.teardown(None)
 
-        with self.app.app_context():
-            expungeservice.request.before()
-            res = self.create_test_user("user1")
-            expungeservice.request.teardown(None)
-
-        with self.app.app_context():
-            expungeservice.request.before()
+            self.create_test_user("user1")
             self.create_test_user("user2")
-            expungeservice.request.teardown(None)
-
-        with self.app.app_context():
-            expungeservice.request.before()
             self.create_test_user("admin")
             expungeservice.request.teardown(None)
 

--- a/src/backend/tests/endpoints/test_auth.py
+++ b/src/backend/tests/endpoints/test_auth.py
@@ -71,21 +71,7 @@ class TestAuth(EndpointShared):
 
     def test_is_admin_auth_token(self):
 
-        admin_email = 'pytest_admin_user@auth_test.com'
-        admin_name = 'AuthTest Name'
-        admin_group_name = 'AuthTest Group Name'
-        admin_password = 'pytest_admin_password'
-        hashed_admin_password = generate_password_hash(admin_password)
-
-        with self.app.app_context():
-            expungeservice.request.before()
-
-            user.create(g.database, admin_email, admin_name,
-                        admin_group_name, hashed_admin_password, True)
-
-            expungeservice.request.teardown(None)
-
-        response = self.generate_auth_token(admin_email, admin_password)
+        response = self.generate_auth_token(self.user_data["admin"]["email"], self.user_data["admin"]["password"])
         response = self.client.get(
             '/api/test/admin_protected',
             headers={
@@ -104,3 +90,9 @@ class TestAuth(EndpointShared):
                     response.get_json()['auth_token'])
             })
         assert(response.status_code == 403)
+
+    def generate_auth_token(self, email, password):
+        return self.client.post("/api/auth_token", json={
+            "email": email,
+            "password": password,
+        })


### PR DESCRIPTION
Previously, the database users.create() operation ran a commit right away. I realized this isn't good and instead all the database ops in an endpoint should be treated as a single transaction. 

In this refactor, the database commit() runs only at the end of an endpoint request, and only if that request is returning without any errors.  

This also let me simplify the endpoint test code further, so that's included. Unit tests are a little faster now. 

Closes #441. This doesn't use the solution I proposed there, because that the wrong idea. If a request encounters any errors, it shouldn't persist any changes to the database. 

This runs a commit() even if no transactions are pending, in which case it has no effect. 
 