### PR TITLE
Fix Heroku deployment issues

### DIFF
--- a/config/nginx/recordexpunge-nginx.conf
+++ b/config/nginx/recordexpunge-nginx.conf
@@ -14,7 +14,7 @@
 
             root /;
 
-            proxy_pass https://recordexpungpdxapi.herokuapp.com/;
+            proxy_pass https://recordexpungpdxapi.herokuapp.com/api/;
 
 
 

--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -1,22 +1,22 @@
-
+handle_error = (rm -rf ./build && exit 1)
 
 api:
 	echo $@
 	mkdir ./build
 	cp -r ../src/backend/expungeservice ./build/expungeservice
 
-	heroku container:push --recursive --app=recordexpungpdxapi
-	heroku container:release web --app=recordexpungpdxapi
+	heroku container:push --recursive --app=recordexpungpdxapi || $(handle_error)
+	heroku container:release web --app=recordexpungpdxapi || $(handle_error)
 	rm -rf ./build
 
 frontend:
 	echo $@
 	mkdir ./build
-	cp -r ../config/nginx/* ./build
-	cp -r ../src/frontend ./build/frontend
+	cp -r ../config/nginx/ ./build/
+	rsync -a ../src/frontend/ ./build/frontend/ --exclude node_modules
 
-	heroku container:push --recursive --app=recordexpungpdx
-	heroku container:release web --app=recordexpungpdx
+	heroku container:push --recursive --app=recordexpungpdx || $(handle_error)
+	heroku container:release web --app=recordexpungpdx || $(handle_error)
 	rm -rf ./build
 
 db:

--- a/src/backend/expungeservice/Dockerfile.web
+++ b/src/backend/expungeservice/Dockerfile.web
@@ -1,10 +1,10 @@
 FROM recordexpungpdx/recordexpungpdx:expungeservicebase
 
 RUN mkdir -p /var/www/expungeservice
+RUN mkdir /var/www/logs/
 COPY . /var/www/expungeservice
 WORKDIR /var/www/expungeservice
-RUN python3.7 -m pip install -r requirements.txt && rm requirements.txt &&\
-    python3.7 -m setup install
+RUN pip3 install pipenv && pipenv install --system --deploy
 
 
 WORKDIR /var/www


### PR DESCRIPTION
This PR fixes a couple of issues on the recordexpungepdx heroku deployment:

- The `\api\` portion of the URL path was being dropped when requests were made to the backend. While the exact reason for this is still a mystery, the NGINX config file has been updated with a fix.
- The production Dockerfile for the backend was missing a needed directory, and using an outdated command to install dependencies.

The deployment Makefile has also been improved to speed up deployment times and handle errors better.