### PR TITLE
Restructure ExpungementResult to contain Type/TimeEligibility classes

### DIFF
--- a/doc/design.md
+++ b/doc/design.md
@@ -404,11 +404,22 @@ Data Model
  - ruling
 
 #### ExpungementResult:
- - type_eligibility
- - type_eligibility_reason
- - time_eligibility
- - time_eligibility_reason
- - date_of_eligibility
+ - type_eligibility :: type Optional[TypeEligibility]
+ - time_eligibility :: type Optional[TimeEligibility]
+
+#### TypeEligibility:
+ - status :: type EligibilityStatus
+ - reason :: type str
+
+#### TimeEligibility:
+ - status :: type bool
+ - reason :: type str
+ - date_will_be_eligible :: type Optional[date]
+
+#### EligibilityStatus: (Enum)
+ - ELIGIBLE
+ - NEEDS_MORE_ANALYSIS 
+ - INELIGIBLE
 
 
 Database Schema

--- a/src/backend/expungeservice/expunger/expunger.py
+++ b/src/backend/expungeservice/expunger/expunger.py
@@ -1,6 +1,7 @@
 from expungeservice.expunger.analyzers.time_analyzer import TimeAnalyzer
 from datetime import date as date_class
 from dateutil.relativedelta import relativedelta
+from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
 class Expunger:
@@ -73,10 +74,11 @@ class Expunger:
             if Expunger._dispositionless(charge) or charge.skip_analysis():
                 self._skipped_charges.append(charge)
 
+    # TODO: Rename as this method has side-effects
     @staticmethod
     def _dispositionless(charge):
         if charge.disposition is None:
-            charge.expungement_result.type_eligibility_reason = "Disposition not found. Needs further analysis"
+            charge.expungement_result.set_type_eligibility(TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason = "Disposition not found. Needs further analysis"))
             return True
 
     def _remove_skipped_charges(self):

--- a/src/backend/expungeservice/models/charge_types/base_charge.py
+++ b/src/backend/expungeservice/models/charge_types/base_charge.py
@@ -4,7 +4,8 @@ from datetime import datetime
 from datetime import date as date_class
 from dateutil.relativedelta import relativedelta
 from expungeservice.models.disposition import Disposition
-from expungeservice.models.expungement_result import ExpungementResult
+from expungeservice.models.expungement_result import ExpungementResult, \
+    TimeEligibility
 
 
 class BaseCharge:
@@ -15,7 +16,7 @@ class BaseCharge:
         self.level = level
         self.date = datetime.date(datetime.strptime(date, '%m/%d/%Y'))
         self.disposition = disposition
-        self.expungement_result = ExpungementResult()
+        self.expungement_result = ExpungementResult(type_eligibility=None, time_eligibility=None)
         self._chapter = chapter
         self._section = section
         self._case = weakref.ref(case)
@@ -44,11 +45,9 @@ class BaseCharge:
         return False
 
     def set_time_ineligible(self, reason, date_of_eligibility):
-        self.expungement_result.time_eligibility = False
-        self.expungement_result.time_eligibility_reason = reason
-        self.expungement_result.date_of_eligibility = date_of_eligibility
+        time_eligibility = TimeEligibility(status = False, reason = reason, date_will_be_eligible = date_of_eligibility)
+        self.expungement_result.time_eligibility = time_eligibility
 
     def set_time_eligible(self, reason=''):
-        self.expungement_result.time_eligibility = True
-        self.expungement_result.time_eligibility_reason = reason
-        self.expungement_result.date_of_eligibility = None
+        time_eligibility = TimeEligibility(status = True, reason = reason, date_will_be_eligible = None)
+        self.expungement_result.time_eligibility = time_eligibility

--- a/src/backend/expungeservice/models/charge_types/felony_class_a.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_a.py
@@ -1,4 +1,5 @@
 from expungeservice.models.charge_types.base_charge import BaseCharge
+from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
 class FelonyClassA(BaseCharge):
@@ -6,8 +7,8 @@ class FelonyClassA(BaseCharge):
     def __init__(self, **kwargs):
         super(FelonyClassA, self).__init__(**kwargs)
         if self.acquitted():
-            self.expungement_result.set_type_eligibility(True)
-            self.expungement_result.set_reason('Eligible under 137.225(1)(b)')
+            self.expungement_result.set_type_eligibility(
+                TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)'))
         else:
-            self.expungement_result.set_type_eligibility(False)
-            self.expungement_result.set_reason('Ineligible under 137.225(5)')
+            self.expungement_result.set_type_eligibility(
+                TypeEligibility(EligibilityStatus.INELIGIBLE, reason = 'Ineligible under 137.225(5)'))

--- a/src/backend/expungeservice/models/charge_types/felony_class_b.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_b.py
@@ -1,4 +1,5 @@
 from expungeservice.models.charge_types.base_charge import BaseCharge
+from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
 class FelonyClassB(BaseCharge):
@@ -6,7 +7,8 @@ class FelonyClassB(BaseCharge):
     def __init__(self, **kwargs):
         super(FelonyClassB, self).__init__(**kwargs)
         if self.acquitted():
-            self.expungement_result.set_type_eligibility(True)
-            self.expungement_result.set_reason('Eligible under 137.225(1)(b)')
+            self.expungement_result.set_type_eligibility(
+                TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)'))
         else:
-            self.expungement_result.set_reason('Further Analysis Needed')
+            self.expungement_result.set_type_eligibility(
+                TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason = 'Further Analysis Needed'))

--- a/src/backend/expungeservice/models/charge_types/felony_class_c.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_c.py
@@ -1,4 +1,5 @@
 from expungeservice.models.charge_types.base_charge import BaseCharge
+from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
 class FelonyClassC(BaseCharge):
@@ -6,8 +7,8 @@ class FelonyClassC(BaseCharge):
     def __init__(self, **kwargs):
         super(FelonyClassC, self).__init__(**kwargs)
         if self.acquitted():
-            self.expungement_result.set_type_eligibility(True)
-            self.expungement_result.set_reason('Eligible under 137.225(1)(b)')
+            self.expungement_result.set_type_eligibility(
+                TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)'))
         else:
-            self.expungement_result.set_type_eligibility(True)
-            self.expungement_result.set_reason('Eligible under 137.225(5)(b)')
+            self.expungement_result.set_type_eligibility(
+                TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(5)(b)'))

--- a/src/backend/expungeservice/models/charge_types/juvenile_charge.py
+++ b/src/backend/expungeservice/models/charge_types/juvenile_charge.py
@@ -1,12 +1,13 @@
 from expungeservice.models.charge_types.base_charge import BaseCharge
+from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
 class JuvenileCharge(BaseCharge):
 
     def __init__(self, **kwargs):
         super(JuvenileCharge, self).__init__(**kwargs)
-        self.expungement_result.set_type_eligibility(None)
-        self.expungement_result.set_reason('Juvenile Charge : Needs further analysis')
+        self.expungement_result.set_type_eligibility(
+            TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason = 'Juvenile Charge : Needs further analysis'))
 
     def skip_analysis(self):
         return True

--- a/src/backend/expungeservice/models/charge_types/level_800_traffic_crime.py
+++ b/src/backend/expungeservice/models/charge_types/level_800_traffic_crime.py
@@ -1,4 +1,5 @@
 from expungeservice.models.charge_types.base_charge import BaseCharge
+from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
 class Level800TrafficCrime(BaseCharge):
@@ -6,11 +7,11 @@ class Level800TrafficCrime(BaseCharge):
     def __init__(self, **kwargs):
         super(Level800TrafficCrime, self).__init__(**kwargs)
         if self._expungeable():
-            self.expungement_result.set_type_eligibility(True)
-            self.expungement_result.set_reason('Eligible under 137.225(1)(b)')
+            self.expungement_result.set_type_eligibility(
+                TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)'))
         else:
-            self.expungement_result.set_type_eligibility(False)
-            self.expungement_result.set_reason('Ineligible under 137.225(5)')
+            self.expungement_result.set_type_eligibility(
+                TypeEligibility(EligibilityStatus.INELIGIBLE, reason = 'Ineligible under 137.225(5)'))
 
     def skip_analysis(self):
         if self._affects_time_analysis():

--- a/src/backend/expungeservice/models/charge_types/list_b.py
+++ b/src/backend/expungeservice/models/charge_types/list_b.py
@@ -1,12 +1,11 @@
 from expungeservice.models.charge_types.base_charge import BaseCharge
-
+from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 class ListB(BaseCharge):
 
     def __init__(self, **kwargs):
         super(ListB, self).__init__(**kwargs)
         if self.acquitted():
-            self.expungement_result.set_type_eligibility(True)
-            self.expungement_result.set_reason('Eligible under 137.225(1)(b)')
+            self.expungement_result.set_type_eligibility(TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)'))
         else:
-            self.expungement_result.set_reason('Further Analysis Needed')
+            self.expungement_result.set_type_eligibility(TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason = 'Further Analysis Needed'))

--- a/src/backend/expungeservice/models/charge_types/marijuana_ineligible.py
+++ b/src/backend/expungeservice/models/charge_types/marijuana_ineligible.py
@@ -1,13 +1,11 @@
 from expungeservice.models.charge_types.base_charge import BaseCharge
-
+from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 class MarijuanaIneligible(BaseCharge):
 
     def __init__(self, **kwargs):
         super(MarijuanaIneligible, self).__init__(**kwargs)
         if self.acquitted():
-            self.expungement_result.set_type_eligibility(True)
-            self.expungement_result.set_reason('Eligible under 137.225(1)(b)')
+            self.expungement_result.set_type_eligibility(TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)'))
         else:
-            self.expungement_result.set_type_eligibility(False)
-            self.expungement_result.set_reason('Ineligible under 137.226')
+            self.expungement_result.set_type_eligibility(TypeEligibility(EligibilityStatus.INELIGIBLE, reason = 'Ineligible under 137.226'))

--- a/src/backend/expungeservice/models/charge_types/misdemeanor.py
+++ b/src/backend/expungeservice/models/charge_types/misdemeanor.py
@@ -1,13 +1,11 @@
 from expungeservice.models.charge_types.base_charge import BaseCharge
-
+from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 class Misdemeanor(BaseCharge):
 
     def __init__(self, **kwargs):
         super(Misdemeanor, self).__init__(**kwargs)
         if self.acquitted():
-            self.expungement_result.set_type_eligibility(True)
-            self.expungement_result.set_reason('Eligible under 137.225(1)(b)')
+            self.expungement_result.set_type_eligibility(TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)'))
         else:
-            self.expungement_result.set_type_eligibility(True)
-            self.expungement_result.set_reason('Eligible under 137.225(5)(b)')
+            self.expungement_result.set_type_eligibility(TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(5)(b)'))

--- a/src/backend/expungeservice/models/charge_types/non_traffic_violation.py
+++ b/src/backend/expungeservice/models/charge_types/non_traffic_violation.py
@@ -1,4 +1,5 @@
 from expungeservice.models.charge_types.base_charge import BaseCharge
+from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
 class NonTrafficViolation(BaseCharge):
@@ -6,8 +7,6 @@ class NonTrafficViolation(BaseCharge):
     def __init__(self, **kwargs):
         super(NonTrafficViolation, self).__init__(**kwargs)
         if self.acquitted():
-            self.expungement_result.set_type_eligibility(True)
-            self.expungement_result.set_reason('Eligible under 137.225(1)(b)')
+            self.expungement_result.set_type_eligibility(TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)'))
         else:
-            self.expungement_result.set_type_eligibility(True)
-            self.expungement_result.set_reason('Eligible under 137.225(5)(d)')
+            self.expungement_result.set_type_eligibility(TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(5)(d)'))

--- a/src/backend/expungeservice/models/charge_types/parking_ticket.py
+++ b/src/backend/expungeservice/models/charge_types/parking_ticket.py
@@ -1,12 +1,12 @@
 from expungeservice.models.charge_types.base_charge import BaseCharge
+from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
 class ParkingTicket(BaseCharge):
 
     def __init__(self, **kwargs):
         super(ParkingTicket, self).__init__(**kwargs)
-        self.expungement_result.set_type_eligibility(False)
-        self.expungement_result.set_reason('Ineligible under 137.225(5)')
+        self.expungement_result.set_type_eligibility(TypeEligibility(EligibilityStatus.INELIGIBLE, reason = 'Ineligible under 137.225(5)'))
 
     def skip_analysis(self):
         return True

--- a/src/backend/expungeservice/models/charge_types/person_crime.py
+++ b/src/backend/expungeservice/models/charge_types/person_crime.py
@@ -1,4 +1,5 @@
 from expungeservice.models.charge_types.base_charge import BaseCharge
+from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
 class PersonCrime(BaseCharge):
@@ -6,8 +7,6 @@ class PersonCrime(BaseCharge):
     def __init__(self, **kwargs):
         super(PersonCrime, self).__init__(**kwargs)
         if self.acquitted():
-            self.expungement_result.set_type_eligibility(True)
-            self.expungement_result.set_reason('Eligible under 137.225(1)(b)')
+            self.expungement_result.set_type_eligibility(TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)'))
         else:
-            self.expungement_result.set_type_eligibility(False)
-            self.expungement_result.set_reason('Ineligible under 137.225(5)')
+            self.expungement_result.set_type_eligibility(TypeEligibility(EligibilityStatus.INELIGIBLE, reason = 'Ineligible under 137.225(5)'))

--- a/src/backend/expungeservice/models/charge_types/schedule_1_p_c_s.py
+++ b/src/backend/expungeservice/models/charge_types/schedule_1_p_c_s.py
@@ -1,13 +1,11 @@
 from expungeservice.models.charge_types.base_charge import BaseCharge
-
+from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 class Schedule1PCS(BaseCharge):
 
     def __init__(self, **kwargs):
         super(Schedule1PCS, self).__init__(**kwargs)
         if self.acquitted():
-            self.expungement_result.set_type_eligibility(True)
-            self.expungement_result.set_reason('Eligible under 137.225(1)(b)')
+            self.expungement_result.set_type_eligibility(TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)'))
         else:
-            self.expungement_result.set_type_eligibility(True)
-            self.expungement_result.set_reason('Eligible under 137.225(5)(C)')
+            self.expungement_result.set_type_eligibility(TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(5)(C)'))

--- a/src/backend/expungeservice/models/charge_types/unclassified_charge.py
+++ b/src/backend/expungeservice/models/charge_types/unclassified_charge.py
@@ -1,12 +1,11 @@
 from expungeservice.models.charge_types.base_charge import BaseCharge
-
+from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 class UnclassifiedCharge(BaseCharge):
 
     def __init__(self, **kwargs):
         super(UnclassifiedCharge, self).__init__(**kwargs)
         if self.acquitted():
-            self.expungement_result.set_type_eligibility(True)
-            self.expungement_result.set_reason('Eligible under 137.225(1)(b)')
+            self.expungement_result.set_type_eligibility(TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)'))
         else:
-            self.expungement_result.set_reason('Examine')
+            self.expungement_result.set_type_eligibility(TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason = 'Examine'))

--- a/src/backend/expungeservice/models/expungement_result.py
+++ b/src/backend/expungeservice/models/expungement_result.py
@@ -1,14 +1,29 @@
-class ExpungementResult:
+from dataclasses import dataclass
+from datetime import date
+from enum import Enum
+from typing import Optional
 
-    def __init__(self):
-        self.type_eligibility = None
-        self.type_eligibility_reason = ''
-        self.time_eligibility = None
-        self.time_eligibility_reason = ''
-        self.date_of_eligibility = None
+
+class EligibilityStatus(str, Enum):
+    ELIGIBLE = "Eligible"
+    NEEDS_MORE_ANALYSIS = "Needs more analysis"
+    INELIGIBLE = "Ineligible"
+
+@dataclass
+class TypeEligibility:
+    status: EligibilityStatus
+    reason: str
+
+@dataclass
+class TimeEligibility:
+    status: bool
+    reason: str
+    date_will_be_eligible: Optional[date]
+
+@dataclass
+class ExpungementResult:
+    type_eligibility: Optional[TypeEligibility]
+    time_eligibility: Optional[TimeEligibility]
 
     def set_type_eligibility(self, type_eligibility):
         self.type_eligibility = type_eligibility
-
-    def set_reason(self, reason):
-        self.type_eligibility_reason = reason

--- a/src/backend/expungeservice/serializer/serializer.py
+++ b/src/backend/expungeservice/serializer/serializer.py
@@ -1,5 +1,6 @@
 import flask
 import expungeservice
+from expungeservice.models.expungement_result import EligibilityStatus
 
 
 class ExpungeModelEncoder(flask.json.JSONEncoder):
@@ -44,12 +45,38 @@ class ExpungeModelEncoder(flask.json.JSONEncoder):
         }
 
     def expungement_result_to_json(self, expungement_result):
+        # Note this logic is just to ensure that there has been no functional changes
+        # from the perspective of the front-end that uses this serializer since last commit.
+        #
+        # TODO: Redesign how expungement result is exposed.
+        if expungement_result.type_eligibility:
+            type_eligibility = expungement_result.type_eligibility
+            if type_eligibility.status == EligibilityStatus.ELIGIBLE:
+                type_eligibility_status = True
+            elif type_eligibility.status == EligibilityStatus.INELIGIBLE:
+                type_eligibility_status = False
+            elif type_eligibility.status == EligibilityStatus.NEEDS_MORE_ANALYSIS:
+                type_eligibility_status = None
+            else:
+                raise Exception('Impossible value for EligibilityStatus enum.')
+            type_eligibility_reason = type_eligibility.reason
+        else:
+            type_eligibility_status = None
+            type_eligibility_reason = ''
+        if expungement_result.time_eligibility:
+            time_eligibility_status = expungement_result.time_eligibility.status
+            time_eligibility_reason = expungement_result.time_eligibility.reason
+            date_of_eligibility = expungement_result.time_eligibility.date_will_be_eligible
+        else:
+            time_eligibility_status = None
+            time_eligibility_reason = ''
+            date_of_eligibility = None
         return {
-            "type_eligibility": expungement_result.type_eligibility,
-            "type_eligibility_reason": expungement_result.type_eligibility_reason,
-            "time_eligibility": expungement_result.time_eligibility,
-            "time_eligibility_reason": expungement_result.time_eligibility,
-            "date_of_eligibility": expungement_result.date_of_eligibility
+            "type_eligibility": type_eligibility_status,
+            "type_eligibility_reason": type_eligibility_reason,
+            "time_eligibility": time_eligibility_status,
+            "time_eligibility_reason": time_eligibility_reason,
+            "date_of_eligibility": date_of_eligibility
         }
 
     def default(self, o):

--- a/src/backend/tests/expunger/test_expunger.py
+++ b/src/backend/tests/expunger/test_expunger.py
@@ -90,7 +90,7 @@ class TestDispositionlessCharge(unittest.TestCase):
 
         expunger.run()
 
-        assert charge.expungement_result.type_eligibility_reason == "Disposition not found. Needs further analysis"
+        assert charge.expungement_result.type_eligibility.reason == "Disposition not found. Needs further analysis"
 
 
 class TestMostRecentConviction(unittest.TestCase):

--- a/src/backend/tests/expunger/test_time_analyzer.py
+++ b/src/backend/tests/expunger/test_time_analyzer.py
@@ -22,9 +22,9 @@ class TestSingleChargeAcquittals(unittest.TestCase):
         self.expunger.charges = [charge]
         TimeAnalyzer.evaluate(self.expunger)
 
-        assert charge.expungement_result.time_eligibility is True
-        assert charge.expungement_result.time_eligibility_reason == ''
-        assert charge.expungement_result.date_of_eligibility is None
+        assert charge.expungement_result.time_eligibility.status is True
+        assert charge.expungement_result.time_eligibility.reason == ''
+        assert charge.expungement_result.time_eligibility.date_will_be_eligible is None
 
     def test_10_yr_old_conviction_with_3_yr_old_mrc(self):
         ten_yr_charge = ChargeFactory.create(disposition=['Convicted', Time.TEN_YEARS_AGO])
@@ -34,13 +34,13 @@ class TestSingleChargeAcquittals(unittest.TestCase):
         self.expunger.charges = [ten_yr_charge, three_yr_mrc]
         TimeAnalyzer.evaluate(self.expunger)
 
-        assert ten_yr_charge.expungement_result.time_eligibility is False
-        assert ten_yr_charge.expungement_result.time_eligibility_reason == 'Time-ineligible under 137.225(7)(b)'
-        assert ten_yr_charge.expungement_result.date_of_eligibility == three_yr_mrc.disposition.date + Time.TEN_YEARS
+        assert ten_yr_charge.expungement_result.time_eligibility.status is False
+        assert ten_yr_charge.expungement_result.time_eligibility.reason == 'Time-ineligible under 137.225(7)(b)'
+        assert ten_yr_charge.expungement_result.time_eligibility.date_will_be_eligible == three_yr_mrc.disposition.date + Time.TEN_YEARS
 
-        assert three_yr_mrc.expungement_result.time_eligibility is True
-        assert three_yr_mrc.expungement_result.time_eligibility_reason == ''
-        assert three_yr_mrc.expungement_result.date_of_eligibility is None
+        assert three_yr_mrc.expungement_result.time_eligibility.status is True
+        assert three_yr_mrc.expungement_result.time_eligibility.reason == ''
+        assert three_yr_mrc.expungement_result.time_eligibility.date_will_be_eligible is None
 
     def test_10_yr_old_conviction_with_less_than_3_yr_old_mrc(self):
         ten_yr_charge = ChargeFactory.create(disposition=['Convicted', Time.TEN_YEARS_AGO])
@@ -50,13 +50,13 @@ class TestSingleChargeAcquittals(unittest.TestCase):
         self.expunger.charges = [ten_yr_charge, less_than_three_yr_mrc]
         TimeAnalyzer.evaluate(self.expunger)
 
-        assert ten_yr_charge.expungement_result.time_eligibility is False
-        assert ten_yr_charge.expungement_result.time_eligibility_reason == 'Time-ineligible under 137.225(7)(b)'
-        assert ten_yr_charge.expungement_result.date_of_eligibility == less_than_three_yr_mrc.disposition.date + Time.TEN_YEARS
+        assert ten_yr_charge.expungement_result.time_eligibility.status is False
+        assert ten_yr_charge.expungement_result.time_eligibility.reason == 'Time-ineligible under 137.225(7)(b)'
+        assert ten_yr_charge.expungement_result.time_eligibility.date_will_be_eligible == less_than_three_yr_mrc.disposition.date + Time.TEN_YEARS
 
-        assert less_than_three_yr_mrc.expungement_result.time_eligibility is False
-        assert less_than_three_yr_mrc.expungement_result.time_eligibility_reason == 'Most recent conviction is less than three years old'
-        assert less_than_three_yr_mrc.expungement_result.date_of_eligibility == date.today() + relativedelta(days=+1)
+        assert less_than_three_yr_mrc.expungement_result.time_eligibility.status is False
+        assert less_than_three_yr_mrc.expungement_result.time_eligibility.reason == 'Most recent conviction is less than three years old'
+        assert less_than_three_yr_mrc.expungement_result.time_eligibility.date_will_be_eligible == date.today() + relativedelta(days=+1)
 
     def test_more_than_three_year_rule_conviction(self):
         charge = ChargeFactory.create(disposition=['Convicted', Time.THREE_YEARS_AGO])
@@ -65,9 +65,9 @@ class TestSingleChargeAcquittals(unittest.TestCase):
         self.expunger.charges = [charge]
         TimeAnalyzer.evaluate(self.expunger)
 
-        assert charge.expungement_result.time_eligibility is True
-        assert charge.expungement_result.time_eligibility_reason == ''
-        assert charge.expungement_result.date_of_eligibility is None
+        assert charge.expungement_result.time_eligibility.status is True
+        assert charge.expungement_result.time_eligibility.reason == ''
+        assert charge.expungement_result.time_eligibility.date_will_be_eligible is None
 
     def test_less_than_three_year_rule_conviction(self):
         charge = ChargeFactory.create(disposition=['Convicted', Time.LESS_THAN_THREE_YEARS_AGO])
@@ -76,9 +76,9 @@ class TestSingleChargeAcquittals(unittest.TestCase):
         self.expunger.charges = [charge]
         TimeAnalyzer.evaluate(self.expunger)
 
-        assert charge.expungement_result.time_eligibility is False
-        assert charge.expungement_result.time_eligibility_reason == 'Most recent conviction is less than three years old'
-        assert charge.expungement_result.date_of_eligibility == date.today() + relativedelta(days=+1)
+        assert charge.expungement_result.time_eligibility.status is False
+        assert charge.expungement_result.time_eligibility.reason == 'Most recent conviction is less than three years old'
+        assert charge.expungement_result.time_eligibility.date_will_be_eligible == date.today() + relativedelta(days=+1)
 
     def test_felony_class_b_greater_than_20yrs(self):
         charge = ChargeFactory.create(name='Aggravated theft in the first degree',
@@ -93,9 +93,9 @@ class TestSingleChargeAcquittals(unittest.TestCase):
         self.expunger.charges = [charge]
         TimeAnalyzer.evaluate(self.expunger)
 
-        assert charge.expungement_result.time_eligibility is True
-        assert charge.expungement_result.time_eligibility_reason == ''
-        assert charge.expungement_result.date_of_eligibility is None
+        assert charge.expungement_result.time_eligibility.status is True
+        assert charge.expungement_result.time_eligibility.reason == ''
+        assert charge.expungement_result.time_eligibility.date_will_be_eligible is None
 
     def test_felony_class_b_less_than_20yrs(self):
         charge = ChargeFactory.create(name='Aggravated theft in the first degree',
@@ -110,9 +110,9 @@ class TestSingleChargeAcquittals(unittest.TestCase):
         self.expunger.charges = [charge]
         TimeAnalyzer.evaluate(self.expunger)
 
-        assert charge.expungement_result.time_eligibility is False
-        assert charge.expungement_result.time_eligibility_reason == 'Time-ineligible under 137.225(5)(a)(A)(i)'
-        assert charge.expungement_result.date_of_eligibility == Time.TOMORROW
+        assert charge.expungement_result.time_eligibility.status is False
+        assert charge.expungement_result.time_eligibility.reason == 'Time-ineligible under 137.225(5)(a)(A)(i)'
+        assert charge.expungement_result.time_eligibility.date_will_be_eligible == Time.TOMORROW
 
 
 class TestDismissalBlock(unittest.TestCase):
@@ -129,9 +129,9 @@ class TestDismissalBlock(unittest.TestCase):
         expunger = Expunger(record)
         expunger.run()
 
-        assert self.recent_dismissal.expungement_result.time_eligibility is True
-        assert self.recent_dismissal.expungement_result.time_eligibility_reason == ''
-        assert self.recent_dismissal.expungement_result.date_of_eligibility is None
+        assert self.recent_dismissal.expungement_result.time_eligibility.status is True
+        assert self.recent_dismissal.expungement_result.time_eligibility.reason == ''
+        assert self.recent_dismissal.expungement_result.time_eligibility.date_will_be_eligible is None
 
     def test_all_mrd_case_related_dismissals_are_expungeable(self):
         case_related_dismissal = ChargeFactory.create_dismissed_charge(case=self.case_1, date=Time.TWO_YEARS_AGO)
@@ -141,13 +141,13 @@ class TestDismissalBlock(unittest.TestCase):
         expunger = Expunger(record)
         expunger.run()
 
-        assert self.recent_dismissal.expungement_result.time_eligibility is True
-        assert self.recent_dismissal.expungement_result.time_eligibility_reason == ''
-        assert self.recent_dismissal.expungement_result.date_of_eligibility is None
+        assert self.recent_dismissal.expungement_result.time_eligibility.status is True
+        assert self.recent_dismissal.expungement_result.time_eligibility.reason == ''
+        assert self.recent_dismissal.expungement_result.time_eligibility.date_will_be_eligible is None
 
-        assert case_related_dismissal.expungement_result.time_eligibility is True
-        assert case_related_dismissal.expungement_result.time_eligibility_reason == ''
-        assert case_related_dismissal.expungement_result.date_of_eligibility is None
+        assert case_related_dismissal.expungement_result.time_eligibility.status is True
+        assert case_related_dismissal.expungement_result.time_eligibility.reason == ''
+        assert case_related_dismissal.expungement_result.time_eligibility.date_will_be_eligible is None
 
     def test_mrd_blocks_dismissals_in_unrelated_cases(self):
         unrelated_dismissal = ChargeFactory.create_dismissed_charge(case=self.case_2, date=Time.TEN_YEARS_AGO)
@@ -157,9 +157,9 @@ class TestDismissalBlock(unittest.TestCase):
         expunger = Expunger(record)
         expunger.run()
 
-        assert unrelated_dismissal.expungement_result.time_eligibility is False
-        assert unrelated_dismissal.expungement_result.time_eligibility_reason == 'Recommend sequential expungement'
-        assert unrelated_dismissal.expungement_result.date_of_eligibility == Time.ONE_YEARS_FROM_NOW
+        assert unrelated_dismissal.expungement_result.time_eligibility.status is False
+        assert unrelated_dismissal.expungement_result.time_eligibility.reason == 'Recommend sequential expungement'
+        assert unrelated_dismissal.expungement_result.time_eligibility.date_will_be_eligible == Time.ONE_YEARS_FROM_NOW
 
     def test_mrd_does_not_block_convictions(self):
         case = CaseFactory.create()
@@ -170,9 +170,9 @@ class TestDismissalBlock(unittest.TestCase):
         expunger = Expunger(record)
         expunger.run()
 
-        assert convicted_charge.expungement_result.time_eligibility is True
-        assert convicted_charge.expungement_result.time_eligibility_reason == ''
-        assert convicted_charge.expungement_result.date_of_eligibility is None
+        assert convicted_charge.expungement_result.time_eligibility.status is True
+        assert convicted_charge.expungement_result.time_eligibility.reason == ''
+        assert convicted_charge.expungement_result.time_eligibility.date_will_be_eligible is None
 
 
 class TestSecondMRCLogic(unittest.TestCase):
@@ -192,13 +192,13 @@ class TestSecondMRCLogic(unittest.TestCase):
 
         self.run_expunger(two_years_ago_charge, three_years_ago_charge)
 
-        assert three_years_ago_charge.expungement_result.time_eligibility is False
-        assert three_years_ago_charge.expungement_result.time_eligibility_reason == 'Time-ineligible under 137.225(7)(b)'
-        assert three_years_ago_charge.expungement_result.date_of_eligibility == two_years_ago_charge.disposition.date + Time.TEN_YEARS
+        assert three_years_ago_charge.expungement_result.time_eligibility.status is False
+        assert three_years_ago_charge.expungement_result.time_eligibility.reason == 'Time-ineligible under 137.225(7)(b)'
+        assert three_years_ago_charge.expungement_result.time_eligibility.date_will_be_eligible == two_years_ago_charge.disposition.date + Time.TEN_YEARS
 
-        assert two_years_ago_charge.expungement_result.time_eligibility is False
-        assert two_years_ago_charge.expungement_result.time_eligibility_reason == 'Multiple convictions within last ten years'
-        assert two_years_ago_charge.expungement_result.date_of_eligibility == three_years_ago_charge.disposition.date + Time.TEN_YEARS
+        assert two_years_ago_charge.expungement_result.time_eligibility.status is False
+        assert two_years_ago_charge.expungement_result.time_eligibility.reason == 'Multiple convictions within last ten years'
+        assert two_years_ago_charge.expungement_result.time_eligibility.date_will_be_eligible == three_years_ago_charge.disposition.date + Time.TEN_YEARS
 
     def test_7_yr_old_conviction_5_yr_old_mrc(self):
         seven_year_ago_charge = ChargeFactory.create(disposition=['Convicted', Time.SEVEN_YEARS_AGO])
@@ -206,13 +206,13 @@ class TestSecondMRCLogic(unittest.TestCase):
 
         self.run_expunger(five_year_ago_charge, seven_year_ago_charge)
 
-        assert seven_year_ago_charge.expungement_result.time_eligibility is False
-        assert seven_year_ago_charge.expungement_result.time_eligibility_reason == 'Time-ineligible under 137.225(7)(b)'
-        assert seven_year_ago_charge.expungement_result.date_of_eligibility == five_year_ago_charge.disposition.date + Time.TEN_YEARS
+        assert seven_year_ago_charge.expungement_result.time_eligibility.status is False
+        assert seven_year_ago_charge.expungement_result.time_eligibility.reason == 'Time-ineligible under 137.225(7)(b)'
+        assert seven_year_ago_charge.expungement_result.time_eligibility.date_will_be_eligible == five_year_ago_charge.disposition.date + Time.TEN_YEARS
 
-        assert five_year_ago_charge.expungement_result.time_eligibility is False
-        assert five_year_ago_charge.expungement_result.time_eligibility_reason == 'Multiple convictions within last ten years'
-        assert five_year_ago_charge.expungement_result.date_of_eligibility == seven_year_ago_charge.disposition.date + Time.TEN_YEARS
+        assert five_year_ago_charge.expungement_result.time_eligibility.status is False
+        assert five_year_ago_charge.expungement_result.time_eligibility.reason == 'Multiple convictions within last ten years'
+        assert five_year_ago_charge.expungement_result.time_eligibility.date_will_be_eligible == seven_year_ago_charge.disposition.date + Time.TEN_YEARS
 
     def test_mrc_is_eligible_in_two_years(self):
         nine_year_old_conviction = ChargeFactory.create(disposition=['Convicted', Time.NINE_YEARS_AGO])
@@ -221,4 +221,4 @@ class TestSecondMRCLogic(unittest.TestCase):
 
         self.run_expunger(one_year_old_conviction, nine_year_old_conviction)
 
-        assert one_year_old_conviction.expungement_result.date_of_eligibility == eligibility_date
+        assert one_year_old_conviction.expungement_result.time_eligibility.date_will_be_eligible == eligibility_date

--- a/src/backend/tests/functional_tests/test_crawler_expunger.py
+++ b/src/backend/tests/functional_tests/test_crawler_expunger.py
@@ -88,14 +88,14 @@ class TestCrawlerAndExpunger(unittest.TestCase):
         assert expunger.most_recent_dismissal.disposition.ruling == 'No Complaint'
         assert len(expunger.acquittals) == 8
 
-        assert record.cases[0].charges[0].expungement_result.time_eligibility is False
-        assert record.cases[0].charges[1].expungement_result.time_eligibility is True
-        assert record.cases[0].charges[2].expungement_result.time_eligibility is False
+        assert record.cases[0].charges[0].expungement_result.time_eligibility.status is False
+        assert record.cases[0].charges[1].expungement_result.time_eligibility.status is True
+        assert record.cases[0].charges[2].expungement_result.time_eligibility.status is False
 
-        assert record.cases[1].charges[0].expungement_result.time_eligibility is False
-        assert record.cases[1].charges[1].expungement_result.time_eligibility is False
-        assert record.cases[1].charges[2].expungement_result.time_eligibility is False
+        assert record.cases[1].charges[0].expungement_result.time_eligibility.status is False
+        assert record.cases[1].charges[1].expungement_result.time_eligibility.status is False
+        assert record.cases[1].charges[2].expungement_result.time_eligibility.status is False
 
-        assert record.cases[2].charges[0].expungement_result.time_eligibility is True
-        assert record.cases[2].charges[1].expungement_result.time_eligibility is True
-        assert record.cases[2].charges[2].expungement_result.time_eligibility is True
+        assert record.cases[2].charges[0].expungement_result.time_eligibility.status is True
+        assert record.cases[2].charges[1].expungement_result.time_eligibility.status is True
+        assert record.cases[2].charges[2].expungement_result.time_eligibility.status is True

--- a/src/backend/tests/models/charge_types/test_juvenile_charge.py
+++ b/src/backend/tests/models/charge_types/test_juvenile_charge.py
@@ -1,5 +1,7 @@
 import unittest
 
+from expungeservice.models.expungement_result import EligibilityStatus
+
 from tests.factories.case_factory import CaseFactory
 from tests.factories.charge_factory import ChargeFactory
 
@@ -11,5 +13,5 @@ class TestJuvenileCharge(unittest.TestCase):
         juvenile_charge = ChargeFactory.create(case=case)
 
         assert juvenile_charge.__class__.__name__ == 'JuvenileCharge'
-        assert juvenile_charge.expungement_result.type_eligibility is None
-        assert juvenile_charge.expungement_result.type_eligibility_reason == 'Juvenile Charge : Needs further analysis'
+        assert juvenile_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert juvenile_charge.expungement_result.type_eligibility.reason == 'Juvenile Charge : Needs further analysis'

--- a/src/backend/tests/models/charge_types/test_level_800_traffic_crime.py
+++ b/src/backend/tests/models/charge_types/test_level_800_traffic_crime.py
@@ -12,6 +12,9 @@ Rules for 800 Level charges are as follows:
 import unittest
 
 from datetime import datetime, timedelta
+
+from expungeservice.models.expungement_result import EligibilityStatus
+
 from tests.factories.charge_factory import ChargeFactory
 from expungeservice.models.disposition import Disposition
 
@@ -57,26 +60,26 @@ class TestLevel800MisdemeanorFelonyEligibility(unittest.TestCase):
     def test_misdemeanor_conviction_is_not_eligible(self):
         charge = ChargeFactory.create(statute='813.010(4)', level='Misdemeanor Class A', disposition=self.convicted)
 
-        assert charge.expungement_result.type_eligibility is False
-        assert charge.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+        assert charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert charge.expungement_result.type_eligibility.reason == 'Ineligible under 137.225(5)'
 
     def test_misdemeanor_dismissal_is_eligible(self):
         charge = ChargeFactory.create(statute='813.010(4)', level='Misdemeanor Class A', disposition=self.dismissed)
 
-        assert charge.expungement_result.type_eligibility is True
-        assert charge.expungement_result.type_eligibility_reason == 'Eligible under 137.225(1)(b)'
+        assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+        assert charge.expungement_result.type_eligibility.reason == 'Eligible under 137.225(1)(b)'
 
     def test_felony_conviction_is_not_eligible(self):
         charge = ChargeFactory.create(statute='819.300', level='Felony Class C', disposition=self.convicted)
 
-        assert charge.expungement_result.type_eligibility is False
-        assert charge.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+        assert charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert charge.expungement_result.type_eligibility.reason == 'Ineligible under 137.225(5)'
 
     def test_felony_dismissal_is_eligible(self):
         charge = ChargeFactory.create(statute='819.300', level='Felony Class C', disposition=self.dismissed)
 
-        assert charge.expungement_result.type_eligibility is True
-        assert charge.expungement_result.type_eligibility_reason == 'Eligible under 137.225(1)(b)'
+        assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+        assert charge.expungement_result.type_eligibility.reason == 'Eligible under 137.225(1)(b)'
 
 
 class TestLevel800ViolationsInfractionsAreNotTypeEligible(unittest.TestCase):
@@ -89,26 +92,26 @@ class TestLevel800ViolationsInfractionsAreNotTypeEligible(unittest.TestCase):
     def test_convicted_violation_is_not_type_eligible(self):
         charge = ChargeFactory.create(statute='801.000', level='Class C Traffic Violation', disposition=self.convicted)
 
-        assert charge.expungement_result.type_eligibility is False
-        assert charge.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+        assert charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert charge.expungement_result.type_eligibility.reason == 'Ineligible under 137.225(5)'
 
     def test_dismissed_violation_is_not_type_eligible(self):
         charge = ChargeFactory.create(statute='801.000', level='Class C Traffic Violation', disposition=self.dismissed)
 
-        assert charge.expungement_result.type_eligibility is False
-        assert charge.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+        assert charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert charge.expungement_result.type_eligibility.reason == 'Ineligible under 137.225(5)'
 
     def test_convicted_infraction_is_not_type_eligible(self):
         charge = ChargeFactory.create(statute='811135', level='Infraction Class B', disposition=self.convicted)
 
-        assert charge.expungement_result.type_eligibility is False
-        assert charge.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+        assert charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert charge.expungement_result.type_eligibility.reason == 'Ineligible under 137.225(5)'
 
     def test_dismissed_infraction_is_not_type_eligible(self):
         charge = ChargeFactory.create(statute='811135', level='Infraction Class B', disposition=self.dismissed)
 
-        assert charge.expungement_result.type_eligibility is False
-        assert charge.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+        assert charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert charge.expungement_result.type_eligibility.reason == 'Ineligible under 137.225(5)'
 
 
 class TestViolationsInfractionsSkipAnalysis(unittest.TestCase):

--- a/src/backend/tests/models/charge_types/test_parking_ticket.py
+++ b/src/backend/tests/models/charge_types/test_parking_ticket.py
@@ -1,5 +1,7 @@
 import unittest
 
+from expungeservice.models.expungement_result import EligibilityStatus
+
 from tests.factories.charge_factory import ChargeFactory
 
 
@@ -14,8 +16,8 @@ class TestParkingTicket(unittest.TestCase):
     def test_parking_violation(self):
         self.build()
 
-        assert self.parking_ticket.expungement_result.type_eligibility is False
-        assert self.parking_ticket.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+        assert self.parking_ticket.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert self.parking_ticket.expungement_result.type_eligibility.reason == 'Ineligible under 137.225(5)'
 
     def test_parking_tickets_skip_analysis(self):
         self.build()
@@ -27,4 +29,4 @@ class TestParkingTicket(unittest.TestCase):
 
         self.parking_ticket.disposition.ruling = 'Dismissed'
 
-        assert self.parking_ticket.expungement_result.type_eligibility is False
+        assert self.parking_ticket.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE

--- a/src/backend/tests/models/charge_types/test_type_analyzer_acquitted_charges.py
+++ b/src/backend/tests/models/charge_types/test_type_analyzer_acquitted_charges.py
@@ -1,6 +1,9 @@
 import unittest
 
 from datetime import datetime, timedelta
+
+from expungeservice.models.expungement_result import EligibilityStatus
+
 from tests.factories.charge_factory import ChargeFactory
 from expungeservice.models.disposition import Disposition
 
@@ -23,8 +26,8 @@ class TestSingleChargeAcquittals(unittest.TestCase):
         felony_class_a_acquitted = self.create_recent_charge()
         self.charges.append(felony_class_a_acquitted)
 
-        assert felony_class_a_acquitted.expungement_result.type_eligibility is True
-        assert felony_class_a_acquitted.expungement_result.type_eligibility_reason == 'Eligible under 137.225(1)(b)'
+        assert felony_class_a_acquitted.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+        assert felony_class_a_acquitted.expungement_result.type_eligibility.reason == 'Eligible under 137.225(1)(b)'
 
 
 class TestSingleChargeDismissals(unittest.TestCase):
@@ -45,8 +48,8 @@ class TestSingleChargeDismissals(unittest.TestCase):
         felony_class_a_dismissed = self.create_recent_charge()
         self.charges.append(felony_class_a_dismissed)
 
-        assert felony_class_a_dismissed.expungement_result.type_eligibility is True
-        assert felony_class_a_dismissed.expungement_result.type_eligibility_reason == 'Eligible under 137.225(1)(b)'
+        assert felony_class_a_dismissed.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+        assert felony_class_a_dismissed.expungement_result.type_eligibility.reason == 'Eligible under 137.225(1)(b)'
 
 
 class TestSingleChargeNoComplaint(unittest.TestCase):
@@ -67,5 +70,5 @@ class TestSingleChargeNoComplaint(unittest.TestCase):
         felony_class_a_no_complaint = self.create_recent_charge()
         self.charges.append(felony_class_a_no_complaint)
 
-        assert felony_class_a_no_complaint.expungement_result.type_eligibility is True
-        assert felony_class_a_no_complaint.expungement_result.type_eligibility_reason == 'Eligible under 137.225(1)(b)'
+        assert felony_class_a_no_complaint.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+        assert felony_class_a_no_complaint.expungement_result.type_eligibility.reason == 'Eligible under 137.225(1)(b)'

--- a/src/backend/tests/models/charge_types/test_type_analyzer_convicted_charges.py
+++ b/src/backend/tests/models/charge_types/test_type_analyzer_convicted_charges.py
@@ -1,6 +1,9 @@
 import unittest
 
 from datetime import datetime, timedelta
+
+from expungeservice.models.expungement_result import EligibilityStatus
+
 from tests.factories.charge_factory import ChargeFactory
 from expungeservice.models.disposition import Disposition
 
@@ -23,8 +26,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         felony_class_a_convicted = self.create_recent_charge()
         self.charges.append(felony_class_a_convicted)
 
-        assert felony_class_a_convicted.expungement_result.type_eligibility is False
-        assert felony_class_a_convicted.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+        assert felony_class_a_convicted.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert felony_class_a_convicted.expungement_result.type_eligibility.reason == 'Ineligible under 137.225(5)'
 
     def test_misdemeanor_sex_crime(self):
         self.single_charge['name'] = 'Sexual Abuse in the Third Degree'
@@ -33,72 +36,72 @@ class TestSingleChargeConvictions(unittest.TestCase):
         misdemeanor_class_a_convicted = self.create_recent_charge()
         self.charges.append(misdemeanor_class_a_convicted)
 
-        assert misdemeanor_class_a_convicted.expungement_result.type_eligibility is False
-        assert misdemeanor_class_a_convicted.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+        assert misdemeanor_class_a_convicted.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert misdemeanor_class_a_convicted.expungement_result.type_eligibility.reason == 'Ineligible under 137.225(5)'
 
     def test_min_statute_range_for_crimes_against_persons(self):
         self.single_charge['statute'] = '163.305'
         convicted_charge = self.create_recent_charge()
         self.charges.append(convicted_charge)
 
-        assert convicted_charge.expungement_result.type_eligibility is False
-        assert convicted_charge.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+        assert convicted_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert convicted_charge.expungement_result.type_eligibility.reason == 'Ineligible under 137.225(5)'
 
     def test_max_statute_range_for_crimes_against_persons(self):
         self.single_charge['statute'] = '163.479'
         convicted_charge = self.create_recent_charge()
         self.charges.append(convicted_charge)
 
-        assert convicted_charge.expungement_result.type_eligibility is False
-        assert convicted_charge.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+        assert convicted_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert convicted_charge.expungement_result.type_eligibility.reason == 'Ineligible under 137.225(5)'
 
     def test_min_statute_range_for_other_crimes_against_persons(self):
         self.single_charge['statute'] = '163.670'
         convicted_charge = self.create_recent_charge()
         self.charges.append(convicted_charge)
 
-        assert convicted_charge.expungement_result.type_eligibility is False
-        assert convicted_charge.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+        assert convicted_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert convicted_charge.expungement_result.type_eligibility.reason == 'Ineligible under 137.225(5)'
 
     def test_max_statute_range_for_other_crimes_against_persons(self):
         self.single_charge['statute'] = '163.693'
         convicted_charge = self.create_recent_charge()
         self.charges.append(convicted_charge)
 
-        assert convicted_charge.expungement_result.type_eligibility is False
-        assert convicted_charge.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+        assert convicted_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert convicted_charge.expungement_result.type_eligibility.reason == 'Ineligible under 137.225(5)'
 
     def test_min_statute_range_for_promoting_prostitution(self):
         self.single_charge['statute'] = '167.008'
         convicted_charge = self.create_recent_charge()
         self.charges.append(convicted_charge)
 
-        assert convicted_charge.expungement_result.type_eligibility is False
-        assert convicted_charge.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+        assert convicted_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert convicted_charge.expungement_result.type_eligibility.reason == 'Ineligible under 137.225(5)'
 
     def test_max_statute_range_for_promoting_prostitution(self):
         self.single_charge['statute'] = '167.107'
         convicted_charge = self.create_recent_charge()
         self.charges.append(convicted_charge)
 
-        assert convicted_charge.expungement_result.type_eligibility is False
-        assert convicted_charge.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+        assert convicted_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert convicted_charge.expungement_result.type_eligibility.reason == 'Ineligible under 137.225(5)'
 
     def test_min_statute_range_for_obscenity_and_minors(self):
         self.single_charge['statute'] = '167.057'
         convicted_charge = self.create_recent_charge()
         self.charges.append(convicted_charge)
 
-        assert convicted_charge.expungement_result.type_eligibility is False
-        assert convicted_charge.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+        assert convicted_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert convicted_charge.expungement_result.type_eligibility.reason == 'Ineligible under 137.225(5)'
 
     def test_max_statute_range_for_obscenity_and_minors(self):
         self.single_charge['statute'] = '167.080'
         convicted_charge = self.create_recent_charge()
         self.charges.append(convicted_charge)
 
-        assert convicted_charge.expungement_result.type_eligibility is False
-        assert convicted_charge.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+        assert convicted_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert convicted_charge.expungement_result.type_eligibility.reason == 'Ineligible under 137.225(5)'
 
     def test_misdemeanor(self):
         self.single_charge['name'] = 'Criminal Trespass in the Second Degree'
@@ -107,8 +110,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         misdemeanor_charge = self.create_recent_charge()
         self.charges.append(misdemeanor_charge)
 
-        assert misdemeanor_charge.expungement_result.type_eligibility is True
-        assert misdemeanor_charge.expungement_result.type_eligibility_reason == 'Eligible under 137.225(5)(b)'
+        assert misdemeanor_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+        assert misdemeanor_charge.expungement_result.type_eligibility.reason == 'Eligible under 137.225(5)(b)'
 
     def test_rape_class_c_felony(self):
         self.single_charge['name'] = 'Rape in the Third Degree'
@@ -117,8 +120,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         sex_crime_charge = self.create_recent_charge()
         self.charges.append(sex_crime_charge)
 
-        assert sex_crime_charge.expungement_result.type_eligibility is False
-        assert sex_crime_charge.expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+        assert sex_crime_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert sex_crime_charge.expungement_result.type_eligibility.reason == 'Ineligible under 137.225(5)'
 
     def test_marijuana_ineligible_statute_475b3493c(self):
         self.single_charge['name'] = 'Unlawful Manufacture of Marijuana Item'
@@ -127,8 +130,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         marijuana_felony_class_c = self.create_recent_charge()
         self.charges.append(marijuana_felony_class_c)
 
-        assert marijuana_felony_class_c.expungement_result.type_eligibility is False
-        assert marijuana_felony_class_c.expungement_result.type_eligibility_reason == 'Ineligible under 137.226'
+        assert marijuana_felony_class_c.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert marijuana_felony_class_c.expungement_result.type_eligibility.reason == 'Ineligible under 137.226'
 
     def test_marijuana_ineligible_statute_475b359(self):
         self.single_charge['name'] = 'Arson incident to manufacture of cannabinoid extract in first degree'
@@ -137,8 +140,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         marijuana_felony_class_a = self.create_recent_charge()
         self.charges.append(marijuana_felony_class_a)
 
-        assert marijuana_felony_class_a.expungement_result.type_eligibility is False
-        assert marijuana_felony_class_a.expungement_result.type_eligibility_reason == 'Ineligible under 137.226'
+        assert marijuana_felony_class_a.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert marijuana_felony_class_a.expungement_result.type_eligibility.reason == 'Ineligible under 137.226'
 
     def test_marijuana_ineligible_statute_475b367(self):
         self.single_charge['name'] = 'Causing another person to ingest marijuana'
@@ -147,8 +150,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         marijuana_felony_class_a = self.create_recent_charge()
         self.charges.append(marijuana_felony_class_a)
 
-        assert marijuana_felony_class_a.expungement_result.type_eligibility is False
-        assert marijuana_felony_class_a.expungement_result.type_eligibility_reason == 'Ineligible under 137.226'
+        assert marijuana_felony_class_a.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert marijuana_felony_class_a.expungement_result.type_eligibility.reason == 'Ineligible under 137.226'
 
     def test_marijuana_ineligible_statute_475b371(self):
         self.single_charge['name'] = 'Administration to another person under 18 years of age'
@@ -157,8 +160,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         marijuana_felony_class_a = self.create_recent_charge()
         self.charges.append(marijuana_felony_class_a)
 
-        assert marijuana_felony_class_a.expungement_result.type_eligibility is False
-        assert marijuana_felony_class_a.expungement_result.type_eligibility_reason == 'Ineligible under 137.226'
+        assert marijuana_felony_class_a.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert marijuana_felony_class_a.expungement_result.type_eligibility.reason == 'Ineligible under 137.226'
 
     def test_marijuana_ineligible_statute_167262(self):
         self.single_charge['name'] = 'Use of minor in controlled substance or marijuana item offense'
@@ -167,8 +170,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         marijuana_misdemeanor_class_a = self.create_recent_charge()
         self.charges.append(marijuana_misdemeanor_class_a)
 
-        assert marijuana_misdemeanor_class_a.expungement_result.type_eligibility is False
-        assert marijuana_misdemeanor_class_a.expungement_result.type_eligibility_reason == 'Ineligible under 137.226'
+        assert marijuana_misdemeanor_class_a.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert marijuana_misdemeanor_class_a.expungement_result.type_eligibility.reason == 'Ineligible under 137.226'
 
     # List B Tests - Currently being marked as "Further Analysis Needed"
 
@@ -179,8 +182,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         list_b_charge = self.create_recent_charge()
         self.charges.append(list_b_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility is None
-        assert list_b_charge.expungement_result.type_eligibility_reason == 'Further Analysis Needed'
+        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert list_b_charge.expungement_result.type_eligibility.reason == 'Further Analysis Needed'
 
     def test_list_b_163205(self):
         self.single_charge['name'] = 'Criminal mistreatment in the first degree'
@@ -189,8 +192,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         list_b_charge = self.create_recent_charge()
         self.charges.append(list_b_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility is None
-        assert list_b_charge.expungement_result.type_eligibility_reason == 'Further Analysis Needed'
+        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert list_b_charge.expungement_result.type_eligibility.reason == 'Further Analysis Needed'
 
     def test_list_b_163575(self):
         self.single_charge['name'] = 'Endangering the welfare of a minor'
@@ -199,8 +202,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         list_b_charge = self.create_recent_charge()
         self.charges.append(list_b_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility is None
-        assert list_b_charge.expungement_result.type_eligibility_reason == 'Further Analysis Needed'
+        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert list_b_charge.expungement_result.type_eligibility.reason == 'Further Analysis Needed'
 
     def test_list_b_163535(self):
         self.single_charge['name'] = 'Abandonment of a child'
@@ -209,8 +212,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         list_b_charge = self.create_recent_charge()
         self.charges.append(list_b_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility is None
-        assert list_b_charge.expungement_result.type_eligibility_reason == 'Further Analysis Needed'
+        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert list_b_charge.expungement_result.type_eligibility.reason == 'Further Analysis Needed'
 
     def test_list_b_163175(self):
         self.single_charge['name'] = 'Assault in the second degree'
@@ -219,8 +222,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         list_b_charge = self.create_recent_charge()
         self.charges.append(list_b_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility is None
-        assert list_b_charge.expungement_result.type_eligibility_reason == 'Further Analysis Needed'
+        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert list_b_charge.expungement_result.type_eligibility.reason == 'Further Analysis Needed'
 
     def test_list_b_163275(self):
         self.single_charge['name'] = 'Coercion'
@@ -229,8 +232,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         list_b_charge = self.create_recent_charge()
         self.charges.append(list_b_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility is None
-        assert list_b_charge.expungement_result.type_eligibility_reason == 'Further Analysis Needed'
+        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert list_b_charge.expungement_result.type_eligibility.reason == 'Further Analysis Needed'
 
     def test_list_b_162165(self):
         self.single_charge['name'] = 'Escape in the first degree'
@@ -239,8 +242,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         list_b_charge = self.create_recent_charge()
         self.charges.append(list_b_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility is None
-        assert list_b_charge.expungement_result.type_eligibility_reason == 'Further Analysis Needed'
+        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert list_b_charge.expungement_result.type_eligibility.reason == 'Further Analysis Needed'
 
     def test_list_b_163525(self):
         self.single_charge['name'] = 'Incest'
@@ -249,8 +252,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         list_b_charge = self.create_recent_charge()
         self.charges.append(list_b_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility is None
-        assert list_b_charge.expungement_result.type_eligibility_reason == 'Further Analysis Needed'
+        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert list_b_charge.expungement_result.type_eligibility.reason == 'Further Analysis Needed'
 
     def test_list_b_164405(self):
         self.single_charge['name'] = 'Robbery in the second degree'
@@ -259,8 +262,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         list_b_charge = self.create_recent_charge()
         self.charges.append(list_b_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility is None
-        assert list_b_charge.expungement_result.type_eligibility_reason == 'Further Analysis Needed'
+        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert list_b_charge.expungement_result.type_eligibility.reason == 'Further Analysis Needed'
 
     def test_list_b_164395(self):
         self.single_charge['name'] = 'Robbery in the third degree'
@@ -269,8 +272,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         list_b_charge = self.create_recent_charge()
         self.charges.append(list_b_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility is None
-        assert list_b_charge.expungement_result.type_eligibility_reason == 'Further Analysis Needed'
+        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert list_b_charge.expungement_result.type_eligibility.reason == 'Further Analysis Needed'
 
     def test_list_b_162185(self):
         self.single_charge['name'] = 'Supplying contraband'
@@ -279,8 +282,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         list_b_charge = self.create_recent_charge()
         self.charges.append(list_b_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility is None
-        assert list_b_charge.expungement_result.type_eligibility_reason == 'Further Analysis Needed'
+        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert list_b_charge.expungement_result.type_eligibility.reason == 'Further Analysis Needed'
 
     def test_list_b_163225(self):
         self.single_charge['name'] = 'Kidnapping in the second degree'
@@ -289,8 +292,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         list_b_charge = self.create_recent_charge()
         self.charges.append(list_b_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility is None
-        assert list_b_charge.expungement_result.type_eligibility_reason == 'Further Analysis Needed'
+        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert list_b_charge.expungement_result.type_eligibility.reason == 'Further Analysis Needed'
 
     def test_list_b_163165(self):
         self.single_charge['name'] = 'Assault in the third degree'
@@ -299,8 +302,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         list_b_charge = self.create_recent_charge()
         self.charges.append(list_b_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility is None
-        assert list_b_charge.expungement_result.type_eligibility_reason == 'Further Analysis Needed'
+        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert list_b_charge.expungement_result.type_eligibility.reason == 'Further Analysis Needed'
 
     def test_list_b_166220(self):
         self.single_charge['name'] = 'Unlawful use of weapon'
@@ -309,8 +312,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         list_b_charge = self.create_recent_charge()
         self.charges.append(list_b_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility is None
-        assert list_b_charge.expungement_result.type_eligibility_reason == 'Further Analysis Needed'
+        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert list_b_charge.expungement_result.type_eligibility.reason == 'Further Analysis Needed'
 
     # Test sub-chapters are not compared when not necessary.
 
@@ -321,8 +324,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         list_b_charge = self.create_recent_charge()
         self.charges.append(list_b_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility is None
-        assert list_b_charge.expungement_result.type_eligibility_reason == 'Further Analysis Needed'
+        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert list_b_charge.expungement_result.type_eligibility.reason == 'Further Analysis Needed'
 
     def test_marijuana_ineligible_statute_475b3592a(self):
         self.single_charge['name'] = 'Arson incident to manufacture of cannabinoid extract in first degree'
@@ -331,8 +334,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         marijuana_felony_class_a = self.create_recent_charge()
         self.charges.append(marijuana_felony_class_a)
 
-        assert marijuana_felony_class_a.expungement_result.type_eligibility is False
-        assert marijuana_felony_class_a.expungement_result.type_eligibility_reason == 'Ineligible under 137.226'
+        assert marijuana_felony_class_a.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert marijuana_felony_class_a.expungement_result.type_eligibility.reason == 'Ineligible under 137.226'
 
     # Possession of controlled substance tests
 
@@ -343,8 +346,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         pcs_charge = self.create_recent_charge()
         self.charges.append(pcs_charge)
 
-        assert pcs_charge.expungement_result.type_eligibility is True
-        assert pcs_charge.expungement_result.type_eligibility_reason == 'Eligible under 137.225(5)(C)'
+        assert pcs_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+        assert pcs_charge.expungement_result.type_eligibility.reason == 'Eligible under 137.225(5)(C)'
 
     def test_pcs_475874(self):
         self.single_charge['name'] = 'Unlawful possession of 3,4-methylenedioxymethamphetamine'
@@ -353,8 +356,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         pcs_charge = self.create_recent_charge()
         self.charges.append(pcs_charge)
 
-        assert pcs_charge.expungement_result.type_eligibility is True
-        assert pcs_charge.expungement_result.type_eligibility_reason == 'Eligible under 137.225(5)(C)'
+        assert pcs_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+        assert pcs_charge.expungement_result.type_eligibility.reason == 'Eligible under 137.225(5)(C)'
 
     def test_pcs_475884(self):
         self.single_charge['name'] = 'Unlawful possession of cocaine'
@@ -363,8 +366,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         pcs_charge = self.create_recent_charge()
         self.charges.append(pcs_charge)
 
-        assert pcs_charge.expungement_result.type_eligibility is True
-        assert pcs_charge.expungement_result.type_eligibility_reason == 'Eligible under 137.225(5)(C)'
+        assert pcs_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+        assert pcs_charge.expungement_result.type_eligibility.reason == 'Eligible under 137.225(5)(C)'
 
     def test_pcs_475894(self):
         self.single_charge['name'] = 'Unlawful possession of methamphetamine'
@@ -373,8 +376,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         pcs_charge = self.create_recent_charge()
         self.charges.append(pcs_charge)
 
-        assert pcs_charge.expungement_result.type_eligibility is True
-        assert pcs_charge.expungement_result.type_eligibility_reason == 'Eligible under 137.225(5)(C)'
+        assert pcs_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+        assert pcs_charge.expungement_result.type_eligibility.reason == 'Eligible under 137.225(5)(C)'
 
     # Eligible misdemeanor and class C felony tests
 
@@ -385,8 +388,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         charge = self.create_recent_charge()
         self.charges.append(charge)
 
-        assert charge.expungement_result.type_eligibility is True
-        assert charge.expungement_result.type_eligibility_reason == 'Eligible under 137.225(5)(b)'
+        assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+        assert charge.expungement_result.type_eligibility.reason == 'Eligible under 137.225(5)(b)'
 
     def test_misdemeanor_164055(self):
         self.single_charge['name'] = 'Theft in the first degree'
@@ -395,8 +398,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         charge = self.create_recent_charge()
         self.charges.append(charge)
 
-        assert charge.expungement_result.type_eligibility is True
-        assert charge.expungement_result.type_eligibility_reason == 'Eligible under 137.225(5)(b)'
+        assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+        assert charge.expungement_result.type_eligibility.reason == 'Eligible under 137.225(5)(b)'
 
     def test_misdemeanor_164125(self):
         self.single_charge['name'] = 'Theft of services'
@@ -405,8 +408,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         charge = self.create_recent_charge()
         self.charges.append(charge)
 
-        assert charge.expungement_result.type_eligibility is True
-        assert charge.expungement_result.type_eligibility_reason == 'Eligible under 137.225(5)(b)'
+        assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+        assert charge.expungement_result.type_eligibility.reason == 'Eligible under 137.225(5)(b)'
 
     def test_drug_free_zone_variance_misdemeanor(self):
         self.single_charge['name'] = '	Drug Free Zone Variance'
@@ -415,8 +418,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         charge = self.create_recent_charge()
         self.charges.append(charge)
 
-        assert charge.expungement_result.type_eligibility is True
-        assert charge.expungement_result.type_eligibility_reason == 'Eligible under 137.225(5)(b)'
+        assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+        assert charge.expungement_result.type_eligibility.reason == 'Eligible under 137.225(5)(b)'
 
     def test_class_b_felony_164057(self):
         self.single_charge['name'] = 'Aggravated theft in the first degree'
@@ -425,8 +428,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         charge = self.create_recent_charge()
         self.charges.append(charge)
 
-        assert charge.expungement_result.type_eligibility is None
-        assert charge.expungement_result.type_eligibility_reason == 'Further Analysis Needed'
+        assert charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert charge.expungement_result.type_eligibility.reason == 'Further Analysis Needed'
 
     def test_class_felony_is_added_to_b_felony_attribute(self):
         self.single_charge['name'] = 'Aggravated theft in the first degree'
@@ -443,8 +446,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         charge = self.create_recent_charge()
         self.charges.append(charge)
 
-        assert charge.expungement_result.type_eligibility is None
-        assert charge.expungement_result.type_eligibility_reason == 'Examine'
+        assert charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert charge.expungement_result.type_eligibility.reason == 'Examine'
 
     # Test non-traffic violation
 
@@ -455,8 +458,8 @@ class TestSingleChargeConvictions(unittest.TestCase):
         charge = self.create_recent_charge()
         self.charges.append(charge)
 
-        assert charge.expungement_result.type_eligibility is True
-        assert charge.expungement_result.type_eligibility_reason == 'Eligible under 137.225(5)(d)'
+        assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+        assert charge.expungement_result.type_eligibility.reason == 'Eligible under 137.225(5)(d)'
 
 
 class TestMultipleCharges(unittest.TestCase):
@@ -486,11 +489,11 @@ class TestMultipleCharges(unittest.TestCase):
         charge = self.create_charge()
         self.charges.append(charge)
 
-        assert self.charges[0].expungement_result.type_eligibility is True
-        assert self.charges[0].expungement_result.type_eligibility_reason == 'Eligible under 137.225(5)(b)'
+        assert self.charges[0].expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+        assert self.charges[0].expungement_result.type_eligibility.reason == 'Eligible under 137.225(5)(b)'
 
-        assert self.charges[1].expungement_result.type_eligibility is False
-        assert self.charges[1].expungement_result.type_eligibility_reason == 'Ineligible under 137.225(5)'
+        assert self.charges[1].expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert self.charges[1].expungement_result.type_eligibility.reason == 'Ineligible under 137.225(5)'
 
     def test_multiple_class_b_felonies_are_added_to_b_felony_list(self):
         # first charge


### PR DESCRIPTION
Note this is preparation work for #385 .

The existing structure for ExpungementResult has a few issues. The type_eligibility field is used to store three states even though it is a boolean field (by abusing the None type). As a result, a person new to this codebase is forced to make an extra mental mapping between "None" and "Needs more analysis". Also the status/reason for type eligibility and the status/reason/date_will_be_eligible for time eligibility are assigned respectively together but this is not hinted with the existing structure. Note there are a few occasions where reason is set without the corresponding status but in all those places it looks as if the status was simply not set.

While the first commit may have an irregularly large number of file changes for one commit, if I did not mess up, there should be no functional changes (NFC) to the front-end. The function `expungement_result_to_json` in `serializer.py` may look like a code smell as a result.