### PR TITLE
Refactor charge.py to set classification at only one location

### DIFF
--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -14,6 +14,7 @@ from expungeservice.models.charge_types.parking_ticket import ParkingTicket
 from expungeservice.models.charge_types.person_crime import PersonCrime
 from expungeservice.models.charge_types.schedule_1_p_c_s import Schedule1PCS
 from expungeservice.models.charge_types.unclassified_charge import UnclassifiedCharge
+from expungeservice.models.charge_classifier import ChargeClassifier
 
 
 class Charge:
@@ -24,119 +25,11 @@ class Charge:
         level = kwargs['level']
         chapter = Charge._set_chapter(kwargs['statute'])
         section = Charge.__set_section(statute)
-        cls.classification = Charge.__classification(case, statute, level, chapter, section)
+        cls.classification = ChargeClassifier(case, statute, level, chapter, section).classify()
         kwargs['chapter'] = chapter
         kwargs['section'] = section
         kwargs['statute'] = statute
         return Charge._to_class(cls.classification)(**kwargs)
-
-    @staticmethod
-    def __classification(case, statute, level, chapter, section):
-        def classification_found(c):
-            return c is not None
-
-        for c in Charge._classifications_list(case, statute, level, chapter, section):
-            if classification_found(c):
-                return c
-
-    @staticmethod
-    def _classifications_list(case, statute, level, chapter, section):
-        yield Charge._juvenile_charge(case)
-        yield from Charge._classification_by_statute(statute, chapter, section)
-        yield Charge._municipal_parking(case)
-        yield from Charge._classification_by_level(level)
-        yield "UnclassifiedCharge"
-
-    @staticmethod
-    def _juvenile_charge(case):
-        if 'juvenile' in case.violation_type.lower():
-            return 'JuvenileCharge'
-
-    @staticmethod
-    def _classification_by_statute(statute, chapter, section):
-        yield Charge._marijuana_ineligible(statute, section)
-        yield Charge._list_b(section)
-        yield Charge._crime_against_person(section)
-        yield Charge._traffic_crime(statute)
-        yield Charge._parking_ticket(statute, chapter)
-        yield Charge._schedule_1_pcs(section)
-
-    @staticmethod
-    def _classification_by_level(level):
-        yield Charge._non_traffic_violation(level)
-        yield Charge._misdemeanor(level)
-        yield Charge._felony_class_c(level)
-        yield Charge._felony_class_b(level)
-        yield Charge._felony_class_a(level)
-
-    @classmethod
-    def _marijuana_ineligible(cls, statute, section):
-        ineligible_statutes = ['475B359', '475B367', '475B371', '167262']
-        if statute == '475B3493C' or section in ineligible_statutes:
-            return 'MarijuanaIneligible'
-
-    @classmethod
-    def _list_b(cls, section):
-        ineligible_statutes = ['163200', '163205', '163575', '163535', '163175', '163275', '162165', '163525', '164405',
-                               '164395', '162185', '166220', '163225', '163165']
-        if section in ineligible_statutes:
-            return 'ListB'
-
-    @classmethod
-    def _crime_against_person(cls, section):
-        statute_ranges = (range(163305, 163480), range(163670, 163694), range(167008, 167108), range(167057, 167081))
-        if section.isdigit() and any(int(section) in statute_range for statute_range in statute_ranges):
-            return 'PersonCrime'
-
-    @classmethod
-    def _traffic_crime(cls, statute):
-        statute_range = range(801, 826)
-        if statute[0:3].isdigit() and int(statute[0:3]) in statute_range:
-            return 'Level800TrafficCrime'
-
-    @classmethod
-    def _parking_ticket(cls, statute, chapter):
-        statute_range = range(1, 100)
-        if chapter:
-            if chapter.isdigit() and int(chapter) in statute_range:
-                return 'ParkingTicket'
-        elif statute.isdigit() and int(statute) in statute_range:
-            return 'ParkingTicket'
-
-    @classmethod
-    def _schedule_1_pcs(cls, section):
-        if section in ['475854', '475874', '475884', '475894']:
-            return 'Schedule1PCS'
-
-    @classmethod
-    def _municipal_parking(cls, case):
-        if 'parking' in case.violation_type.lower():
-            return 'ParkingTicket'
-
-    @classmethod
-    def _non_traffic_violation(cls, level):
-        if 'Violation' in level:
-            return 'NonTrafficViolation'
-
-    @classmethod
-    def _misdemeanor(cls, level):
-        if 'Misdemeanor' in level:
-            return 'Misdemeanor'
-
-    @classmethod
-    def _felony_class_c(cls, level):
-        if level == 'Felony Class C':
-            return 'FelonyClassC'
-
-    @classmethod
-    def _felony_class_b(cls, level):
-        if level == 'Felony Class B':
-            return 'FelonyClassB'
-
-    @classmethod
-    def _felony_class_a(cls, level):
-        if level == 'Felony Class A':
-            return 'FelonyClassA'
 
     @staticmethod
     def _to_class(name):

--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -18,18 +18,18 @@ from expungeservice.models.charge_classifier import ChargeClassifier
 
 
 class Charge:
-    @classmethod
-    def create(cls, **kwargs):
+    @staticmethod
+    def create(**kwargs):
         case = kwargs['case']
         statute = Charge.__strip_non_alphanumeric_chars(kwargs['statute'])
         level = kwargs['level']
         chapter = Charge._set_chapter(kwargs['statute'])
         section = Charge.__set_section(statute)
-        cls.classification = ChargeClassifier(case, statute, level, chapter, section).classify()
+        classification = ChargeClassifier(case, statute, level, chapter, section).classify()
         kwargs['chapter'] = chapter
         kwargs['section'] = section
         kwargs['statute'] = statute
-        return Charge._to_class(cls.classification)(**kwargs)
+        return Charge._to_class(classification)(**kwargs)
 
     @staticmethod
     def _to_class(name):

--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -17,123 +17,126 @@ from expungeservice.models.charge_types.unclassified_charge import UnclassifiedC
 
 
 class Charge:
-    classification = None
-
     @classmethod
     def create(cls, **kwargs):
-        cls.classification = None
         case = kwargs['case']
         statute = Charge.__strip_non_alphanumeric_chars(kwargs['statute'])
         level = kwargs['level']
         chapter = Charge._set_chapter(kwargs['statute'])
         section = Charge.__set_section(statute)
-        Charge._set_classification(case, statute, level, chapter, section)
+        cls.classification = Charge.__classification(case, statute, level, chapter, section)
         kwargs['chapter'] = chapter
         kwargs['section'] = section
         kwargs['statute'] = statute
         return Charge._to_class(cls.classification)(**kwargs)
 
-    @classmethod
-    def _set_classification(cls, case, statute, level, chapter, section):
-        if Charge._juvenile_charge(case):
-            cls.classification = 'JuvenileCharge'
-        Charge._set_classification_by_statute(statute, chapter, section)
-        if not cls.classification:
-            Charge._municipal_parking(case)
-        if not cls.classification:
-            Charge._set_classification_by_level(level)
-        if not cls.classification:
-            cls.classification = 'UnclassifiedCharge'
+    @staticmethod
+    def __classification(case, statute, level, chapter, section):
+        def classification_found(c):
+            return c is not None
+
+        for c in Charge._classifications_list(case, statute, level, chapter, section):
+            if classification_found(c):
+                return c
+
+    @staticmethod
+    def _classifications_list(case, statute, level, chapter, section):
+        yield Charge._juvenile_charge(case)
+        yield from Charge._classification_by_statute(statute, chapter, section)
+        yield Charge._municipal_parking(case)
+        yield from Charge._classification_by_level(level)
+        yield "UnclassifiedCharge"
 
     @staticmethod
     def _juvenile_charge(case):
-        return 'juvenile' in case.violation_type.lower()
+        if 'juvenile' in case.violation_type.lower():
+            return 'JuvenileCharge'
 
     @staticmethod
-    def _set_classification_by_statute(statute, chapter, section):
-        Charge._marijuana_ineligible(statute, section)
-        Charge._list_b(section)
-        Charge._crime_against_person(section)
-        Charge._traffic_crime(statute)
-        Charge._parking_ticket(statute, chapter)
-        Charge._schedule_1_pcs(section)
+    def _classification_by_statute(statute, chapter, section):
+        yield Charge._marijuana_ineligible(statute, section)
+        yield Charge._list_b(section)
+        yield Charge._crime_against_person(section)
+        yield Charge._traffic_crime(statute)
+        yield Charge._parking_ticket(statute, chapter)
+        yield Charge._schedule_1_pcs(section)
 
     @staticmethod
-    def _set_classification_by_level(level):
-        Charge._non_traffic_violation(level)
-        Charge._misdemeanor(level)
-        Charge._felony_class_c(level)
-        Charge._felony_class_b(level)
-        Charge._felony_class_a(level)
+    def _classification_by_level(level):
+        yield Charge._non_traffic_violation(level)
+        yield Charge._misdemeanor(level)
+        yield Charge._felony_class_c(level)
+        yield Charge._felony_class_b(level)
+        yield Charge._felony_class_a(level)
 
     @classmethod
     def _marijuana_ineligible(cls, statute, section):
         ineligible_statutes = ['475B359', '475B367', '475B371', '167262']
         if statute == '475B3493C' or section in ineligible_statutes:
-            cls.classification = 'MarijuanaIneligible'
+            return 'MarijuanaIneligible'
 
     @classmethod
     def _list_b(cls, section):
         ineligible_statutes = ['163200', '163205', '163575', '163535', '163175', '163275', '162165', '163525', '164405',
                                '164395', '162185', '166220', '163225', '163165']
         if section in ineligible_statutes:
-            cls.classification = 'ListB'
+            return 'ListB'
 
     @classmethod
     def _crime_against_person(cls, section):
         statute_ranges = (range(163305, 163480), range(163670, 163694), range(167008, 167108), range(167057, 167081))
         if section.isdigit() and any(int(section) in statute_range for statute_range in statute_ranges):
-            cls.classification = 'PersonCrime'
+            return 'PersonCrime'
 
     @classmethod
     def _traffic_crime(cls, statute):
         statute_range = range(801, 826)
         if statute[0:3].isdigit() and int(statute[0:3]) in statute_range:
-            cls.classification = 'Level800TrafficCrime'
+            return 'Level800TrafficCrime'
 
     @classmethod
     def _parking_ticket(cls, statute, chapter):
         statute_range = range(1, 100)
         if chapter:
             if chapter.isdigit() and int(chapter) in statute_range:
-                cls.classification = 'ParkingTicket'
+                return 'ParkingTicket'
         elif statute.isdigit() and int(statute) in statute_range:
-            cls.classification = 'ParkingTicket'
+            return 'ParkingTicket'
 
     @classmethod
     def _schedule_1_pcs(cls, section):
         if section in ['475854', '475874', '475884', '475894']:
-            cls.classification = 'Schedule1PCS'
+            return 'Schedule1PCS'
 
     @classmethod
     def _municipal_parking(cls, case):
         if 'parking' in case.violation_type.lower():
-            cls.classification = 'ParkingTicket'
+            return 'ParkingTicket'
 
     @classmethod
     def _non_traffic_violation(cls, level):
         if 'Violation' in level:
-            cls.classification = 'NonTrafficViolation'
+            return 'NonTrafficViolation'
 
     @classmethod
     def _misdemeanor(cls, level):
         if 'Misdemeanor' in level:
-            cls.classification = 'Misdemeanor'
+            return 'Misdemeanor'
 
     @classmethod
     def _felony_class_c(cls, level):
         if level == 'Felony Class C':
-            cls.classification = 'FelonyClassC'
+            return 'FelonyClassC'
 
     @classmethod
     def _felony_class_b(cls, level):
         if level == 'Felony Class B':
-            cls.classification = 'FelonyClassB'
+            return 'FelonyClassB'
 
     @classmethod
     def _felony_class_a(cls, level):
         if level == 'Felony Class A':
-            cls.classification = 'FelonyClassA'
+            return 'FelonyClassA'
 
     @staticmethod
     def _to_class(name):

--- a/src/backend/expungeservice/models/charge_classifier.py
+++ b/src/backend/expungeservice/models/charge_classifier.py
@@ -1,0 +1,118 @@
+from dataclasses import dataclass
+
+from expungeservice.models.case import Case
+
+
+@dataclass
+class ChargeClassifier:
+    case : Case
+    statute : str
+    level : str
+    chapter : str
+    section : str
+
+    def classify(self):
+        def classification_found(c):
+            return c is not None
+
+        for c in self.__classifications_list():
+            if classification_found(c):
+                return c
+
+    def __classifications_list(self):
+        yield ChargeClassifier._juvenile_charge(self.case)
+        yield from ChargeClassifier._classification_by_statute(self.statute, self.chapter, self.section)
+        yield ChargeClassifier._municipal_parking(self.case)
+        yield from ChargeClassifier._classification_by_level(self.level)
+        yield "UnclassifiedCharge"
+
+    @staticmethod
+    def _juvenile_charge(case):
+        if 'juvenile' in case.violation_type.lower():
+            return 'JuvenileCharge'
+
+    @staticmethod
+    def _classification_by_statute(statute, chapter, section):
+        yield ChargeClassifier._marijuana_ineligible(statute, section)
+        yield ChargeClassifier._list_b(section)
+        yield ChargeClassifier._crime_against_person(section)
+        yield ChargeClassifier._traffic_crime(statute)
+        yield ChargeClassifier._parking_ticket(statute, chapter)
+        yield ChargeClassifier._schedule_1_pcs(section)
+
+    @staticmethod
+    def _classification_by_level(level):
+        yield ChargeClassifier._non_traffic_violation(level)
+        yield ChargeClassifier._misdemeanor(level)
+        yield ChargeClassifier._felony_class_c(level)
+        yield ChargeClassifier._felony_class_b(level)
+        yield ChargeClassifier._felony_class_a(level)
+
+    @classmethod
+    def _marijuana_ineligible(cls, statute, section):
+        ineligible_statutes = ['475B359', '475B367', '475B371', '167262']
+        if statute == '475B3493C' or section in ineligible_statutes:
+            return 'MarijuanaIneligible'
+
+    @classmethod
+    def _list_b(cls, section):
+        ineligible_statutes = ['163200', '163205', '163575', '163535', '163175', '163275', '162165', '163525', '164405',
+                               '164395', '162185', '166220', '163225', '163165']
+        if section in ineligible_statutes:
+            return 'ListB'
+
+    @classmethod
+    def _crime_against_person(cls, section):
+        statute_ranges = (range(163305, 163480), range(163670, 163694), range(167008, 167108), range(167057, 167081))
+        if section.isdigit() and any(int(section) in statute_range for statute_range in statute_ranges):
+            return 'PersonCrime'
+
+    @classmethod
+    def _traffic_crime(cls, statute):
+        statute_range = range(801, 826)
+        if statute[0:3].isdigit() and int(statute[0:3]) in statute_range:
+            return 'Level800TrafficCrime'
+
+    @classmethod
+    def _parking_ticket(cls, statute, chapter):
+        statute_range = range(1, 100)
+        if chapter:
+            if chapter.isdigit() and int(chapter) in statute_range:
+                return 'ParkingTicket'
+        elif statute.isdigit() and int(statute) in statute_range:
+            return 'ParkingTicket'
+
+    @classmethod
+    def _schedule_1_pcs(cls, section):
+        if section in ['475854', '475874', '475884', '475894']:
+            return 'Schedule1PCS'
+
+    @classmethod
+    def _municipal_parking(cls, case):
+        if 'parking' in case.violation_type.lower():
+            return 'ParkingTicket'
+
+    @classmethod
+    def _non_traffic_violation(cls, level):
+        if 'Violation' in level:
+            return 'NonTrafficViolation'
+
+    @classmethod
+    def _misdemeanor(cls, level):
+        if 'Misdemeanor' in level:
+            return 'Misdemeanor'
+
+    @classmethod
+    def _felony_class_c(cls, level):
+        if level == 'Felony Class C':
+            return 'FelonyClassC'
+
+    @classmethod
+    def _felony_class_b(cls, level):
+        if level == 'Felony Class B':
+            return 'FelonyClassB'
+
+    @classmethod
+    def _felony_class_a(cls, level):
+        if level == 'Felony Class A':
+            return 'FelonyClassA'

--- a/src/backend/expungeservice/models/charge_classifier.py
+++ b/src/backend/expungeservice/models/charge_classifier.py
@@ -48,33 +48,33 @@ class ChargeClassifier:
         yield ChargeClassifier._felony_class_b(level)
         yield ChargeClassifier._felony_class_a(level)
 
-    @classmethod
-    def _marijuana_ineligible(cls, statute, section):
+    @staticmethod
+    def _marijuana_ineligible(statute, section):
         ineligible_statutes = ['475B359', '475B367', '475B371', '167262']
         if statute == '475B3493C' or section in ineligible_statutes:
             return 'MarijuanaIneligible'
 
-    @classmethod
-    def _list_b(cls, section):
+    @staticmethod
+    def _list_b(section):
         ineligible_statutes = ['163200', '163205', '163575', '163535', '163175', '163275', '162165', '163525', '164405',
                                '164395', '162185', '166220', '163225', '163165']
         if section in ineligible_statutes:
             return 'ListB'
 
-    @classmethod
-    def _crime_against_person(cls, section):
+    @staticmethod
+    def _crime_against_person(section):
         statute_ranges = (range(163305, 163480), range(163670, 163694), range(167008, 167108), range(167057, 167081))
         if section.isdigit() and any(int(section) in statute_range for statute_range in statute_ranges):
             return 'PersonCrime'
 
-    @classmethod
-    def _traffic_crime(cls, statute):
+    @staticmethod
+    def _traffic_crime(statute):
         statute_range = range(801, 826)
         if statute[0:3].isdigit() and int(statute[0:3]) in statute_range:
             return 'Level800TrafficCrime'
 
-    @classmethod
-    def _parking_ticket(cls, statute, chapter):
+    @staticmethod
+    def _parking_ticket(statute, chapter):
         statute_range = range(1, 100)
         if chapter:
             if chapter.isdigit() and int(chapter) in statute_range:
@@ -82,37 +82,37 @@ class ChargeClassifier:
         elif statute.isdigit() and int(statute) in statute_range:
             return 'ParkingTicket'
 
-    @classmethod
-    def _schedule_1_pcs(cls, section):
+    @staticmethod
+    def _schedule_1_pcs(section):
         if section in ['475854', '475874', '475884', '475894']:
             return 'Schedule1PCS'
 
-    @classmethod
-    def _municipal_parking(cls, case):
+    @staticmethod
+    def _municipal_parking(case):
         if 'parking' in case.violation_type.lower():
             return 'ParkingTicket'
 
-    @classmethod
-    def _non_traffic_violation(cls, level):
+    @staticmethod
+    def _non_traffic_violation(level):
         if 'Violation' in level:
             return 'NonTrafficViolation'
 
-    @classmethod
-    def _misdemeanor(cls, level):
+    @staticmethod
+    def _misdemeanor(level):
         if 'Misdemeanor' in level:
             return 'Misdemeanor'
 
-    @classmethod
-    def _felony_class_c(cls, level):
+    @staticmethod
+    def _felony_class_c(level):
         if level == 'Felony Class C':
             return 'FelonyClassC'
 
-    @classmethod
-    def _felony_class_b(cls, level):
+    @staticmethod
+    def _felony_class_b(level):
         if level == 'Felony Class B':
             return 'FelonyClassB'
 
-    @classmethod
-    def _felony_class_a(cls, level):
+    @staticmethod
+    def _felony_class_a(level):
         if level == 'Felony Class A':
             return 'FelonyClassA'


### PR DESCRIPTION
I made these refactorings while working on #385. Review should be easier if followed commit by commit.

The below is self-quoted from commit messages.

> The existing design relies upon unnecessarily many mutable methods to set the classification of a Charge. The structure of the method `_set_classification` implies "non-linear" logic though the logic itself is "linear": it attempts match a classification type to the current charge and then moves onto the next attempt. Using yields ensures that once the classification type is found, the loop short circuits to return what was found as a string representing the corresponding class name. Since the classification will always be "UnclassifiedCharge" if nothing else matches, the `cls.classification = None` can be removed.
> 
> Extract charge classifier into its own class 

