### PR TITLE
Remove usage of reflection to resolve charge type

### DIFF
--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -1,19 +1,5 @@
 import re
-import sys
 
-from expungeservice.models.charge_types.juvenile_charge import JuvenileCharge
-from expungeservice.models.charge_types.felony_class_a import FelonyClassA
-from expungeservice.models.charge_types.felony_class_b import FelonyClassB
-from expungeservice.models.charge_types.felony_class_c import FelonyClassC
-from expungeservice.models.charge_types.level_800_traffic_crime import Level800TrafficCrime
-from expungeservice.models.charge_types.list_b import ListB
-from expungeservice.models.charge_types.marijuana_ineligible import MarijuanaIneligible
-from expungeservice.models.charge_types.misdemeanor import Misdemeanor
-from expungeservice.models.charge_types.non_traffic_violation import NonTrafficViolation
-from expungeservice.models.charge_types.parking_ticket import ParkingTicket
-from expungeservice.models.charge_types.person_crime import PersonCrime
-from expungeservice.models.charge_types.schedule_1_p_c_s import Schedule1PCS
-from expungeservice.models.charge_types.unclassified_charge import UnclassifiedCharge
 from expungeservice.models.charge_classifier import ChargeClassifier
 
 
@@ -29,11 +15,7 @@ class Charge:
         kwargs['chapter'] = chapter
         kwargs['section'] = section
         kwargs['statute'] = statute
-        return Charge._to_class(classification)(**kwargs)
-
-    @staticmethod
-    def _to_class(name):
-        return getattr(sys.modules[__name__], name)
+        return classification(**kwargs)
 
     @staticmethod
     def __strip_non_alphanumeric_chars(statute):

--- a/src/backend/expungeservice/models/charge_classifier.py
+++ b/src/backend/expungeservice/models/charge_classifier.py
@@ -1,5 +1,18 @@
 from dataclasses import dataclass
 
+from expungeservice.models.charge_types.juvenile_charge import JuvenileCharge
+from expungeservice.models.charge_types.felony_class_a import FelonyClassA
+from expungeservice.models.charge_types.felony_class_b import FelonyClassB
+from expungeservice.models.charge_types.felony_class_c import FelonyClassC
+from expungeservice.models.charge_types.level_800_traffic_crime import Level800TrafficCrime
+from expungeservice.models.charge_types.list_b import ListB
+from expungeservice.models.charge_types.marijuana_ineligible import MarijuanaIneligible
+from expungeservice.models.charge_types.misdemeanor import Misdemeanor
+from expungeservice.models.charge_types.non_traffic_violation import NonTrafficViolation
+from expungeservice.models.charge_types.parking_ticket import ParkingTicket
+from expungeservice.models.charge_types.person_crime import PersonCrime
+from expungeservice.models.charge_types.schedule_1_p_c_s import Schedule1PCS
+from expungeservice.models.charge_types.unclassified_charge import UnclassifiedCharge
 from expungeservice.models.case import Case
 
 
@@ -24,12 +37,12 @@ class ChargeClassifier:
         yield from ChargeClassifier._classification_by_statute(self.statute, self.chapter, self.section)
         yield ChargeClassifier._municipal_parking(self.case)
         yield from ChargeClassifier._classification_by_level(self.level)
-        yield "UnclassifiedCharge"
+        yield UnclassifiedCharge
 
     @staticmethod
     def _juvenile_charge(case):
         if 'juvenile' in case.violation_type.lower():
-            return 'JuvenileCharge'
+            return JuvenileCharge
 
     @staticmethod
     def _classification_by_statute(statute, chapter, section):
@@ -52,67 +65,67 @@ class ChargeClassifier:
     def _marijuana_ineligible(statute, section):
         ineligible_statutes = ['475B359', '475B367', '475B371', '167262']
         if statute == '475B3493C' or section in ineligible_statutes:
-            return 'MarijuanaIneligible'
+            return MarijuanaIneligible
 
     @staticmethod
     def _list_b(section):
         ineligible_statutes = ['163200', '163205', '163575', '163535', '163175', '163275', '162165', '163525', '164405',
                                '164395', '162185', '166220', '163225', '163165']
         if section in ineligible_statutes:
-            return 'ListB'
+            return ListB
 
     @staticmethod
     def _crime_against_person(section):
         statute_ranges = (range(163305, 163480), range(163670, 163694), range(167008, 167108), range(167057, 167081))
         if section.isdigit() and any(int(section) in statute_range for statute_range in statute_ranges):
-            return 'PersonCrime'
+            return PersonCrime
 
     @staticmethod
     def _traffic_crime(statute):
         statute_range = range(801, 826)
         if statute[0:3].isdigit() and int(statute[0:3]) in statute_range:
-            return 'Level800TrafficCrime'
+            return Level800TrafficCrime
 
     @staticmethod
     def _parking_ticket(statute, chapter):
         statute_range = range(1, 100)
         if chapter:
             if chapter.isdigit() and int(chapter) in statute_range:
-                return 'ParkingTicket'
+                return ParkingTicket
         elif statute.isdigit() and int(statute) in statute_range:
-            return 'ParkingTicket'
+            return ParkingTicket
 
     @staticmethod
     def _schedule_1_pcs(section):
         if section in ['475854', '475874', '475884', '475894']:
-            return 'Schedule1PCS'
+            return Schedule1PCS
 
     @staticmethod
     def _municipal_parking(case):
         if 'parking' in case.violation_type.lower():
-            return 'ParkingTicket'
+            return ParkingTicket
 
     @staticmethod
     def _non_traffic_violation(level):
         if 'Violation' in level:
-            return 'NonTrafficViolation'
+            return NonTrafficViolation
 
     @staticmethod
     def _misdemeanor(level):
         if 'Misdemeanor' in level:
-            return 'Misdemeanor'
+            return Misdemeanor
 
     @staticmethod
     def _felony_class_c(level):
         if level == 'Felony Class C':
-            return 'FelonyClassC'
+            return FelonyClassC
 
     @staticmethod
     def _felony_class_b(level):
         if level == 'Felony Class B':
-            return 'FelonyClassB'
+            return FelonyClassB
 
     @staticmethod
     def _felony_class_a(level):
         if level == 'Felony Class A':
-            return 'FelonyClassA'
+            return FelonyClassA


### PR DESCRIPTION
This is a follow up refactoring from #503.

Reflection (getattr) doesn't really gain us anything anymore. My IDE would warn that the various charge_type imports in charge.py were unused. And it was also impossible (at least by default without some plugin) for the IDE to jump from the class name string to the class itself. In general, reflection is powerful but should only be used if necessary as it can lead to fragility and less readable code.