### PR TITLE
Remove unnecessary Promise wrapping from apiService

### DIFF
--- a/src/frontend/src/redux/middleware/request.ts
+++ b/src/frontend/src/redux/middleware/request.ts
@@ -45,7 +45,7 @@ const RequestMiddleware = (store: MiddlewareAPI) => (next: Dispatch) => (
   ) {
     let promise = makeUnauthenticatedRequest(action);
     let result = next(action);
-    return Object.assign({ promise: promise }, result);
+    return Object.assign({ promise }, result);
   }
 
   // This error shouldn't occur because app code has access to the store and thus knows
@@ -56,7 +56,7 @@ const RequestMiddleware = (store: MiddlewareAPI) => (next: Dispatch) => (
 
   let promise = makeAuthenticatedRequest(store, action);
   let result = next(action);
-  return Object.assign({ promise: promise }, result);
+  return Object.assign({ promise }, result);
 };
 
 function makeUnauthenticatedRequest(action: RequestAction): AxiosPromise {

--- a/src/frontend/src/redux/store.tsx
+++ b/src/frontend/src/redux/store.tsx
@@ -18,8 +18,7 @@ const rootReducer = combineReducers({
 
 const store = configureStore({
   reducer: rootReducer,
-  // See withoutUnserializables in middleware/request for why RequestMiddleware is first.
-  middleware: [RequestMiddleware, ...getDefaultMiddleware()]
+  middleware: [...getDefaultMiddleware(), RequestMiddleware]
 });
 
 export type AppState = ReturnType<typeof rootReducer>;

--- a/src/frontend/src/service/api-service.ts
+++ b/src/frontend/src/service/api-service.ts
@@ -1,4 +1,5 @@
 import { REQUEST, RequestAction } from '../redux/middleware/request';
+import { AxiosPromise } from 'axios';
 
 type Method = 'post' | 'delete' | 'get' | 'head' | 'delete' | 'options' | 'put';
 
@@ -19,11 +20,9 @@ export type Request = {
 export default function apiService(
   dispatch: Function,
   request: Request
-): Promise<any> {
-  return new Promise((resolve, reject) => {
-    // The Action dispatched here is handled in the Request Middleware, which actually makes
-    // the request using the resolve and reject callbacks passed, so you can call
-    // apiService(...).then(...).catch(...) like a normal Axios request.
-    dispatch({ type: REQUEST, request, resolve, reject } as RequestAction);
-  });
+): AxiosPromise {
+  // The Action dispatched here is handled in the Request Middleware, so you can call
+  // apiService(...).then(...).catch(...) like a normal Axios request.
+  let result = dispatch({ type: REQUEST, request } as RequestAction);
+  return result.promise;
 }


### PR DESCRIPTION
We currently are doing an unnecessary double Promise wrapping with apiService. In the existing middleware, we return the result of the dispatch functions (at line 49 and 59 of request.ts) without the result of the axios request. By returning the result of the axios request directly, we no longer need to pass in the resolve/reject capabilities of the wrapping Promise.

Front-end unit test results

```
 PASS  src/service/api-service.test.ts
  API SERVICE TEST
    ✓ returns data with get (5ms)
    ✓ returns with error on bad base url (1ms)
    ✓ returns with 404 error on bad route
    ✓ returns search in JSON (1ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        2.01s, estimated 3s
Ran all test suites.
```