### PR TITLE
Bump sleep on before_script to 5 seconds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
 - make src/backend/expungeservice/requirements.txt database_image expungeservice_image
 - docker stack deploy -c docker-compose.test.yml recordexpungpdx
 before_script:
-- counter=0 ; while ((counter < 20)) && ! pg_isready --host=$PGHOST --port=$PGPORT --dbname=$PGDATABASE ; do sleep 3; let counter=counter+1; done
+- counter=0 ; while ((counter < 20)) && ! pg_isready --host=$PGHOST --port=$PGPORT --dbname=$PGDATABASE ; do sleep 5; let counter=counter+1; done
 script:
 - make dev_test
 notifications:


### PR DESCRIPTION
Note this is a temporary solution.

The build https://travis-ci.com/codeforpdx/recordexpungPDX/builds/134934266 was failing because the expungeservice container wasn't up yet.