### PR TITLE
Update .dependabot config to match new Dockerfile placement

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -16,7 +16,7 @@ update_configs:
     - "dependencies"
 
   - package_manager: "docker"
-    directory: "/src/backend/expungeservice"
+    directory: "/src/backend"
     update_schedule: "daily"
     default_labels:
     - "dependencies"


### PR DESCRIPTION
This is a follow up from https://github.com/codeforpdx/recordexpungPDX/pull/515. I forgot to update the .dependabot config when I moved the Dockerfiles up a directory.

Closes #523 