### PR TITLE
Add logout endpoint and sync it with logout button on the frontend

### DIFF
--- a/src/backend/expungeservice/endpoints/auth.py
+++ b/src/backend/expungeservice/endpoints/auth.py
@@ -1,5 +1,6 @@
 from flask.views import MethodView
 from flask import request, jsonify, g
+from flask_login import login_required, logout_user
 from flask_login.login_manager import LoginManager
 from werkzeug.security import check_password_hash
 from dacite import from_dict
@@ -33,6 +34,13 @@ class AuthToken(MethodView):
         return jsonify({})
 
 
+class Logout(MethodView):
+    @login_required
+    def post(self):
+        logout_user()
+        return "Success"
+
+
 def __user_loader(user_id):
     user_db_result = user_db_util.read(
         g.database,
@@ -43,6 +51,8 @@ def __user_loader(user_id):
 def register(app):
     app.add_url_rule('/api/auth_token',
                      view_func=AuthToken.as_view('auth_token'))
+    app.add_url_rule('/api/logout',
+                     view_func=Logout.as_view('logout'))
 
     app.secret_key = app.config.get("SECRET_KEY")
     login_manager = LoginManager()

--- a/src/backend/expungeservice/endpoints/usersview.py
+++ b/src/backend/expungeservice/endpoints/usersview.py
@@ -1,6 +1,6 @@
 from flask.views import MethodView
 from flask import request, jsonify
-from flask_login import login_required, current_user
+from flask_login import login_required, current_user, fresh_login_required
 from werkzeug.security import generate_password_hash
 
 from flask import g
@@ -85,7 +85,7 @@ def put_from_user_id(user_id):
 
 
 class UsersView(MethodView):
-    @login_required
+    @fresh_login_required
     def get(self, user_id):
         """
         Fetch a single user's data if a user_id is specified.
@@ -163,7 +163,7 @@ class UsersView(MethodView):
 
         return jsonify(response_data), 201
 
-    @login_required
+    @fresh_login_required
     def put(self, user_id):
         """
         Update the user entry with new values for one or more of the user data fields:
@@ -173,12 +173,12 @@ class UsersView(MethodView):
 
 
 class UserView(MethodView):
-    @login_required
+    @fresh_login_required
     def get(self):
         user_id = current_user.user_id
         return get_from_user_id(user_id)
 
-    @login_required
+    @fresh_login_required
     def put(self):
         user_id = current_user.user_id
         return put_from_user_id(user_id)

--- a/src/backend/tests/endpoints/test_auth.py
+++ b/src/backend/tests/endpoints/test_auth.py
@@ -134,3 +134,13 @@ class TestAuth(EndpointShared):
 
         response = self.client.get('/api/test/user_protected')
         assert(response.status_code == 200) # TODO: Ideally this should be 401
+
+    def test_cookie_cannot_be_used_for_fresh_login(self):
+        self.login(self.user_data["user1"]["email"], self.user_data["user1"]["password"])
+
+        self.client.cookie_jar.clear(domain="localhost.local", path="/", name="session")
+
+        response = self.client.put(
+            "/api/users/%s" % self.user_data["user1"]["user_id"],
+            json={"password":"new_password"})
+        assert(response.status_code == 401)

--- a/src/frontend/src/redux/system/actions.ts
+++ b/src/frontend/src/redux/system/actions.ts
@@ -19,10 +19,15 @@ export function logIn(email: string, password: string): any {
   };
 }
 
-export function logOut() {
-  removeCookie();
-  return {
-    type: LOG_OUT
+export function logOut(): any {
+  return (dispatch: Dispatch) => {
+    return apiService(dispatch, {
+      url: '/api/logout',
+      method: 'post'
+    }).then((response: any) => {
+      removeCookie();
+      dispatch({ type: LOG_OUT });
+    });
   };
 }
 

--- a/src/frontend/src/redux/system/actions.ts
+++ b/src/frontend/src/redux/system/actions.ts
@@ -3,6 +3,7 @@ import { removeCookie, hasOeciToken } from '../../service/cookie-service';
 import history from '../../service/history';
 import { LOG_IN, LOG_OUT } from './types';
 import { Dispatch } from 'redux';
+import { AxiosError } from 'axios';
 
 export function logIn(email: string, password: string): any {
   return (dispatch: Dispatch) => {
@@ -24,10 +25,14 @@ export function logOut(): any {
     return apiService(dispatch, {
       url: '/api/logout',
       method: 'post'
-    }).then((response: any) => {
-      removeCookie();
-      dispatch({ type: LOG_OUT });
-    });
+    })
+      .then((response: any) => {
+        removeCookie();
+        dispatch({ type: LOG_OUT });
+      })
+      .catch((error: AxiosError) => {
+        alert(error.message);
+      });
   };
 }
 

--- a/src/frontend/src/service/api-service.ts
+++ b/src/frontend/src/service/api-service.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosPromise } from 'axios';
-import { logOut } from '../redux/system/actions';
+import { removeCookie } from './cookie-service';
+import { LOG_OUT } from '../redux/system/types';
 
 type Method = 'post' | 'delete' | 'get' | 'head' | 'delete' | 'options' | 'put';
 
@@ -21,7 +22,8 @@ export default function apiService(
 ): AxiosPromise {
   return axios.request(request).catch(error => {
     if (error.response && error.response.status === 401) {
-      dispatch(logOut());
+      removeCookie();
+      dispatch({ type: LOG_OUT });
     }
     return Promise.reject(error);
   });


### PR DESCRIPTION
Closes #504 

~~Relative to #521~~

Quoted from individual commits:

> Add backend endpoint for logout
> 
> Sync backend logout endpoint with frontend logout button
> Note that when the frontend makes a request to a protected endpoint and fails because the backend says they aren't logged in, the frontend logs out the user without hitting the backend logout endpoint again.
>
>  Ensure sensitive endpoints require fresh login
> Sensitive operations like changing passwords or looking up your own user information should require a fresh login.



