### PR TITLE
Rename BaseCharge to Charge and Charge to ChargeCreator

### DIFF
--- a/src/backend/expungeservice/crawler/crawler.py
+++ b/src/backend/expungeservice/crawler/crawler.py
@@ -1,6 +1,6 @@
 import requests
 
-from expungeservice.models.charge import Charge
+from expungeservice.models.charge_creator import ChargeCreator
 from expungeservice.models.disposition import Disposition
 from expungeservice.models.record import Record
 from expungeservice.crawler.parsers.param_parser import ParamParser
@@ -77,4 +77,4 @@ class Crawler:
         if case_parser.hashed_dispo_data.get(charge_id):
             charge['disposition'] = Disposition(case_parser.hashed_dispo_data[charge_id].get('date'),
                                                 case_parser.hashed_dispo_data[charge_id].get('ruling'))
-        return Charge.create(**charge)
+        return ChargeCreator.create(**charge)

--- a/src/backend/expungeservice/models/case.py
+++ b/src/backend/expungeservice/models/case.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime, date
 from typing import List, Optional
 
-from expungeservice.models.charge import Charge
+from expungeservice.models.charge_types.charge import Charge
 
 
 @dataclass

--- a/src/backend/expungeservice/models/charge_creator.py
+++ b/src/backend/expungeservice/models/charge_creator.py
@@ -3,14 +3,14 @@ import re
 from expungeservice.models.charge_classifier import ChargeClassifier
 
 
-class Charge:
+class ChargeCreator:
     @staticmethod
     def create(**kwargs):
         case = kwargs['case']
-        statute = Charge.__strip_non_alphanumeric_chars(kwargs['statute'])
+        statute = ChargeCreator.__strip_non_alphanumeric_chars(kwargs['statute'])
         level = kwargs['level']
-        chapter = Charge._set_chapter(kwargs['statute'])
-        section = Charge.__set_section(statute)
+        chapter = ChargeCreator._set_chapter(kwargs['statute'])
+        section = ChargeCreator.__set_section(statute)
         classification = ChargeClassifier(case.violation_type, statute, level, chapter, section).classify()
         kwargs['chapter'] = chapter
         kwargs['section'] = section

--- a/src/backend/expungeservice/models/charge_types/charge.py
+++ b/src/backend/expungeservice/models/charge_types/charge.py
@@ -3,12 +3,11 @@ import weakref
 from datetime import datetime
 from datetime import date as date_class
 from dateutil.relativedelta import relativedelta
-from expungeservice.models.disposition import Disposition
 from expungeservice.models.expungement_result import ExpungementResult, \
     TimeEligibility, EligibilityStatus, TypeEligibility
 
 
-class BaseCharge:
+class Charge:
 
     def __init__(self, case, name, statute, level, date, chapter, section, disposition=None):
         self.name = name

--- a/src/backend/expungeservice/models/charge_types/felony_class_a.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_a.py
@@ -1,8 +1,8 @@
-from expungeservice.models.charge_types.base_charge import BaseCharge
+from expungeservice.models.charge_types.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
-class FelonyClassA(BaseCharge):
+class FelonyClassA(Charge):
 
     def __init__(self, **kwargs):
         super(FelonyClassA, self).__init__(**kwargs)

--- a/src/backend/expungeservice/models/charge_types/felony_class_b.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_b.py
@@ -1,8 +1,8 @@
-from expungeservice.models.charge_types.base_charge import BaseCharge
+from expungeservice.models.charge_types.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
-class FelonyClassB(BaseCharge):
+class FelonyClassB(Charge):
 
     def __init__(self, **kwargs):
         super(FelonyClassB, self).__init__(**kwargs)

--- a/src/backend/expungeservice/models/charge_types/felony_class_c.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_c.py
@@ -1,8 +1,8 @@
-from expungeservice.models.charge_types.base_charge import BaseCharge
+from expungeservice.models.charge_types.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
-class FelonyClassC(BaseCharge):
+class FelonyClassC(Charge):
 
     def __init__(self, **kwargs):
         super(FelonyClassC, self).__init__(**kwargs)

--- a/src/backend/expungeservice/models/charge_types/juvenile_charge.py
+++ b/src/backend/expungeservice/models/charge_types/juvenile_charge.py
@@ -1,8 +1,8 @@
-from expungeservice.models.charge_types.base_charge import BaseCharge
+from expungeservice.models.charge_types.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
-class JuvenileCharge(BaseCharge):
+class JuvenileCharge(Charge):
 
     def __init__(self, **kwargs):
         super(JuvenileCharge, self).__init__(**kwargs)

--- a/src/backend/expungeservice/models/charge_types/level_800_traffic_crime.py
+++ b/src/backend/expungeservice/models/charge_types/level_800_traffic_crime.py
@@ -1,8 +1,8 @@
-from expungeservice.models.charge_types.base_charge import BaseCharge
+from expungeservice.models.charge_types.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
-class Level800TrafficCrime(BaseCharge):
+class Level800TrafficCrime(Charge):
 
     def __init__(self, **kwargs):
         super(Level800TrafficCrime, self).__init__(**kwargs)

--- a/src/backend/expungeservice/models/charge_types/list_b.py
+++ b/src/backend/expungeservice/models/charge_types/list_b.py
@@ -1,7 +1,7 @@
-from expungeservice.models.charge_types.base_charge import BaseCharge
+from expungeservice.models.charge_types.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
-class ListB(BaseCharge):
+class ListB(Charge):
 
     def __init__(self, **kwargs):
         super(ListB, self).__init__(**kwargs)

--- a/src/backend/expungeservice/models/charge_types/marijuana_ineligible.py
+++ b/src/backend/expungeservice/models/charge_types/marijuana_ineligible.py
@@ -1,7 +1,7 @@
-from expungeservice.models.charge_types.base_charge import BaseCharge
+from expungeservice.models.charge_types.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
-class MarijuanaIneligible(BaseCharge):
+class MarijuanaIneligible(Charge):
 
     def __init__(self, **kwargs):
         super(MarijuanaIneligible, self).__init__(**kwargs)

--- a/src/backend/expungeservice/models/charge_types/misdemeanor.py
+++ b/src/backend/expungeservice/models/charge_types/misdemeanor.py
@@ -1,7 +1,7 @@
-from expungeservice.models.charge_types.base_charge import BaseCharge
+from expungeservice.models.charge_types.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
-class Misdemeanor(BaseCharge):
+class Misdemeanor(Charge):
 
     def __init__(self, **kwargs):
         super(Misdemeanor, self).__init__(**kwargs)

--- a/src/backend/expungeservice/models/charge_types/non_traffic_violation.py
+++ b/src/backend/expungeservice/models/charge_types/non_traffic_violation.py
@@ -1,8 +1,8 @@
-from expungeservice.models.charge_types.base_charge import BaseCharge
+from expungeservice.models.charge_types.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
-class NonTrafficViolation(BaseCharge):
+class NonTrafficViolation(Charge):
 
     def __init__(self, **kwargs):
         super(NonTrafficViolation, self).__init__(**kwargs)

--- a/src/backend/expungeservice/models/charge_types/parking_ticket.py
+++ b/src/backend/expungeservice/models/charge_types/parking_ticket.py
@@ -1,8 +1,8 @@
-from expungeservice.models.charge_types.base_charge import BaseCharge
+from expungeservice.models.charge_types.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
-class ParkingTicket(BaseCharge):
+class ParkingTicket(Charge):
 
     def __init__(self, **kwargs):
         super(ParkingTicket, self).__init__(**kwargs)

--- a/src/backend/expungeservice/models/charge_types/person_crime.py
+++ b/src/backend/expungeservice/models/charge_types/person_crime.py
@@ -1,8 +1,8 @@
-from expungeservice.models.charge_types.base_charge import BaseCharge
+from expungeservice.models.charge_types.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
-class PersonCrime(BaseCharge):
+class PersonCrime(Charge):
 
     def __init__(self, **kwargs):
         super(PersonCrime, self).__init__(**kwargs)

--- a/src/backend/expungeservice/models/charge_types/schedule_1_p_c_s.py
+++ b/src/backend/expungeservice/models/charge_types/schedule_1_p_c_s.py
@@ -1,7 +1,7 @@
-from expungeservice.models.charge_types.base_charge import BaseCharge
+from expungeservice.models.charge_types.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
-class Schedule1PCS(BaseCharge):
+class Schedule1PCS(Charge):
 
     def __init__(self, **kwargs):
         super(Schedule1PCS, self).__init__(**kwargs)

--- a/src/backend/expungeservice/models/charge_types/unclassified_charge.py
+++ b/src/backend/expungeservice/models/charge_types/unclassified_charge.py
@@ -1,7 +1,7 @@
-from expungeservice.models.charge_types.base_charge import BaseCharge
+from expungeservice.models.charge_types.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
-class UnclassifiedCharge(BaseCharge):
+class UnclassifiedCharge(Charge):
 
     def __init__(self, **kwargs):
         super(UnclassifiedCharge, self).__init__(**kwargs)

--- a/src/backend/tests/factories/charge_factory.py
+++ b/src/backend/tests/factories/charge_factory.py
@@ -1,5 +1,5 @@
 from datetime import date as date_class
-from expungeservice.models.charge import Charge
+from expungeservice.models.charge_creator import ChargeCreator
 from expungeservice.models.disposition import Disposition
 from tests.factories.case_factory import CaseFactory
 
@@ -19,7 +19,7 @@ class ChargeFactory:
 
     @staticmethod
     def save(charge):
-        return Charge.create(**charge)
+        return ChargeCreator.create(**charge)
 
     @staticmethod
     def create(case=CaseFactory.create(),
@@ -33,7 +33,7 @@ class ChargeFactory:
             disposition = Disposition(date=date, ruling=ruling)
         kwargs = {'case': case, 'name': name, 'statute': statute, 'level': level, 'date': date, 'disposition': disposition}
 
-        return Charge.create(**kwargs)
+        return ChargeCreator.create(**kwargs)
 
     @staticmethod
     def create_dismissed_charge(case=CaseFactory.create(),
@@ -44,4 +44,4 @@ class ChargeFactory:
         disposition = Disposition(date=date_class.today().strftime('%m/%d/%Y'), ruling='Dismissed')
         kwargs = {'case': case, 'name': name, 'statute': statute, 'level': level, 'date': date, 'disposition': disposition}
 
-        return Charge.create(**kwargs)
+        return ChargeCreator.create(**kwargs)


### PR DESCRIPTION
The existing Charge class' sole purpose is to create one of the subclasses of BaseCharge. It makes sense to rename it to ChargeCreator as it doesn't ever instantiate itself (i.e., it is not a Charge). This opens up the name Charge to be used instead of BaseCharge.

Note I would have named ChargeCreator as ChargeFactory but we already have a ChargeFactory class in `tests/`.