### PR TITLE
Remove obsolete targets from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,8 @@
-.PHONY: install run clean
-
-install:
-	pipenv install
+.PHONY: clean
 
 clean:
-	rm -rf src/backend/*.egg-info
-	find . -type f -name \*~ | xargs rm
+	rm -rf src/backend/*.egg-info &
+	find . -type f -name \*~ | xargs rm &
 	find . -type f -name \*pyc | xargs rm
 
 IMAGES := database_image expungeservice_image webserver_image
@@ -30,22 +27,6 @@ dev_build:
 
 dev_logs:
 	docker-compose -f docker-compose.dev.yml logs -f
-
-dev_deploy: $(IMAGES) dev_start
-	echo $@
-
-dev_start:
-	# This restarts the docker stack without rebuilding the underlying docker images;
-	# to reflect  code changes in the new stack you'll need to rebuild the altered image(s)
-	# with the appropriate make target,
-	# or with `make dev` which rebuilds all three images.
-
-	echo $@
-	docker stack deploy -c docker-compose.dev.yml $(STACK_NAME)
-
-dev_stop:
-	echo $@
-	docker stack rm $(STACK_NAME)
 
 dev_psql:
 	docker exec -ti $$(docker ps -qf name=$(DB_CONTAINER_NAME)) psql -U postgres -d $(PGDATABASE)
@@ -76,9 +57,6 @@ applogs:
 weblogs:
 	docker logs --details -ft $$(docker ps -qf name=$(FRONTEND_CONTAINER_NAME))
 
-test:
-	pipenv run pytest --ignore=src/frontend/
-
 dev_test:
 	docker exec -t $$(docker ps -qf name=$(BACKEND_CONTAINER_NAME)) pytest
 
@@ -87,7 +65,3 @@ dev_drop_database:
 
 dev_mock_oeci_up:
 	docker-compose -f docker-compose.dev.yml -f src/frontend/developerUtils/docker-compose.mock-oeci.yml up -d
-
-.PHONY: $(REQUIREMENTS_TXT)
-$(REQUIREMENTS_TXT):
-	pipenv lock -r > $@

--- a/Makefile
+++ b/Makefile
@@ -65,3 +65,7 @@ dev_drop_database:
 
 dev_mock_oeci_up:
 	docker-compose -f docker-compose.dev.yml -f src/frontend/developerUtils/docker-compose.mock-oeci.yml up -d
+
+.PHONY: $(REQUIREMENTS_TXT)
+$(REQUIREMENTS_TXT):
+	pipenv lock -r > $@

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,6 @@ clean:
 	find . -type f -name \*~ | xargs rm &
 	find . -type f -name \*pyc | xargs rm
 
-IMAGES := database_image expungeservice_image webserver_image
-
 STACK_NAME := recordexpungpdx
 PGDATABASE := record_expunge
 DB_CONTAINER_NAME := db


### PR DESCRIPTION
The following make targets are no longer needed:

- `install`, `$requirements.txt` : we no longer use pipenv natively
- `dev_start`, `dev_stop`, and `dev_deploy`: we no longer use `dev stack` commands for running docker
- `test`: we no longer use pytest natively, and `dev_test` is the correct usage. 


Also added `&` to the `make clean` because failure on line 2 (if no files match) causes line 3 to not run, potentially leaving behind some artifacts.