### PR TITLE
Refactor charge classes

### DIFF
--- a/src/backend/expungeservice/models/charge_types/charge.py
+++ b/src/backend/expungeservice/models/charge_types/charge.py
@@ -3,8 +3,7 @@ import weakref
 from datetime import datetime
 from datetime import date as date_class
 from dateutil.relativedelta import relativedelta
-from expungeservice.models.expungement_result import ExpungementResult, \
-    TimeEligibility, EligibilityStatus, TypeEligibility
+from expungeservice.models.expungement_result import ExpungementResult, TimeEligibility, EligibilityStatus
 
 
 class Charge:
@@ -22,7 +21,7 @@ class Charge:
         self._case = weakref.ref(case)
 
     def _default_type_eligibility(self):
-        return TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason='Examine')
+        raise NotImplementedError
 
     def case(self):
         return self._case

--- a/src/backend/expungeservice/models/charge_types/charge.py
+++ b/src/backend/expungeservice/models/charge_types/charge.py
@@ -15,13 +15,13 @@ class Charge:
         self.level = level
         self.date = datetime.date(datetime.strptime(date, '%m/%d/%Y'))
         self.disposition = disposition
-        type_eligibility = self.default_type_eligibility()
+        type_eligibility = self._default_type_eligibility()
         self.expungement_result = ExpungementResult(type_eligibility=type_eligibility, time_eligibility=None)
         self._chapter = chapter
         self._section = section
         self._case = weakref.ref(case)
 
-    def default_type_eligibility(self):
+    def _default_type_eligibility(self):
         return TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason='Examine')
 
     def case(self):

--- a/src/backend/expungeservice/models/charge_types/charge.py
+++ b/src/backend/expungeservice/models/charge_types/charge.py
@@ -52,9 +52,9 @@ class Charge:
             date_will_be_eligible = date_of_eligibility
         else:
             date_will_be_eligible = None
-        time_eligibility = TimeEligibility(status = False, reason = reason, date_will_be_eligible = date_will_be_eligible)
+        time_eligibility = TimeEligibility(status=False, reason=reason, date_will_be_eligible=date_will_be_eligible)
         self.expungement_result.time_eligibility = time_eligibility
 
     def set_time_eligible(self, reason=''):
-        time_eligibility = TimeEligibility(status = True, reason = reason, date_will_be_eligible = None)
+        time_eligibility = TimeEligibility(status=True, reason=reason, date_will_be_eligible=None)
         self.expungement_result.time_eligibility = time_eligibility

--- a/src/backend/expungeservice/models/charge_types/felony_class_a.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_a.py
@@ -4,7 +4,7 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class FelonyClassA(Charge):
 
-    def default_type_eligibility(self):
+    def _default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')
         else:

--- a/src/backend/expungeservice/models/charge_types/felony_class_a.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_a.py
@@ -6,6 +6,6 @@ class FelonyClassA(Charge):
 
     def _default_type_eligibility(self):
         if self.acquitted():
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')
+            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason='Eligible under 137.225(1)(b)')
         else:
-            return TypeEligibility(EligibilityStatus.INELIGIBLE, reason = 'Ineligible under 137.225(5)')
+            return TypeEligibility(EligibilityStatus.INELIGIBLE, reason='Ineligible under 137.225(5)')

--- a/src/backend/expungeservice/models/charge_types/felony_class_a.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_a.py
@@ -4,9 +4,6 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class FelonyClassA(Charge):
 
-    def __init__(self, **kwargs):
-        super(FelonyClassA, self).__init__(**kwargs)
-
     def default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')

--- a/src/backend/expungeservice/models/charge_types/felony_class_b.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_b.py
@@ -6,6 +6,6 @@ class FelonyClassB(Charge):
 
     def _default_type_eligibility(self):
         if self.acquitted():
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')
+            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason='Eligible under 137.225(1)(b)')
         else:
-            return TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason = 'Further Analysis Needed')
+            return TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason='Further Analysis Needed')

--- a/src/backend/expungeservice/models/charge_types/felony_class_b.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_b.py
@@ -4,7 +4,7 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class FelonyClassB(Charge):
 
-    def default_type_eligibility(self):
+    def _default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')
         else:

--- a/src/backend/expungeservice/models/charge_types/felony_class_b.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_b.py
@@ -4,9 +4,6 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class FelonyClassB(Charge):
 
-    def __init__(self, **kwargs):
-        super(FelonyClassB, self).__init__(**kwargs)
-
     def default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')

--- a/src/backend/expungeservice/models/charge_types/felony_class_c.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_c.py
@@ -6,6 +6,6 @@ class FelonyClassC(Charge):
 
     def _default_type_eligibility(self):
         if self.acquitted():
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')
+            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason='Eligible under 137.225(1)(b)')
         else:
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(5)(b)')
+            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason='Eligible under 137.225(5)(b)')

--- a/src/backend/expungeservice/models/charge_types/felony_class_c.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_c.py
@@ -4,7 +4,7 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class FelonyClassC(Charge):
 
-    def default_type_eligibility(self):
+    def _default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')
         else:

--- a/src/backend/expungeservice/models/charge_types/felony_class_c.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_c.py
@@ -4,9 +4,6 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class FelonyClassC(Charge):
 
-    def __init__(self, **kwargs):
-        super(FelonyClassC, self).__init__(**kwargs)
-
     def default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')

--- a/src/backend/expungeservice/models/charge_types/juvenile_charge.py
+++ b/src/backend/expungeservice/models/charge_types/juvenile_charge.py
@@ -4,7 +4,7 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class JuvenileCharge(Charge):
 
-    def default_type_eligibility(self):
+    def _default_type_eligibility(self):
         return TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason = 'Juvenile Charge : Needs further analysis')
 
     def skip_analysis(self):

--- a/src/backend/expungeservice/models/charge_types/juvenile_charge.py
+++ b/src/backend/expungeservice/models/charge_types/juvenile_charge.py
@@ -4,9 +4,6 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class JuvenileCharge(Charge):
 
-    def __init__(self, **kwargs):
-        super(JuvenileCharge, self).__init__(**kwargs)
-
     def default_type_eligibility(self):
         return TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason = 'Juvenile Charge : Needs further analysis')
 

--- a/src/backend/expungeservice/models/charge_types/juvenile_charge.py
+++ b/src/backend/expungeservice/models/charge_types/juvenile_charge.py
@@ -5,7 +5,7 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 class JuvenileCharge(Charge):
 
     def _default_type_eligibility(self):
-        return TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason = 'Juvenile Charge : Needs further analysis')
+        return TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason='Juvenile Charge : Needs further analysis')
 
     def skip_analysis(self):
         return True

--- a/src/backend/expungeservice/models/charge_types/level_800_traffic_crime.py
+++ b/src/backend/expungeservice/models/charge_types/level_800_traffic_crime.py
@@ -4,9 +4,6 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class Level800TrafficCrime(Charge):
 
-    def __init__(self, **kwargs):
-        super(Level800TrafficCrime, self).__init__(**kwargs)
-
     def default_type_eligibility(self):
         if self._expungeable():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')

--- a/src/backend/expungeservice/models/charge_types/level_800_traffic_crime.py
+++ b/src/backend/expungeservice/models/charge_types/level_800_traffic_crime.py
@@ -4,7 +4,7 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class Level800TrafficCrime(Charge):
 
-    def default_type_eligibility(self):
+    def _default_type_eligibility(self):
         if self._expungeable():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')
         else:

--- a/src/backend/expungeservice/models/charge_types/level_800_traffic_crime.py
+++ b/src/backend/expungeservice/models/charge_types/level_800_traffic_crime.py
@@ -6,9 +6,9 @@ class Level800TrafficCrime(Charge):
 
     def _default_type_eligibility(self):
         if self._expungeable():
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')
+            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason='Eligible under 137.225(1)(b)')
         else:
-            return TypeEligibility(EligibilityStatus.INELIGIBLE, reason = 'Ineligible under 137.225(5)')
+            return TypeEligibility(EligibilityStatus.INELIGIBLE, reason='Ineligible under 137.225(5)')
 
     def skip_analysis(self):
         if self._affects_time_analysis():

--- a/src/backend/expungeservice/models/charge_types/list_b.py
+++ b/src/backend/expungeservice/models/charge_types/list_b.py
@@ -3,7 +3,7 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class ListB(Charge):
 
-    def default_type_eligibility(self):
+    def _default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')
         else:

--- a/src/backend/expungeservice/models/charge_types/list_b.py
+++ b/src/backend/expungeservice/models/charge_types/list_b.py
@@ -1,10 +1,11 @@
 from expungeservice.models.charge_types.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
+
 class ListB(Charge):
 
     def _default_type_eligibility(self):
         if self.acquitted():
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')
+            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason='Eligible under 137.225(1)(b)')
         else:
-            return TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason = 'Further Analysis Needed')
+            return TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason='Further Analysis Needed')

--- a/src/backend/expungeservice/models/charge_types/list_b.py
+++ b/src/backend/expungeservice/models/charge_types/list_b.py
@@ -3,9 +3,6 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class ListB(Charge):
 
-    def __init__(self, **kwargs):
-        super(ListB, self).__init__(**kwargs)
-
     def default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')

--- a/src/backend/expungeservice/models/charge_types/marijuana_ineligible.py
+++ b/src/backend/expungeservice/models/charge_types/marijuana_ineligible.py
@@ -3,7 +3,7 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class MarijuanaIneligible(Charge):
 
-    def default_type_eligibility(self):
+    def _default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')
         else:

--- a/src/backend/expungeservice/models/charge_types/marijuana_ineligible.py
+++ b/src/backend/expungeservice/models/charge_types/marijuana_ineligible.py
@@ -1,10 +1,11 @@
 from expungeservice.models.charge_types.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
+
 class MarijuanaIneligible(Charge):
 
     def _default_type_eligibility(self):
         if self.acquitted():
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')
+            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason='Eligible under 137.225(1)(b)')
         else:
-            return TypeEligibility(EligibilityStatus.INELIGIBLE, reason = 'Ineligible under 137.226')
+            return TypeEligibility(EligibilityStatus.INELIGIBLE, reason='Ineligible under 137.226')

--- a/src/backend/expungeservice/models/charge_types/marijuana_ineligible.py
+++ b/src/backend/expungeservice/models/charge_types/marijuana_ineligible.py
@@ -3,9 +3,6 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class MarijuanaIneligible(Charge):
 
-    def __init__(self, **kwargs):
-        super(MarijuanaIneligible, self).__init__(**kwargs)
-
     def default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')

--- a/src/backend/expungeservice/models/charge_types/misdemeanor.py
+++ b/src/backend/expungeservice/models/charge_types/misdemeanor.py
@@ -3,7 +3,7 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class Misdemeanor(Charge):
 
-    def default_type_eligibility(self):
+    def _default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')
         else:

--- a/src/backend/expungeservice/models/charge_types/misdemeanor.py
+++ b/src/backend/expungeservice/models/charge_types/misdemeanor.py
@@ -1,10 +1,11 @@
 from expungeservice.models.charge_types.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
+
 class Misdemeanor(Charge):
 
     def _default_type_eligibility(self):
         if self.acquitted():
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')
+            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason='Eligible under 137.225(1)(b)')
         else:
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(5)(b)')
+            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason='Eligible under 137.225(5)(b)')

--- a/src/backend/expungeservice/models/charge_types/misdemeanor.py
+++ b/src/backend/expungeservice/models/charge_types/misdemeanor.py
@@ -3,9 +3,6 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class Misdemeanor(Charge):
 
-    def __init__(self, **kwargs):
-        super(Misdemeanor, self).__init__(**kwargs)
-
     def default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')

--- a/src/backend/expungeservice/models/charge_types/non_traffic_violation.py
+++ b/src/backend/expungeservice/models/charge_types/non_traffic_violation.py
@@ -4,7 +4,7 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class NonTrafficViolation(Charge):
 
-    def default_type_eligibility(self):
+    def _default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')
         else:

--- a/src/backend/expungeservice/models/charge_types/non_traffic_violation.py
+++ b/src/backend/expungeservice/models/charge_types/non_traffic_violation.py
@@ -6,6 +6,6 @@ class NonTrafficViolation(Charge):
 
     def _default_type_eligibility(self):
         if self.acquitted():
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')
+            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason='Eligible under 137.225(1)(b)')
         else:
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(5)(d)')
+            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason='Eligible under 137.225(5)(d)')

--- a/src/backend/expungeservice/models/charge_types/non_traffic_violation.py
+++ b/src/backend/expungeservice/models/charge_types/non_traffic_violation.py
@@ -4,9 +4,6 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class NonTrafficViolation(Charge):
 
-    def __init__(self, **kwargs):
-        super(NonTrafficViolation, self).__init__(**kwargs)
-
     def default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')

--- a/src/backend/expungeservice/models/charge_types/parking_ticket.py
+++ b/src/backend/expungeservice/models/charge_types/parking_ticket.py
@@ -4,7 +4,7 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class ParkingTicket(Charge):
 
-    def default_type_eligibility(self):
+    def _default_type_eligibility(self):
         return TypeEligibility(EligibilityStatus.INELIGIBLE, reason = 'Ineligible under 137.225(5)')
 
     def skip_analysis(self):

--- a/src/backend/expungeservice/models/charge_types/parking_ticket.py
+++ b/src/backend/expungeservice/models/charge_types/parking_ticket.py
@@ -5,7 +5,7 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 class ParkingTicket(Charge):
 
     def _default_type_eligibility(self):
-        return TypeEligibility(EligibilityStatus.INELIGIBLE, reason = 'Ineligible under 137.225(5)')
+        return TypeEligibility(EligibilityStatus.INELIGIBLE, reason='Ineligible under 137.225(5)')
 
     def skip_analysis(self):
         return True

--- a/src/backend/expungeservice/models/charge_types/parking_ticket.py
+++ b/src/backend/expungeservice/models/charge_types/parking_ticket.py
@@ -4,9 +4,6 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class ParkingTicket(Charge):
 
-    def __init__(self, **kwargs):
-        super(ParkingTicket, self).__init__(**kwargs)
-
     def default_type_eligibility(self):
         return TypeEligibility(EligibilityStatus.INELIGIBLE, reason = 'Ineligible under 137.225(5)')
 

--- a/src/backend/expungeservice/models/charge_types/person_crime.py
+++ b/src/backend/expungeservice/models/charge_types/person_crime.py
@@ -6,6 +6,6 @@ class PersonCrime(Charge):
 
     def _default_type_eligibility(self):
         if self.acquitted():
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')
+            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason='Eligible under 137.225(1)(b)')
         else:
-            return TypeEligibility(EligibilityStatus.INELIGIBLE, reason = 'Ineligible under 137.225(5)')
+            return TypeEligibility(EligibilityStatus.INELIGIBLE, reason='Ineligible under 137.225(5)')

--- a/src/backend/expungeservice/models/charge_types/person_crime.py
+++ b/src/backend/expungeservice/models/charge_types/person_crime.py
@@ -4,7 +4,7 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class PersonCrime(Charge):
 
-    def default_type_eligibility(self):
+    def _default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')
         else:

--- a/src/backend/expungeservice/models/charge_types/person_crime.py
+++ b/src/backend/expungeservice/models/charge_types/person_crime.py
@@ -4,9 +4,6 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class PersonCrime(Charge):
 
-    def __init__(self, **kwargs):
-        super(PersonCrime, self).__init__(**kwargs)
-
     def default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')

--- a/src/backend/expungeservice/models/charge_types/schedule_1_p_c_s.py
+++ b/src/backend/expungeservice/models/charge_types/schedule_1_p_c_s.py
@@ -3,9 +3,6 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class Schedule1PCS(Charge):
 
-    def __init__(self, **kwargs):
-        super(Schedule1PCS, self).__init__(**kwargs)
-
     def default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')

--- a/src/backend/expungeservice/models/charge_types/schedule_1_p_c_s.py
+++ b/src/backend/expungeservice/models/charge_types/schedule_1_p_c_s.py
@@ -3,7 +3,7 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class Schedule1PCS(Charge):
 
-    def default_type_eligibility(self):
+    def _default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')
         else:

--- a/src/backend/expungeservice/models/charge_types/schedule_1_p_c_s.py
+++ b/src/backend/expungeservice/models/charge_types/schedule_1_p_c_s.py
@@ -1,10 +1,11 @@
 from expungeservice.models.charge_types.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
+
 class Schedule1PCS(Charge):
 
     def _default_type_eligibility(self):
         if self.acquitted():
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')
+            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason='Eligible under 137.225(1)(b)')
         else:
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(5)(C)')
+            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason='Eligible under 137.225(5)(C)')

--- a/src/backend/expungeservice/models/charge_types/unclassified_charge.py
+++ b/src/backend/expungeservice/models/charge_types/unclassified_charge.py
@@ -1,10 +1,11 @@
 from expungeservice.models.charge_types.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
+
 class UnclassifiedCharge(Charge):
 
     def _default_type_eligibility(self):
         if self.acquitted():
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')
+            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason='Eligible under 137.225(1)(b)')
         else:
-            return TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason = 'Examine')
+            return TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason='Examine')

--- a/src/backend/expungeservice/models/charge_types/unclassified_charge.py
+++ b/src/backend/expungeservice/models/charge_types/unclassified_charge.py
@@ -3,7 +3,7 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class UnclassifiedCharge(Charge):
 
-    def default_type_eligibility(self):
+    def _default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')
         else:

--- a/src/backend/expungeservice/models/charge_types/unclassified_charge.py
+++ b/src/backend/expungeservice/models/charge_types/unclassified_charge.py
@@ -3,9 +3,6 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 class UnclassifiedCharge(Charge):
 
-    def __init__(self, **kwargs):
-        super(UnclassifiedCharge, self).__init__(**kwargs)
-
     def default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason = 'Eligible under 137.225(1)(b)')


### PR DESCRIPTION
It's best to review the commit message for the reasoning behind each refactoring. 

- Removed init method in charge subclasses
- Made default_type_eligibility method protected
- Replace default value with NotImplementedError
- Fixed spacing to comply with PEP8