### PR TITLE
Integrate mypy (an optional static type checker for Python) into backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ weblogs:
 	docker logs --details -ft $$(docker ps -qf name=$(FRONTEND_CONTAINER_NAME))
 
 dev_test:
+	docker exec -t $$(docker ps -qf name=$(BACKEND_CONTAINER_NAME)) mypy
 	docker exec -t $$(docker ps -qf name=$(BACKEND_CONTAINER_NAME)) pytest
 
 dev_drop_database:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The app is deployed on the webapp hosting service, [Heroku](https://www.heroku.c
 
 Our latest dev version (this repo's master branch) is publicly viewable! Here: https://recordexpungpdx.herokuapp.com/
 
-**Our dev environment** is entirely containerized with Docker, and no other dependencies need to be installed natively. Within the Docker stack, we use Python's [pipenv](https://docs.pipenv.org/en/latest/) for maintaining backend dependencies, and [pytest](https://pytest.org/en/latest/) to develop backend code. We use [NPM](https://www.npmjs.com/) to develop and build the frontend code. Docker is used to build and deploy the app stack for both local development and for deployment to the web. A postgres database runs as a service within the docker stack, which exposes a connection locally for development and testing.
+**Our dev environment** is entirely containerized with Docker, and no other dependencies need to be installed natively. We use Python's [pipenv](https://docs.pipenv.org/en/latest/) for maintaining backend dependencies. We use [mypy](http://mypy-lang.org/) to type check any optional typings and [pytest](https://pytest.org/en/latest/) to test backend code. We use [NPM](https://www.npmjs.com/) to develop and build the frontend code. Docker is used to build and deploy the app stack for both local development and for deployment to the web. A postgres database runs as a service within the docker stack, which exposes a connection locally for development and testing.
 
 ## Installation
 

--- a/src/backend/Pipfile
+++ b/src/backend/Pipfile
@@ -20,6 +20,7 @@ uwsgi = "*"
 cryptography = "*"
 flask-login = "==0.4.1"
 dacite = "==1.0.2"
+mypy = "==0.740"
 
 [dev-packages]
 

--- a/src/backend/Pipfile.lock
+++ b/src/backend/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f6989501d7413cfd4037cbb8178674f37b7846318aac4d06ef97b469fa51cf46"
+            "sha256": "2dff8506b3899ed67bab8e161908e24520c1bd3172658b2883f3bb8449bfadbc"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -249,6 +249,33 @@
             ],
             "version": "==7.2.0"
         },
+        "mypy": {
+            "hashes": [
+                "sha256:1521c186a3d200c399bd5573c828ea2db1362af7209b2adb1bb8532cea2fb36f",
+                "sha256:31a046ab040a84a0fc38bc93694876398e62bc9f35eca8ccbf6418b7297f4c00",
+                "sha256:3b1a411909c84b2ae9b8283b58b48541654b918e8513c20a400bb946aa9111ae",
+                "sha256:48c8bc99380575deb39f5d3400ebb6a8a1cb5cc669bbba4d3bb30f904e0a0e7d",
+                "sha256:540c9caa57a22d0d5d3c69047cc9dd0094d49782603eb03069821b41f9e970e9",
+                "sha256:672e418425d957e276c291930a3921b4a6413204f53fe7c37cad7bc57b9a3391",
+                "sha256:6ed3b9b3fdc7193ea7aca6f3c20549b377a56f28769783a8f27191903a54170f",
+                "sha256:9371290aa2cad5ad133e4cdc43892778efd13293406f7340b9ffe99d5ec7c1d9",
+                "sha256:ace6ac1d0f87d4072f05b5468a084a45b4eda970e4d26704f201e06d47ab2990",
+                "sha256:b428f883d2b3fe1d052c630642cc6afddd07d5cd7873da948644508be3b9d4a7",
+                "sha256:d5bf0e6ec8ba346a2cf35cb55bf4adfddbc6b6576fcc9e10863daa523e418dbb",
+                "sha256:d7574e283f83c08501607586b3167728c58e8442947e027d2d4c7dcd6d82f453",
+                "sha256:dc889c84241a857c263a2b1cd1121507db7d5b5f5e87e77147097230f374d10b",
+                "sha256:f4748697b349f373002656bf32fede706a0e713d67bfdcf04edf39b1f61d46eb"
+            ],
+            "index": "pypi",
+            "version": "==0.740"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
+                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
+            ],
+            "version": "==0.4.3"
+        },
         "packaging": {
             "hashes": [
                 "sha256:28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47",
@@ -265,10 +292,12 @@
         },
         "psycopg2": {
             "hashes": [
+                "sha256:4212ca404c4445dc5746c0d68db27d2cbfb87b523fe233dc84ecd24062e35677",
                 "sha256:47fc642bf6f427805daf52d6e52619fe0637648fe27017062d898f3bf891419d",
                 "sha256:72772181d9bad1fa349792a1e7384dde56742c14af2b9986013eb94a240f005b",
                 "sha256:8396be6e5ff844282d4d49b81631772f80dabae5658d432202faf101f5283b7c",
                 "sha256:893c11064b347b24ecdd277a094413e1954f8a4e8cdaf7ffbe7ca3db87c103f0",
+                "sha256:92a07dfd4d7c325dd177548c4134052d4842222833576c8391aab6f74038fc3f",
                 "sha256:965c4c93e33e6984d8031f74e51227bd755376a9df6993774fd5b6fb3288b1f4",
                 "sha256:9ab75e0b2820880ae24b7136c4d230383e07db014456a476d096591172569c38",
                 "sha256:b0845e3bdd4aa18dc2f9b6fb78fbd3d9d371ad167fd6d1b7ad01c0a6cdad4fc6",
@@ -303,18 +332,18 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:4acadc9a2b96c19fe00932a38ca63e601180c39a189a696abce1eaab641447e1",
-                "sha256:61b5ed888beab19ddccab3478910e2076a6b5a0295dffc43021890e136edf764"
+                "sha256:20f995ecd72f2a1f4bf6b072b63b22e2eb457836601e76d6e5dfcd75436acc1f",
+                "sha256:4ca62001be367f01bd3e92ecbb79070272a9d4964dce6a48a82ff0b8bc7e683a"
             ],
-            "version": "==2.4.4"
+            "version": "==2.4.5"
         },
         "pytest": {
             "hashes": [
-                "sha256:27abc3fef618a01bebb1f0d6d303d2816a99aa87a5968ebc32fe971be91eb1e6",
-                "sha256:58cee9e09242937e136dbb3dab466116ba20d6b7828c7620f23947f37eb4dae4"
+                "sha256:15837d2880cb94821087bc07476892ea740696b20e90288fd6c19e44b435abdb",
+                "sha256:b6cf7ad9064049ee486586b3a0ddd70dc5136c40e1147e7d286efd77ba66c5eb"
             ],
             "index": "pypi",
-            "version": "==5.2.2"
+            "version": "==5.2.3"
         },
         "python-dateutil": {
             "hashes": [
@@ -359,12 +388,45 @@
             ],
             "version": "==1.13.0"
         },
+        "typed-ast": {
+            "hashes": [
+                "sha256:1170afa46a3799e18b4c977777ce137bb53c7485379d9706af8a59f2ea1aa161",
+                "sha256:18511a0b3e7922276346bcb47e2ef9f38fb90fd31cb9223eed42c85d1312344e",
+                "sha256:262c247a82d005e43b5b7f69aff746370538e176131c32dda9cb0f324d27141e",
+                "sha256:2b907eb046d049bcd9892e3076c7a6456c93a25bebfe554e931620c90e6a25b0",
+                "sha256:354c16e5babd09f5cb0ee000d54cfa38401d8b8891eefa878ac772f827181a3c",
+                "sha256:48e5b1e71f25cfdef98b013263a88d7145879fbb2d5185f2a0c79fa7ebbeae47",
+                "sha256:4e0b70c6fc4d010f8107726af5fd37921b666f5b31d9331f0bd24ad9a088e631",
+                "sha256:630968c5cdee51a11c05a30453f8cd65e0cc1d2ad0d9192819df9978984529f4",
+                "sha256:66480f95b8167c9c5c5c87f32cf437d585937970f3fc24386f313a4c97b44e34",
+                "sha256:71211d26ffd12d63a83e079ff258ac9d56a1376a25bc80b1cdcdf601b855b90b",
+                "sha256:7954560051331d003b4e2b3eb822d9dd2e376fa4f6d98fee32f452f52dd6ebb2",
+                "sha256:838997f4310012cf2e1ad3803bce2f3402e9ffb71ded61b5ee22617b3a7f6b6e",
+                "sha256:95bd11af7eafc16e829af2d3df510cecfd4387f6453355188342c3e79a2ec87a",
+                "sha256:bc6c7d3fa1325a0c6613512a093bc2a2a15aeec350451cbdf9e1d4bffe3e3233",
+                "sha256:cc34a6f5b426748a507dd5d1de4c1978f2eb5626d51326e43280941206c209e1",
+                "sha256:d755f03c1e4a51e9b24d899561fec4ccaf51f210d52abdf8c07ee2849b212a36",
+                "sha256:d7c45933b1bdfaf9f36c579671fec15d25b06c8398f113dab64c18ed1adda01d",
+                "sha256:d896919306dd0aa22d0132f62a1b78d11aaf4c9fc5b3410d3c666b818191630a",
+                "sha256:fdc1c9bbf79510b76408840e009ed65958feba92a88833cdceecff93ae8fff66",
+                "sha256:ffde2fbfad571af120fcbfbbc61c72469e72f550d676c3342492a9dfdefb8f12"
+            ],
+            "version": "==1.4.0"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:091ecc894d5e908ac75209f10d5b4f118fbdb2eb1ede6a63544054bb1edb41f2",
+                "sha256:910f4656f54de5993ad9304959ce9bb903f90aadc7c67a0bef07e678014e892d",
+                "sha256:cf8b63fedea4d89bab840ecbb93e75578af28f76f66c35889bd7065f5af88575"
+            ],
+            "version": "==3.7.4.1"
+        },
         "urllib3": {
             "hashes": [
-                "sha256:3de946ffbed6e6746608990594d08faac602528ac7015ac28d33cee6a45b7398",
-                "sha256:9a107b99a5393caf59c7aa3c1249c16e6879447533d0887f4336dde834c7be86"
+                "sha256:a8a318824cc77d1fd4b2bec2ded92646630d7fe8619497b142c84a9e6f5a7293",
+                "sha256:f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745"
             ],
-            "version": "==1.25.6"
+            "version": "==1.25.7"
         },
         "uwsgi": {
             "hashes": [

--- a/src/backend/expungeservice/app.py
+++ b/src/backend/expungeservice/app.py
@@ -36,7 +36,7 @@ def create_app(env_name):
 
 def __register_endpoints(app):
     prefix = "expungeservice.endpoints."
-    for _, module_name, _ in pkgutil.iter_modules(endpoints.__path__):
+    for _, module_name, _ in pkgutil.iter_modules(endpoints.__path__): # type: ignore  # mypy issue #1422
         module = import_module(prefix + module_name)
         register_fn = getattr(module, "register")
         register_fn(app)

--- a/src/backend/expungeservice/crawler/crawler.py
+++ b/src/backend/expungeservice/crawler/crawler.py
@@ -14,7 +14,7 @@ class Crawler:
 
     def __init__(self):
         self.session = requests.Session()
-        self.response = requests.Response
+        self.response = requests.Response()
         self.result = RecordParser()
 
     def login(self, username, password, close_session=False):

--- a/src/backend/expungeservice/database/database.py
+++ b/src/backend/expungeservice/database/database.py
@@ -126,7 +126,7 @@ def get_database():
         In the dev environment, we use a set of env vars for the db conn:
         '''
         host = os.environ['PGHOST']
-        port = os.environ['PGPORT']
+        port = int(os.environ['PGPORT'])
         name = os.environ['PGDATABASE']
         username = os.environ['POSTGRES_USERNAME']
         password = os.environ['POSTGRES_PASSWORD']

--- a/src/backend/expungeservice/endpoints/oeci_login.py
+++ b/src/backend/expungeservice/endpoints/oeci_login.py
@@ -52,7 +52,7 @@ class OeciLogin(MethodView):
             secure=os.getenv("TIER") == "production",
             httponly=False,
             samesite="strict",
-            expires=time.time() + 15 * 60,  # 15 minutes
+            expires=time.time() + 15 * 60, # type: ignore # 15 minutes
             value=encrypted_credentials)
 
         return response, 201

--- a/src/backend/expungeservice/endpoints/usersview.py
+++ b/src/backend/expungeservice/endpoints/usersview.py
@@ -1,3 +1,5 @@
+from typing import Dict, List
+
 from flask.views import MethodView
 from flask import request, jsonify
 from flask_login import login_required, current_user, fresh_login_required
@@ -102,7 +104,7 @@ class UsersView(MethodView):
 
             user_db_data = user_db_util.fetchall(g.database)
 
-            response_data = {"users": []}
+            response_data: Dict[str, List[Dict[str, str]]] = {"users": []}
             for user_entry in user_db_data:
                 response_data["users"].append({
                     "user_id": user_entry["user_id"],

--- a/src/backend/expungeservice/models/record.py
+++ b/src/backend/expungeservice/models/record.py
@@ -1,3 +1,8 @@
+from typing import List
+
+from expungeservice.models.charge_types.charge import Charge
+
+
 class Record:
 
     def __init__(self, list_cases):
@@ -6,7 +11,7 @@ class Record:
 
     @property
     def charges(self):
-        list_charges = []
+        list_charges: List[Charge] = []
 
         for case in self.cases:
             list_charges.extend(case.charges)
@@ -20,4 +25,4 @@ class Record:
         for case in self.cases:
             total += case.get_balance_due_in_cents()
 
-        return round(total/100.0, 2)
+        return round(total / 100.0, 2)

--- a/src/backend/expungeservice/request/__init__.py
+++ b/src/backend/expungeservice/request/__init__.py
@@ -1,2 +1,1 @@
 from .request import *
-from . import error

--- a/src/backend/mypy.ini
+++ b/src/backend/mypy.ini
@@ -1,0 +1,12 @@
+[mypy]
+python_version = 3.7
+files = expungeservice/**/*.py
+namespace_packages = True
+ignore_missing_imports = True
+check_untyped_defs = True
+
+[mypy-expungeservice.serializer.*]
+ignore_errors = True
+
+[mypy-expungeservice.crawler.parsers.*]
+ignore_errors = True


### PR DESCRIPTION
This PR should barely affect anyone who isn't using the [new types feature in Python](https://docs.python.org/3/library/typing.html). Most commonly, it may occasionally require you to specify the type of the variable when using an empty list such as `list_charges: List[Charge] = []` but I would argue that this is a helpful use of types for a reader. Worst case just annotate your failing line with `# type: ignore` and `mypy` will move on. So far in this project's backend, I've been the only one to use types, albeit sparingly for now. As the project becomes larger, we should start adding types to our codebase.

The type checker doesn't apply to the tests/ or expungeservice/serializer/ folders for now.

