### PR TITLE
Update JSON response structure of search endpoint

### DIFF
--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -57,9 +57,9 @@ class Charge:
             date_will_be_eligible = date_of_eligibility
         else:
             date_will_be_eligible = None
-        time_eligibility = TimeEligibility(status = EligibilityStatus.INELIGIBLE, reason = reason, date_will_be_eligible = date_will_be_eligible)
+        time_eligibility = TimeEligibility(status=EligibilityStatus.INELIGIBLE, reason=reason, date_will_be_eligible=date_will_be_eligible)
         self.expungement_result.time_eligibility = time_eligibility
 
     def set_time_eligible(self, reason=''):
-        time_eligibility = TimeEligibility(status = EligibilityStatus.ELIGIBLE, reason = reason, date_will_be_eligible = None)
+        time_eligibility = TimeEligibility(status=EligibilityStatus.ELIGIBLE, reason=reason, date_will_be_eligible=None)
         self.expungement_result.time_eligibility = time_eligibility

--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -57,9 +57,9 @@ class Charge:
             date_will_be_eligible = date_of_eligibility
         else:
             date_will_be_eligible = None
-        time_eligibility = TimeEligibility(status=False, reason=reason, date_will_be_eligible=date_will_be_eligible)
+        time_eligibility = TimeEligibility(status = EligibilityStatus.INELIGIBLE, reason = reason, date_will_be_eligible = date_will_be_eligible)
         self.expungement_result.time_eligibility = time_eligibility
 
     def set_time_eligible(self, reason=''):
-        time_eligibility = TimeEligibility(status=True, reason=reason, date_will_be_eligible=None)
+        time_eligibility = TimeEligibility(status = EligibilityStatus.ELIGIBLE, reason = reason, date_will_be_eligible = None)
         self.expungement_result.time_eligibility = time_eligibility

--- a/src/backend/expungeservice/models/expungement_result.py
+++ b/src/backend/expungeservice/models/expungement_result.py
@@ -16,7 +16,7 @@ class TypeEligibility:
 
 @dataclass
 class TimeEligibility:
-    status: bool
+    status: EligibilityStatus
     reason: str
     date_will_be_eligible: Optional[date]
 

--- a/src/backend/expungeservice/serializer/serializer.py
+++ b/src/backend/expungeservice/serializer/serializer.py
@@ -1,3 +1,5 @@
+import dataclasses
+
 import flask
 import expungeservice
 from expungeservice.models.expungement_result import EligibilityStatus
@@ -38,7 +40,7 @@ class ExpungeModelEncoder(flask.json.JSONEncoder):
             "level": charge.level,
             "date": charge.date,
             "disposition": disposition,
-            "expungement_result": self.expungement_result_to_json(charge.expungement_result)
+            "expungement_result": dataclasses.asdict(charge.expungement_result)
         }
 
     def disposition_to_json(self, disposition):
@@ -46,41 +48,6 @@ class ExpungeModelEncoder(flask.json.JSONEncoder):
             "date": disposition.date ,
             "ruling": disposition.ruling,
             "status": disposition.status
-        }
-
-    def expungement_result_to_json(self, expungement_result):
-        # Note this logic is just to ensure that there has been no functional changes
-        # from the perspective of the front-end that uses this serializer since last commit.
-        #
-        # TODO: Redesign how expungement result is exposed.
-        if expungement_result.type_eligibility:
-            type_eligibility = expungement_result.type_eligibility
-            if type_eligibility.status == EligibilityStatus.ELIGIBLE:
-                type_eligibility_status = True
-            elif type_eligibility.status == EligibilityStatus.INELIGIBLE:
-                type_eligibility_status = False
-            elif type_eligibility.status == EligibilityStatus.NEEDS_MORE_ANALYSIS:
-                type_eligibility_status = None
-            else:
-                raise Exception('Impossible value for EligibilityStatus enum.')
-            type_eligibility_reason = type_eligibility.reason
-        else:
-            type_eligibility_status = None
-            type_eligibility_reason = ''
-        if expungement_result.time_eligibility:
-            time_eligibility_status = expungement_result.time_eligibility.status
-            time_eligibility_reason = expungement_result.time_eligibility.reason
-            date_of_eligibility = expungement_result.time_eligibility.date_will_be_eligible
-        else:
-            time_eligibility_status = None
-            time_eligibility_reason = ''
-            date_of_eligibility = None
-        return {
-            "type_eligibility": type_eligibility_status,
-            "type_eligibility_reason": type_eligibility_reason,
-            "time_eligibility": time_eligibility_status,
-            "time_eligibility_reason": time_eligibility_reason,
-            "date_of_eligibility": date_of_eligibility
         }
 
     def default(self, o):

--- a/src/backend/tests/expunger/test_time_analyzer.py
+++ b/src/backend/tests/expunger/test_time_analyzer.py
@@ -4,6 +4,7 @@ from datetime import date
 from dateutil.relativedelta import relativedelta
 from expungeservice.expunger.analyzers.time_analyzer import TimeAnalyzer
 from expungeservice.expunger.expunger import Expunger
+from expungeservice.models.expungement_result import EligibilityStatus
 from expungeservice.models.record import Record
 from tests.factories.case_factory import CaseFactory
 from tests.factories.charge_factory import ChargeFactory
@@ -22,7 +23,7 @@ class TestSingleChargeAcquittals(unittest.TestCase):
         self.expunger.charges = [charge]
         TimeAnalyzer.evaluate(self.expunger)
 
-        assert charge.expungement_result.time_eligibility.status is True
+        assert charge.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
         assert charge.expungement_result.time_eligibility.reason == ''
         assert charge.expungement_result.time_eligibility.date_will_be_eligible is None
 
@@ -34,11 +35,11 @@ class TestSingleChargeAcquittals(unittest.TestCase):
         self.expunger.charges = [ten_yr_charge, three_yr_mrc]
         TimeAnalyzer.evaluate(self.expunger)
 
-        assert ten_yr_charge.expungement_result.time_eligibility.status is False
+        assert ten_yr_charge.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
         assert ten_yr_charge.expungement_result.time_eligibility.reason == 'Time-ineligible under 137.225(7)(b)'
         assert ten_yr_charge.expungement_result.time_eligibility.date_will_be_eligible == three_yr_mrc.disposition.date + Time.TEN_YEARS
 
-        assert three_yr_mrc.expungement_result.time_eligibility.status is True
+        assert three_yr_mrc.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
         assert three_yr_mrc.expungement_result.time_eligibility.reason == ''
         assert three_yr_mrc.expungement_result.time_eligibility.date_will_be_eligible is None
 
@@ -50,11 +51,11 @@ class TestSingleChargeAcquittals(unittest.TestCase):
         self.expunger.charges = [ten_yr_charge, less_than_three_yr_mrc]
         TimeAnalyzer.evaluate(self.expunger)
 
-        assert ten_yr_charge.expungement_result.time_eligibility.status is False
+        assert ten_yr_charge.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
         assert ten_yr_charge.expungement_result.time_eligibility.reason == 'Time-ineligible under 137.225(7)(b)'
         assert ten_yr_charge.expungement_result.time_eligibility.date_will_be_eligible == less_than_three_yr_mrc.disposition.date + Time.TEN_YEARS
 
-        assert less_than_three_yr_mrc.expungement_result.time_eligibility.status is False
+        assert less_than_three_yr_mrc.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
         assert less_than_three_yr_mrc.expungement_result.time_eligibility.reason == 'Most recent conviction is less than three years old'
         assert less_than_three_yr_mrc.expungement_result.time_eligibility.date_will_be_eligible == date.today() + relativedelta(days=+1)
 
@@ -65,7 +66,7 @@ class TestSingleChargeAcquittals(unittest.TestCase):
         self.expunger.charges = [charge]
         TimeAnalyzer.evaluate(self.expunger)
 
-        assert charge.expungement_result.time_eligibility.status is True
+        assert charge.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
         assert charge.expungement_result.time_eligibility.reason == ''
         assert charge.expungement_result.time_eligibility.date_will_be_eligible is None
 
@@ -76,7 +77,7 @@ class TestSingleChargeAcquittals(unittest.TestCase):
         self.expunger.charges = [charge]
         TimeAnalyzer.evaluate(self.expunger)
 
-        assert charge.expungement_result.time_eligibility.status is False
+        assert charge.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
         assert charge.expungement_result.time_eligibility.reason == 'Most recent conviction is less than three years old'
         assert charge.expungement_result.time_eligibility.date_will_be_eligible == date.today() + relativedelta(days=+1)
 
@@ -93,7 +94,7 @@ class TestSingleChargeAcquittals(unittest.TestCase):
         self.expunger.charges = [charge]
         TimeAnalyzer.evaluate(self.expunger)
 
-        assert charge.expungement_result.time_eligibility.status is True
+        assert charge.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
         assert charge.expungement_result.time_eligibility.reason == ''
         assert charge.expungement_result.time_eligibility.date_will_be_eligible is None
 
@@ -110,7 +111,7 @@ class TestSingleChargeAcquittals(unittest.TestCase):
         self.expunger.charges = [charge]
         TimeAnalyzer.evaluate(self.expunger)
 
-        assert charge.expungement_result.time_eligibility.status is False
+        assert charge.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
         assert charge.expungement_result.time_eligibility.reason == 'Time-ineligible under 137.225(5)(a)(A)(i)'
         assert charge.expungement_result.time_eligibility.date_will_be_eligible == Time.TOMORROW
 
@@ -125,7 +126,7 @@ class TestSingleChargeAcquittals(unittest.TestCase):
         self.expunger.charges = [charge]
         TimeAnalyzer.evaluate(self.expunger)
 
-        assert charge.expungement_result.time_eligibility.status is False
+        assert charge.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
         assert charge.expungement_result.time_eligibility.reason == 'Most recent conviction is less than three years old'
         assert charge.expungement_result.time_eligibility.date_will_be_eligible is None
 
@@ -144,7 +145,7 @@ class TestDismissalBlock(unittest.TestCase):
         expunger = Expunger(record)
         expunger.run()
 
-        assert self.recent_dismissal.expungement_result.time_eligibility.status is True
+        assert self.recent_dismissal.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
         assert self.recent_dismissal.expungement_result.time_eligibility.reason == ''
         assert self.recent_dismissal.expungement_result.time_eligibility.date_will_be_eligible is None
 
@@ -156,11 +157,11 @@ class TestDismissalBlock(unittest.TestCase):
         expunger = Expunger(record)
         expunger.run()
 
-        assert self.recent_dismissal.expungement_result.time_eligibility.status is True
+        assert self.recent_dismissal.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
         assert self.recent_dismissal.expungement_result.time_eligibility.reason == ''
         assert self.recent_dismissal.expungement_result.time_eligibility.date_will_be_eligible is None
 
-        assert case_related_dismissal.expungement_result.time_eligibility.status is True
+        assert case_related_dismissal.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
         assert case_related_dismissal.expungement_result.time_eligibility.reason == ''
         assert case_related_dismissal.expungement_result.time_eligibility.date_will_be_eligible is None
 
@@ -172,7 +173,7 @@ class TestDismissalBlock(unittest.TestCase):
         expunger = Expunger(record)
         expunger.run()
 
-        assert unrelated_dismissal.expungement_result.time_eligibility.status is False
+        assert unrelated_dismissal.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
         assert unrelated_dismissal.expungement_result.time_eligibility.reason == 'Recommend sequential expungement'
         assert unrelated_dismissal.expungement_result.time_eligibility.date_will_be_eligible == Time.ONE_YEARS_FROM_NOW
 
@@ -185,7 +186,7 @@ class TestDismissalBlock(unittest.TestCase):
         expunger = Expunger(record)
         expunger.run()
 
-        assert convicted_charge.expungement_result.time_eligibility.status is True
+        assert convicted_charge.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
         assert convicted_charge.expungement_result.time_eligibility.reason == ''
         assert convicted_charge.expungement_result.time_eligibility.date_will_be_eligible is None
 
@@ -207,11 +208,11 @@ class TestSecondMRCLogic(unittest.TestCase):
 
         self.run_expunger(two_years_ago_charge, three_years_ago_charge)
 
-        assert three_years_ago_charge.expungement_result.time_eligibility.status is False
+        assert three_years_ago_charge.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
         assert three_years_ago_charge.expungement_result.time_eligibility.reason == 'Time-ineligible under 137.225(7)(b)'
         assert three_years_ago_charge.expungement_result.time_eligibility.date_will_be_eligible == two_years_ago_charge.disposition.date + Time.TEN_YEARS
 
-        assert two_years_ago_charge.expungement_result.time_eligibility.status is False
+        assert two_years_ago_charge.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
         assert two_years_ago_charge.expungement_result.time_eligibility.reason == 'Multiple convictions within last ten years'
         assert two_years_ago_charge.expungement_result.time_eligibility.date_will_be_eligible == three_years_ago_charge.disposition.date + Time.TEN_YEARS
 
@@ -221,11 +222,11 @@ class TestSecondMRCLogic(unittest.TestCase):
 
         self.run_expunger(five_year_ago_charge, seven_year_ago_charge)
 
-        assert seven_year_ago_charge.expungement_result.time_eligibility.status is False
+        assert seven_year_ago_charge.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
         assert seven_year_ago_charge.expungement_result.time_eligibility.reason == 'Time-ineligible under 137.225(7)(b)'
         assert seven_year_ago_charge.expungement_result.time_eligibility.date_will_be_eligible == five_year_ago_charge.disposition.date + Time.TEN_YEARS
 
-        assert five_year_ago_charge.expungement_result.time_eligibility.status is False
+        assert five_year_ago_charge.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
         assert five_year_ago_charge.expungement_result.time_eligibility.reason == 'Multiple convictions within last ten years'
         assert five_year_ago_charge.expungement_result.time_eligibility.date_will_be_eligible == seven_year_ago_charge.disposition.date + Time.TEN_YEARS
 

--- a/src/backend/tests/functional_tests/test_crawler_expunger.py
+++ b/src/backend/tests/functional_tests/test_crawler_expunger.py
@@ -3,6 +3,7 @@ from datetime import date as date_class
 import pytest
 from dateutil.relativedelta import relativedelta
 from expungeservice.expunger.expunger import Expunger
+from expungeservice.models.expungement_result import EligibilityStatus
 from tests.factories.crawler_factory import CrawlerFactory
 from tests.fixtures.case_details import CaseDetails
 from tests.fixtures.john_doe import JohnDoe
@@ -126,14 +127,14 @@ def test_expunger_runs_time_analyzer(record_with_specific_dates):
     assert expunger.most_recent_dismissal.disposition.ruling == 'No Complaint'
     assert len(expunger.acquittals) == 8
 
-    assert record.cases[0].charges[0].expungement_result.time_eligibility.status is False
-    assert record.cases[0].charges[1].expungement_result.time_eligibility.status is True
-    assert record.cases[0].charges[2].expungement_result.time_eligibility.status is False
+    assert record.cases[0].charges[0].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert record.cases[0].charges[1].expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert record.cases[0].charges[2].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
 
-    assert record.cases[1].charges[0].expungement_result.time_eligibility.status is False
-    assert record.cases[1].charges[1].expungement_result.time_eligibility.status is False
-    assert record.cases[1].charges[2].expungement_result.time_eligibility.status is False
+    assert record.cases[1].charges[0].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert record.cases[1].charges[1].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert record.cases[1].charges[2].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
 
-    assert record.cases[2].charges[0].expungement_result.time_eligibility.status is True
-    assert record.cases[2].charges[1].expungement_result.time_eligibility.status is True
-    assert record.cases[2].charges[2].expungement_result.time_eligibility.status is True
+    assert record.cases[2].charges[0].expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert record.cases[2].charges[1].expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert record.cases[2].charges[2].expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE

--- a/src/frontend/src/components/Charge/index.tsx
+++ b/src/frontend/src/components/Charge/index.tsx
@@ -50,13 +50,23 @@ export default class Charge extends React.Component<Props> {
       }
     };
 
+    const recordTimeRender = () => {
+      if (expungement_result.time_eligibility) {
+        return (
+          <RecordTime time_eligibility={expungement_result.time_eligibility} />
+        );
+      }
+    };
+
     return (
       <div className="br3 ma2 bg-white">
         <Eligibility expungement_result={expungement_result} />
         <div className="flex-l ph3 pb3">
           <div className="w-100 w-30-l pr3">
-            <RecordTime expungement_result={expungement_result} />
-            <RecordType expungement_result={expungement_result} />
+            {recordTimeRender()}
+            <RecordType
+              type_eligibility={expungement_result.type_eligibility}
+            />
           </div>
           <div className="w-100 w-70-l pr3">
             <ul className="list">

--- a/src/frontend/src/components/Eligibility/index.tsx
+++ b/src/frontend/src/components/Eligibility/index.tsx
@@ -37,27 +37,28 @@ export default class Eligibility extends React.Component<Props> {
     );
 
     const eligibility = () => {
-      if (
-        type_eligibility.status === 'Eligible' &&
-        time_eligibility &&
-        time_eligibility.status === 'Eligible'
-      ) {
-        return eligibleNow;
-      } else if (
-        type_eligibility.status === 'Eligible' &&
-        time_eligibility &&
-        time_eligibility.date_of_eligibility !== null
-      ) {
-        return eligibleOn(time_eligibility.date_of_eligibility);
-      } else if (
-        type_eligibility.status === 'Needs more analysis' &&
-        time_eligibility
-      ) {
-        return eligibleWithReview(time_eligibility.date_of_eligibility);
-      } else if (type_eligibility.status === 'Ineligible') {
-        return ineligible;
-      } else {
-        return 'Unknown type or time eligibility';
+      switch (type_eligibility.status) {
+        case 'Eligible':
+          if (time_eligibility && time_eligibility.status === 'Eligible') {
+            return eligibleNow;
+          } else if (
+            time_eligibility &&
+            time_eligibility.date_of_eligibility !== null
+          ) {
+            return eligibleOn(time_eligibility.date_of_eligibility);
+          } else {
+            return 'Eligible but no time eligibility (Please report)';
+          }
+        case 'Needs more analysis':
+          if (time_eligibility) {
+            return eligibleWithReview(time_eligibility.date_of_eligibility);
+          } else {
+            return 'Possibly eligible but no time eligibility (Please report)';
+          }
+        case 'Ineligible':
+          return ineligible;
+        default:
+          return 'Unknown type eligibility (Please report)';
       }
     };
 

--- a/src/frontend/src/components/Eligibility/index.tsx
+++ b/src/frontend/src/components/Eligibility/index.tsx
@@ -9,8 +9,7 @@ export default class Eligibility extends React.Component<Props> {
   render() {
     const {
       type_eligibility,
-      time_eligibility,
-      date_of_eligibility
+      time_eligibility
     } = this.props.expungement_result;
 
     const eligibleNow = (
@@ -38,13 +37,24 @@ export default class Eligibility extends React.Component<Props> {
     );
 
     const eligibility = () => {
-      if (type_eligibility === true && time_eligibility === true) {
+      if (
+        type_eligibility.status === 'Eligible' &&
+        time_eligibility &&
+        time_eligibility.status === 'Eligible'
+      ) {
         return eligibleNow;
-      } else if (type_eligibility === true && date_of_eligibility !== null) {
-        return eligibleOn(date_of_eligibility);
-      } else if (type_eligibility === null) {
-        return eligibleWithReview(date_of_eligibility);
-      } else if (type_eligibility === false) {
+      } else if (
+        type_eligibility.status === 'Eligible' &&
+        time_eligibility &&
+        time_eligibility.date_of_eligibility !== null
+      ) {
+        return eligibleOn(time_eligibility.date_of_eligibility);
+      } else if (
+        type_eligibility.status === 'Needs more analysis' &&
+        time_eligibility
+      ) {
+        return eligibleWithReview(time_eligibility.date_of_eligibility);
+      } else if (type_eligibility.status === 'Ineligible') {
         return ineligible;
       } else {
         return 'Unknown type or time eligibility';

--- a/src/frontend/src/components/Eligibility/index.tsx
+++ b/src/frontend/src/components/Eligibility/index.tsx
@@ -36,24 +36,29 @@ export default class Eligibility extends React.Component<Props> {
       </h2>
     );
 
+    const handleWhenTypeEligibile = () => {
+      if (time_eligibility) {
+        if (time_eligibility.status === 'Eligible') {
+          return eligibleNow;
+        } else if (time_eligibility.date_of_eligibility !== null) {
+          return eligibleOn(time_eligibility.date_of_eligibility);
+        } else {
+          return 'Eligible but no date on time analysis (Please report)';
+        }
+      } else {
+        return 'Eligible but no time analysis (Please report)';
+      }
+    };
+
     const eligibility = () => {
       switch (type_eligibility.status) {
         case 'Eligible':
-          if (time_eligibility && time_eligibility.status === 'Eligible') {
-            return eligibleNow;
-          } else if (
-            time_eligibility &&
-            time_eligibility.date_of_eligibility !== null
-          ) {
-            return eligibleOn(time_eligibility.date_of_eligibility);
-          } else {
-            return 'Eligible but no time eligibility (Please report)';
-          }
+          return handleWhenTypeEligibile();
         case 'Needs more analysis':
           if (time_eligibility) {
             return eligibleWithReview(time_eligibility.date_of_eligibility);
           } else {
-            return 'Possibly eligible but no time eligibility (Please report)';
+            return 'Possibly eligible but no time analysis (Please report)';
           }
         case 'Ineligible':
           return ineligible;

--- a/src/frontend/src/components/RecordTime/index.tsx
+++ b/src/frontend/src/components/RecordTime/index.tsx
@@ -1,16 +1,13 @@
 import React from 'react';
-import { ExpungementResultType } from '../SearchResults/types';
+import { TimeEligibility } from '../SearchResults/types';
 
 interface Props {
-  expungement_result: ExpungementResultType;
+  time_eligibility: TimeEligibility;
 }
 
 export default class RecordTime extends React.Component<Props> {
   render() {
-    const {
-      time_eligibility_reason,
-      time_eligibility
-    } = this.props.expungement_result;
+    const { status, reason } = this.props.time_eligibility;
 
     const timeNow = (
       <div className="relative mb3">
@@ -24,20 +21,20 @@ export default class RecordTime extends React.Component<Props> {
       </div>
     );
 
-    const timeLater = (
+    const timeLater = (reason: string) => (
       <div className="relative mb3">
         <i aria-hidden="true" className="absolute fas fa-clock dark-blue"></i>
         <div className="ml3 pl1">
-          <span className="fw7">Time:</span> {time_eligibility_reason}
+          <span className="fw7">Time:</span> {reason}
         </div>
       </div>
     );
 
     const time = () => {
-      if (time_eligibility === true) {
+      if (status === 'Eligible') {
         return timeNow;
       } else {
-        return timeLater;
+        return timeLater(reason);
       }
     };
 

--- a/src/frontend/src/components/RecordType/index.tsx
+++ b/src/frontend/src/components/RecordType/index.tsx
@@ -1,18 +1,15 @@
 import React from 'react';
-import { ExpungementResultType } from '../SearchResults/types';
+import { TypeEligibility } from '../SearchResults/types';
 
 interface Props {
-  expungement_result: ExpungementResultType;
+  type_eligibility: TypeEligibility;
 }
 
 export default class RecordType extends React.Component<Props> {
   render() {
-    const {
-      type_eligibility,
-      type_eligibility_reason
-    } = this.props.expungement_result;
+    const { status, reason } = this.props.type_eligibility;
 
-    const eligible = (
+    const eligible = (reason: string) => (
       <div className="relative mb3">
         <i
           aria-hidden="true"
@@ -20,7 +17,7 @@ export default class RecordType extends React.Component<Props> {
         ></i>
         <div className="ml3 pl1">
           <span className="fw7">Type:</span> Eligible{' '}
-          <span className="nowrap">({type_eligibility_reason})</span>
+          <span className="nowrap">({reason})</span>
         </div>
       </div>
     );
@@ -37,22 +34,22 @@ export default class RecordType extends React.Component<Props> {
       </div>
     );
 
-    const ineligible = (
+    const ineligible = (reason: string) => (
       <div className="relative mb3">
         <i aria-hidden="true" className="absolute fas fa-times-circle red"></i>
         <div className="ml3 pl1">
           <span className="fw7">Type:</span> Ineligible{' '}
-          <span className="nowrap">({type_eligibility_reason})</span>
+          <span className="nowrap">({reason})</span>
         </div>
       </div>
     );
 
-    if (type_eligibility === true) {
-      return eligible;
-    } else if (type_eligibility === null) {
+    if (status == 'Eligible') {
+      return eligible(reason);
+    } else if (status === 'Needs more analysis') {
       return review;
-    } else if (type_eligibility === false) {
-      return ineligible;
+    } else if (status === 'Ineligible') {
+      return ineligible(reason);
     } else {
       return 'Unknown type eligibility';
     }

--- a/src/frontend/src/components/SearchResults/types.ts
+++ b/src/frontend/src/components/SearchResults/types.ts
@@ -29,9 +29,17 @@ export interface Record {
 }
 
 export interface ExpungementResultType {
-  type_eligibility: boolean | string;
-  time_eligibility: boolean;
+  type_eligibility: TypeEligibility;
+  time_eligibility?: TimeEligibility;
+}
+
+export interface TypeEligibility {
+  status: string;
+  reason: string;
+}
+
+export interface TimeEligibility {
+  status: string;
+  reason: string;
   date_of_eligibility: string;
-  time_eligibility_reason: string;
-  type_eligibility_reason: string;
 }

--- a/src/frontend/src/service/__mocks__/axios.ts
+++ b/src/frontend/src/service/__mocks__/axios.ts
@@ -72,11 +72,11 @@ const fakeRecord = {
               ruling: 'Convicted'
             },
             expungement_result: {
-              type_eligibility: false,
-              type_eligibility_reason: 'Ineligible under 137.225(5)',
-              time_eligibility: null,
-              time_eligibility_reason: '',
-              date_of_eligibility: null
+              type_eligibility: {
+                status: 'Ineligible',
+                reason: 'Ineligible under 137.225(5)'
+              },
+              time_eligibility: null
             }
           }
         ],
@@ -104,11 +104,15 @@ const fakeRecord = {
               ruling: 'Dismissed'
             },
             expungement_result: {
-              type_eligibility: true,
-              type_eligibility_reason: 'Eligible under 137.225(1)(b)',
-              time_eligibility: null,
-              time_eligibility_reason: '',
-              date_of_eligibility: '2/11/2020'
+              type_eligibility: {
+                status: 'Eligible',
+                reason: 'Eligible under 137.225(1)(b)'
+              },
+              time_eligibility: {
+                status: 'Ineligible',
+                reason: '',
+                date_of_eligibility: '2/11/2020'
+              }
             }
           },
           {
@@ -121,11 +125,15 @@ const fakeRecord = {
               ruling: 'Dismissed'
             },
             expungement_result: {
-              type_eligibility: true,
-              type_eligibility_reason: 'Eligible under 137.225(1)(b)',
-              time_eligibility: null,
-              time_eligibility_reason: '',
-              date_of_eligibility: '2/11/2020'
+              type_eligibility: {
+                status: 'Eligible',
+                reason: 'Eligible under 137.225(1)(b)'
+              },
+              time_eligibility: {
+                status: 'Ineligible',
+                reason: '',
+                date_of_eligibility: '2/11/2020'
+              }
             }
           }
         ],

--- a/src/frontend/src/service/api-service.test.ts
+++ b/src/frontend/src/service/api-service.test.ts
@@ -88,11 +88,11 @@ const fakeRecord = {
               ruling: 'Convicted'
             },
             expungement_result: {
-              type_eligibility: false,
-              type_eligibility_reason: 'Ineligible under 137.225(5)',
-              time_eligibility: null,
-              time_eligibility_reason: '',
-              date_of_eligibility: null
+              type_eligibility: {
+                status: 'Ineligible',
+                reason: 'Ineligible under 137.225(5)'
+              },
+              time_eligibility: null
             }
           }
         ],
@@ -120,11 +120,15 @@ const fakeRecord = {
               ruling: 'Dismissed'
             },
             expungement_result: {
-              type_eligibility: true,
-              type_eligibility_reason: 'Eligible under 137.225(1)(b)',
-              time_eligibility: null,
-              time_eligibility_reason: '',
-              date_of_eligibility: '2/11/2020'
+              type_eligibility: {
+                status: 'Eligible',
+                reason: 'Eligible under 137.225(1)(b)'
+              },
+              time_eligibility: {
+                status: 'Ineligible',
+                reason: '',
+                date_of_eligibility: '2/11/2020'
+              }
             }
           },
           {
@@ -137,11 +141,15 @@ const fakeRecord = {
               ruling: 'Dismissed'
             },
             expungement_result: {
-              type_eligibility: true,
-              type_eligibility_reason: 'Eligible under 137.225(1)(b)',
-              time_eligibility: null,
-              time_eligibility_reason: '',
-              date_of_eligibility: '2/11/2020'
+              type_eligibility: {
+                status: 'Eligible',
+                reason: 'Eligible under 137.225(1)(b)'
+              },
+              time_eligibility: {
+                status: 'Ineligible',
+                reason: '',
+                date_of_eligibility: '2/11/2020'
+              }
             }
           }
         ],


### PR DESCRIPTION
~~Relative to #543~~

The expungement result object will now more closely reflect the backend structure. The `type_eligibility` and `time_eligibility` are now their own separate objects. The status fields are no longer just booleans or null instead they are "Eligible", "Ineligible", or "Needs more analysis".

Examples

```
{
  "expungement_result": {
    "type_eligibility": {
      "status": "Eligible",
      "reason": "Eligible under 137.225(1)(b)"
    },
    "time_eligibility": {
      "status": "Ineligible",
      "reason": "Recommend sequential expungement",
      "date_will_be_eligible": "Sun, 15 Nov 2020 00:00:00 GMT"
    }
  }
}
```

```
{
  "expungement_result": {
    "type_eligibility": {
      "status": "Ineligible",
      "reason": "Ineligible under 137.225(5)"
    },
    "time_eligibility": null
  }
}
```