### PR TITLE
Ensure search button triggers with one click

### DIFF
--- a/src/frontend/src/components/RecordSearch/index.tsx
+++ b/src/frontend/src/components/RecordSearch/index.tsx
@@ -40,36 +40,37 @@ class RecordSearch extends React.Component<Props, State> {
 
   handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    this.validateForm();
-    if (
-      this.state.missingInputs === false &&
-      this.state.invalidDate === false
-    ) {
-      // Dispatch an action.
-      let state = this.state;
-      let firstName = state.firstName;
-      let lastName = state.lastName;
-      let dateOfBirth = state.dateOfBirth;
-      this.props.fetchRecords(firstName, lastName, dateOfBirth);
-    }
+    this.validateForm().then(() => {
+      if (
+        this.state.missingInputs === false &&
+        this.state.invalidDate === false
+      ) {
+        // Dispatch an action.
+        let state = this.state;
+        let firstName = state.firstName;
+        let lastName = state.lastName;
+        let dateOfBirth = state.dateOfBirth;
+        this.props.fetchRecords(firstName, lastName, dateOfBirth);
+      }
+    });
   };
 
   validateForm = () => {
-    this.setState({
-      firstNameHasInput: this.state.firstName.trim().length === 0
-    });
-    this.setState({
-      lastNameHasInput: this.state.lastName.trim().length === 0
-    });
-    this.setState({
-      missingInputs:
-        this.state.firstName.trim().length === 0 ||
-        this.state.lastName.trim().length === 0 ||
-        this.state.dateOfBirth.trim().length === 0
-    });
-    this.setState({
-      invalidDate:
-        moment(this.state.dateOfBirth, 'MM/DD/YYYY', true).isValid() === false
+    return new Promise(resolve => {
+      this.setState(
+        {
+          firstNameHasInput: this.state.firstName.trim().length === 0,
+          lastNameHasInput: this.state.lastName.trim().length === 0,
+          missingInputs:
+            this.state.firstName.trim().length === 0 ||
+            this.state.lastName.trim().length === 0 ||
+            this.state.dateOfBirth.trim().length === 0,
+          invalidDate:
+            moment(this.state.dateOfBirth, 'MM/DD/YYYY', true).isValid() ===
+            false
+        },
+        resolve
+      );
     });
   };
 


### PR DESCRIPTION
Closes https://github.com/codeforpdx/recordexpungPDX/issues/561

`setState` is an asynchronous call and thus we must wait for it to return before proceeding to call fetchRecords. Two clicks were required because missingInputs and invalidDate were only set to True after the if statement on the first click.