### PR TITLE
Set dependabot to update frontend deps once a month

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -10,7 +10,7 @@ update_configs:
 
   - package_manager: "javascript"
     directory: "/src/frontend"
-    update_schedule: "live"
+    update_schedule: "monthly"
     default_labels:
     - "frontend"
     - "dependencies"


### PR DESCRIPTION
Frontend deps are now checked once a month. Security updates will
still be applied immediately. This is done because we do not have the
bandwidth to handle frontend dep updates on a weekly basis. The number
of allowed PRs dependabot is allowed to have open is also reduced to 5.

<img width="528" alt="Screenshot 2019-11-16 12 09 14" src="https://user-images.githubusercontent.com/19519317/68998639-eda7b200-0869-11ea-8960-533ebe358cc9.png">

This means that at any given time we should have no more than 5 PRs
(exluding security updates) open at any given time. Plus the one month
review cycle will give us time to thoroughly review the dep update.

Fixes #522 