### PR TITLE
Clear search records when AllRecords component unmounts

### DIFF
--- a/src/frontend/src/containers/AllRecords.tsx
+++ b/src/frontend/src/containers/AllRecords.tsx
@@ -2,17 +2,25 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { AppState } from '../redux/store';
 import { Record } from '../redux/records/types';
-import { loadSearchRecords } from '../redux/records/actions';
+import {
+  loadSearchRecords,
+  clearSearchRecords
+} from '../redux/records/actions';
 import RecordSearch from '../components/RecordSearch';
 import SearchResults from '../components/SearchResults';
 import AllStatus from './AllStatus';
 
 type Props = {
   fetchRecords: Function;
+  clearRecords: Function;
   records?: Record;
 };
 
 class AllRecords extends Component<Props> {
+  componentWillUnmount() {
+    this.props.clearRecords();
+  }
+
   render() {
     // Fetch has now been passed down to RecordSearch componant and is triggered when submit button is pressed.
     // Currentlly no matter what the user puts in the search fields, it still triggers a mock fetch with pre determined API response
@@ -36,9 +44,7 @@ const mapStateToProps = (state: AppState) => {
   };
 };
 
-export default connect(
-  mapStateToProps,
-  {
-    fetchRecords: loadSearchRecords
-  }
-)(AllRecords);
+export default connect(mapStateToProps, {
+  fetchRecords: loadSearchRecords,
+  clearRecords: clearSearchRecords
+})(AllRecords);

--- a/src/frontend/src/redux/records/actions.ts
+++ b/src/frontend/src/redux/records/actions.ts
@@ -4,7 +4,8 @@ import { AxiosError, AxiosResponse } from 'axios';
 import {
   LOAD_SEARCH_RECORDS,
   LOAD_SEARCH_RECORDS_LOADING,
-  SearchResponse
+  SearchResponse,
+  CLEAR_SEARCH_RECORDS
 } from './types';
 
 function validateResponseData(data: SearchResponse): boolean {
@@ -44,5 +45,11 @@ export function loadSearchRecords(
       .catch((error: AxiosError<SearchResponse>) => {
         alert(error.message);
       });
+  };
+}
+
+export function clearSearchRecords() {
+  return {
+    type: CLEAR_SEARCH_RECORDS
   };
 }

--- a/src/frontend/src/redux/records/reducer.ts
+++ b/src/frontend/src/redux/records/reducer.ts
@@ -2,7 +2,8 @@ import {
   LOAD_SEARCH_RECORDS,
   LOAD_SEARCH_RECORDS_LOADING,
   SearchRecordState,
-  SearchRecordsActionType
+  SearchRecordsActionType,
+  CLEAR_SEARCH_RECORDS
 } from './types';
 
 const initalState: SearchRecordState = {
@@ -25,6 +26,8 @@ export function recordsReducer(
       // while loading state is true, a spinner is rendered on the screen. If loading
       // state is false, and no records were fetched, no search results found will be displayed.
       return { ...state, loading: true };
+    case CLEAR_SEARCH_RECORDS:
+      return { ...state, records: {}, loading: false };
     default:
       return state;
   }

--- a/src/frontend/src/redux/records/types.ts
+++ b/src/frontend/src/redux/records/types.ts
@@ -29,6 +29,7 @@ export interface Record {
 // These constants are used as the 'type' field in Redux actions.
 export const LOAD_SEARCH_RECORDS = 'LOAD_SEARCH_RECORDS';
 export const LOAD_SEARCH_RECORDS_LOADING = 'LOAD_SEARCH_RECORDS_LOADING';
+export const CLEAR_SEARCH_RECORDS = 'CLEAR_SEARCH_RECORDS';
 
 export interface SearchRecordState {
   loading: boolean;
@@ -36,7 +37,10 @@ export interface SearchRecordState {
 }
 
 interface SearchRecordsAction {
-  type: typeof LOAD_SEARCH_RECORDS | typeof LOAD_SEARCH_RECORDS_LOADING;
+  type:
+    | typeof LOAD_SEARCH_RECORDS
+    | typeof LOAD_SEARCH_RECORDS_LOADING
+    | typeof CLEAR_SEARCH_RECORDS;
   search_records: Record;
 }
 


### PR DESCRIPTION
Closes https://github.com/codeforpdx/recordexpungPDX/issues/568

Otherwise old search records will still remain even after the user navigates to a different page and back.