### PR TITLE
Save anonymized search results to database

### DIFF
--- a/config/postgres/initdb/scripts/create-tables.sql
+++ b/config/postgres/initdb/scripts/create-tables.sql
@@ -35,6 +35,7 @@ CREATE TABLE rules (
 
 CREATE TABLE search_results (
     search_result_id      UUID NOT NULL,
+    user_id               UUID NOT NULL REFERENCES users(user_id),
     date_searched         TIMESTAMP WITH TIME ZONE DEFAULT now(),
     hashed_search_params  BIGINT NOT NULL,
     num_charges           INTEGER,

--- a/config/postgres/initdb/scripts/create-tables.sql
+++ b/config/postgres/initdb/scripts/create-tables.sql
@@ -36,7 +36,7 @@ CREATE TABLE rules (
 CREATE TABLE search_results (
     search_result_id      UUID NOT NULL,
     date_searched         TIMESTAMP WITH TIME ZONE DEFAULT now(),
-    hashed_search_params  INTEGER NOT NULL,
+    hashed_search_params  BIGINT NOT NULL,
     num_charges           INTEGER,
     num_eligible_charges  INTEGER,
     PRIMARY KEY (search_result_id)

--- a/config/postgres/initdb/scripts/create-tables.sql
+++ b/config/postgres/initdb/scripts/create-tables.sql
@@ -32,3 +32,13 @@ CREATE TABLE rules (
     text    TEXT UNIQUE NOT NULL,
     PRIMARY KEY (rule_id)
 );
+
+CREATE TABLE search_results (
+    search_result_id      UUID NOT NULL,
+    date_searched         TIMESTAMP WITH TIME ZONE DEFAULT now(),
+    hashed_search_params  INTEGER NOT NULL,
+    num_charges           INTEGER,
+    num_eligible_charges  INTEGER,
+    PRIMARY KEY (search_result_id)
+);
+

--- a/config/postgres/initdb/scripts/create-tables.sql
+++ b/config/postgres/initdb/scripts/create-tables.sql
@@ -35,7 +35,7 @@ CREATE TABLE rules (
 
 CREATE TABLE search_results (
     search_result_id      UUID NOT NULL,
-    user_id               UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    user_id               UUID REFERENCES users(user_id),
     date_searched         TIMESTAMP WITH TIME ZONE DEFAULT now(),
     hashed_search_params  TEXT NOT NULL,
     num_charges           INTEGER,

--- a/config/postgres/initdb/scripts/create-tables.sql
+++ b/config/postgres/initdb/scripts/create-tables.sql
@@ -35,9 +35,9 @@ CREATE TABLE rules (
 
 CREATE TABLE search_results (
     search_result_id      UUID NOT NULL,
-    user_id               UUID NOT NULL REFERENCES users(user_id),
+    user_id               UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
     date_searched         TIMESTAMP WITH TIME ZONE DEFAULT now(),
-    hashed_search_params  BIGINT NOT NULL,
+    hashed_search_params  TEXT NOT NULL,
     num_charges           INTEGER,
     num_eligible_charges  INTEGER,
     PRIMARY KEY (search_result_id)

--- a/src/backend/expungeservice/endpoints/search.py
+++ b/src/backend/expungeservice/endpoints/search.py
@@ -1,6 +1,6 @@
 from flask.views import MethodView
 from flask import request, current_app
-from flask_login import login_required
+from flask_login import login_required, current_user
 
 from expungeservice.request import check_data_fields
 from expungeservice.request.error import error
@@ -8,6 +8,7 @@ from expungeservice.crawler.crawler import Crawler
 from expungeservice.expunger.expunger import Expunger
 from expungeservice.serializer import ExpungeModelEncoder
 from expungeservice.crypto import DataCipher
+from expungeservice.stats import save_result
 
 
 class Search(MethodView):
@@ -45,6 +46,8 @@ class Search(MethodView):
 
         expunger = Expunger(record)
         expunger.run()
+
+        save_result(current_user.user_id, request_data, record)
 
         response_data = {
             "data": {

--- a/src/backend/expungeservice/endpoints/search.py
+++ b/src/backend/expungeservice/endpoints/search.py
@@ -1,6 +1,6 @@
 from flask.views import MethodView
 from flask import request, current_app
-from flask_login import login_required, current_user
+from flask_login import login_required
 import logging
 
 from expungeservice.request import check_data_fields
@@ -49,7 +49,7 @@ class Search(MethodView):
         expunger.run()
 
         try:
-            save_result(current_user.user_id, request_data, record)
+            save_result(request_data, record)
         except Exception as ex:
             logging.error("Saving search result failed with exception: %s" % ex , stack_info = True)
 

--- a/src/backend/expungeservice/endpoints/search.py
+++ b/src/backend/expungeservice/endpoints/search.py
@@ -1,6 +1,7 @@
 from flask.views import MethodView
 from flask import request, current_app
 from flask_login import login_required, current_user
+import logging
 
 from expungeservice.request import check_data_fields
 from expungeservice.request.error import error
@@ -47,7 +48,10 @@ class Search(MethodView):
         expunger = Expunger(record)
         expunger.run()
 
-        save_result(current_user.user_id, request_data, record)
+        try:
+            save_result(current_user.user_id, request_data, record)
+        except Exception as ex:
+            logging.error("Saving search result failed with exception: %s" % ex , stack_info = True)
 
         response_data = {
             "data": {

--- a/src/backend/expungeservice/stats/__init__.py
+++ b/src/backend/expungeservice/stats/__init__.py
@@ -1,0 +1,1 @@
+from .stats import *

--- a/src/backend/expungeservice/stats/stats.py
+++ b/src/backend/expungeservice/stats/stats.py
@@ -4,9 +4,12 @@ import hashlib
 
 from expungeservice.database.db_util import rollback_errors
 from expungeservice.models.expungement_result import EligibilityStatus
+from flask_login import current_user
 
 
-def save_result(user_id, request_data, record):
+def save_result(request_data, record):
+
+    user_id = current_user.user_id
 
     search_param_string = (
         user_id +

--- a/src/backend/expungeservice/stats/stats.py
+++ b/src/backend/expungeservice/stats/stats.py
@@ -1,4 +1,5 @@
 from flask import g
+import uuid
 
 from expungeservice.database.db_util import rollback_errors
 from expungeservice.models.expungement_result import EligibilityStatus
@@ -19,15 +20,15 @@ def save_result(user_id, request_data, record):
         c.expungement_result.type_eligibility.status == EligibilityStatus.ELIGIBLE])
 
     insert_result = db_insert_result(
-        g.database, hashed_search_params, num_charges, num_eligible_charges)
+        g.database, user_id, hashed_search_params, num_charges, num_eligible_charges)
 
 
 @rollback_errors
-def db_insert_result(database, hashed_search_params, num_charges, num_eligible_charges):
+def db_insert_result(database, user_id, hashed_search_params, num_charges, num_eligible_charges):
 
     result= database.cursor.execute(
         """
-        INSERT INTO  SEARCH_RESULTS(search_result_id, hashed_search_params, num_charges, num_eligible_charges )
-        VALUES ( uuid_generate_v4(), %(params)s, %(num_charges)s, %(num_eligible_charges)s);
-        """, {'params': hashed_search_params, 'num_charges': num_charges,
+        INSERT INTO  SEARCH_RESULTS(search_result_id, user_id, hashed_search_params, num_charges, num_eligible_charges )
+        VALUES ( uuid_generate_v4(), %(user_id)s, %(params)s, %(num_charges)s, %(num_eligible_charges)s);
+        """, {'user_id': uuid.UUID(user_id).hex, 'params': hashed_search_params, 'num_charges': num_charges,
               'num_eligible_charges': num_eligible_charges})

--- a/src/backend/expungeservice/stats/stats.py
+++ b/src/backend/expungeservice/stats/stats.py
@@ -19,14 +19,14 @@ def save_result(user_id, request_data, record):
     num_eligible_charges = len([ c for c in record.charges if
         c.expungement_result.type_eligibility.status == EligibilityStatus.ELIGIBLE])
 
-    insert_result = db_insert_result(
+    _db_insert_result(
         g.database, user_id, hashed_search_params, num_charges, num_eligible_charges)
 
 
 @rollback_errors
-def db_insert_result(database, user_id, hashed_search_params, num_charges, num_eligible_charges):
+def _db_insert_result(database, user_id, hashed_search_params, num_charges, num_eligible_charges):
 
-    result= database.cursor.execute(
+    database.cursor.execute(
         """
         INSERT INTO  SEARCH_RESULTS(search_result_id, user_id, hashed_search_params, num_charges, num_eligible_charges )
         VALUES ( uuid_generate_v4(), %(user_id)s, %(params)s, %(num_charges)s, %(num_eligible_charges)s);

--- a/src/backend/expungeservice/stats/stats.py
+++ b/src/backend/expungeservice/stats/stats.py
@@ -1,0 +1,33 @@
+from flask import g
+
+from expungeservice.database.db_util import rollback_errors
+from expungeservice.models.expungement_result import EligibilityStatus
+
+
+def save_result(user_id, request_data, record):
+
+    hashed_search_params = hash(
+        user_id +
+        request_data["first_name"] +
+        request_data["last_name"] +
+        request_data["middle_name"] +
+        request_data["birth_date"])
+
+    num_charges = len(record.charges)
+
+    num_eligible_charges = len([ c for c in record.charges if
+        c.expungement_result.type_eligibility.status == EligibilityStatus.ELIGIBLE])
+
+    insert_result = db_insert_result(
+        g.database, hashed_search_params, num_charges, num_eligible_charges)
+
+
+@rollback_errors
+def db_insert_result(database, hashed_search_params, num_charges, num_eligible_charges):
+
+    result= database.cursor.execute(
+        """
+        INSERT INTO  SEARCH_RESULTS(search_result_id, hashed_search_params, num_charges, num_eligible_charges )
+        VALUES ( uuid_generate_v4(), %(params)s, %(num_charges)s, %(num_eligible_charges)s);
+        """, {'params': hashed_search_params, 'num_charges': num_charges,
+              'num_eligible_charges': num_eligible_charges})

--- a/src/backend/tests/endpoints/test_search.py
+++ b/src/backend/tests/endpoints/test_search.py
@@ -4,6 +4,7 @@ from expungeservice.endpoints import search
 from tests.endpoints.endpoint_util import EndpointShared
 from tests.factories.crawler_factory import CrawlerFactory
 from expungeservice.serializer import ExpungeModelEncoder
+import expungeservice
 from expungeservice import stats
 
 
@@ -22,6 +23,11 @@ class TestSearch(EndpointShared):
         self.mock_record = {
             "john_doe": CrawlerFactory.create(self.crawler)
         }
+        self.search_request_data = {
+            "first_name": "John",
+            "last_name": "Doe",
+            "middle_name": "",
+            "birth_date": "02/02/1990"}
 
 
     def tearDown(self):
@@ -36,11 +42,19 @@ class TestSearch(EndpointShared):
     def mock_search(self, mocked_record_name):
         return lambda s, first_name, last_name, middle_name, birth_date: self.mock_record[mocked_record_name]
 
+    def mock_save_result_fail(self, user_id, request_data, record):
+        raise Exception("Exception to test failing save_result")
+
     def test_search(self):
         self.login(self.user_data["user1"]["email"], self.user_data["user1"]["password"])
 
         search.Crawler.login = self.mock_login(True)
         search.Crawler.search = self.mock_search("john_doe")
+
+        """
+        A separate test, below, verifies that the save-result step
+        also works. Here, we mock the function to reduce the scope of the test.
+        """
         search.save_result = lambda user_id, request_data, record : None
 
         """
@@ -59,10 +73,82 @@ class TestSearch(EndpointShared):
 
 
         response = self.client.post("/api/search",
-            json={"first_name": "John",
-                  "last_name": "Doe",
-                  "middle_name": "",
-                  "birth_date": "02/02/1990"})
+            json=self.search_request_data)
+
+        assert(response.status_code == 200)
+        data = response.get_json()["data"]
+
+        """
+        Check that the resulting "record" field in the response matches what we gave to the
+        mock search function.
+        (use this json encode-decode approach because it turns a Record into a dict.)
+        """
+        assert data["record"] == json.loads(json.dumps(
+            self.mock_record["john_doe"], cls = ExpungeModelEncoder))
+
+
+    def test_search_creates_save_results(self):
+        """
+        This is the same test as above except it includes the save-results step. Less unit-y,
+        more of a vertical test.
+        """
+
+        self.login(self.user_data["user1"]["email"], self.user_data["user1"]["password"])
+
+        search.Crawler.login = self.mock_login(True)
+        search.Crawler.search = self.mock_search("john_doe")
+
+        self.client.post(
+            "/api/oeci_login",
+            json={"oeci_username": "correctusername",
+                  "oeci_password": "correctpassword"})
+
+        assert self.client.cookie_jar._cookies[
+            "localhost.local"]["/"]["oeci_token"]
+
+        response = self.client.post("/api/search",
+            json=self.search_request_data)
+
+        assert(response.status_code == 200)
+        data = response.get_json()["data"]
+
+        """
+        Check that the resulting "record" field in the response matches
+        what we gave to the mock search function.
+
+        (use this json encode-decode approach because it turns a Record into a dict.)
+        """
+        assert data["record"] == json.loads(json.dumps(
+            self.mock_record["john_doe"], cls = ExpungeModelEncoder))
+
+
+        self.check_search_result_saved(
+            self.user_data["user1"]["user_id"], self.search_request_data,
+            num_eligible_charges = 6, num_charges = 9)
+
+
+    def test_search_with_failing_save_results(self):
+        """
+        The search endpoint should succeed even if something goes wrong with the save-result step.
+
+        """
+
+        self.login(self.user_data["user1"]["email"], self.user_data["user1"]["password"])
+        search.Crawler.login = self.mock_login(True)
+        search.Crawler.search = self.mock_search("john_doe")
+        search.save_result = self. mock_save_result_fail
+
+        self.client.post(
+            "/api/oeci_login",
+            json={"oeci_username": "correctusername",
+                  "oeci_password": "correctpassword"})
+
+        assert self.client.cookie_jar._cookies[
+            "localhost.local"]["/"]["oeci_token"]
+
+
+        response = self.client.post("/api/search",
+            json=self.search_request_data)
 
         assert(response.status_code == 200)
         data = response.get_json()["data"]

--- a/src/backend/tests/endpoints/test_search.py
+++ b/src/backend/tests/endpoints/test_search.py
@@ -4,6 +4,7 @@ from expungeservice.endpoints import search
 from tests.endpoints.endpoint_util import EndpointShared
 from tests.factories.crawler_factory import CrawlerFactory
 from expungeservice.serializer import ExpungeModelEncoder
+from expungeservice import stats
 
 
 class TestSearch(EndpointShared):
@@ -14,6 +15,7 @@ class TestSearch(EndpointShared):
         """ Save these actual function refs to reinstate after we're done mocking them."""
         self.crawler_login = search.Crawler.login
         self.search = search.Crawler.search
+        self.save_result = search.save_result
 
         self.crawler = CrawlerFactory.setup()
         self.crawler.logged_in = True
@@ -25,6 +27,8 @@ class TestSearch(EndpointShared):
     def tearDown(self):
         search.Crawler.login = self.crawler_login
         search.Crawler.search = self.search
+        search.save_result = self.save_result
+
 
     def mock_login(self, return_value):
         return lambda s, username, password, close_session=False: return_value
@@ -37,6 +41,7 @@ class TestSearch(EndpointShared):
 
         search.Crawler.login = self.mock_login(True)
         search.Crawler.search = self.mock_search("john_doe")
+        search.save_result = lambda request_data, record : None
 
         """
         as a more unit-y unit test, we could make the encrypted cookie

--- a/src/backend/tests/endpoints/test_search.py
+++ b/src/backend/tests/endpoints/test_search.py
@@ -41,7 +41,7 @@ class TestSearch(EndpointShared):
 
         search.Crawler.login = self.mock_login(True)
         search.Crawler.search = self.mock_search("john_doe")
-        search.save_result = lambda request_data, record : None
+        search.save_result = lambda user_id, request_data, record : None
 
         """
         as a more unit-y unit test, we could make the encrypted cookie

--- a/src/backend/tests/stats/test_stats_save_result.py
+++ b/src/backend/tests/stats/test_stats_save_result.py
@@ -1,11 +1,29 @@
-from flask import g
+from flask import g, request
+
 
 import expungeservice
 from expungeservice.database.db_util import rollback_errors
-from expungeservice.stats import save_result
+from expungeservice import stats
 from tests.factories.crawler_factory import CrawlerFactory
 from expungeservice.database import get_database
 from tests.endpoints.endpoint_util import EndpointShared
+from flask.views import MethodView
+
+
+class TestStatsView(MethodView):
+    """
+    To get the direct call to stats.save_result() to work,
+    this endpoint wrapper is needed so that the flask.current_user
+    object gets populated with user_id
+    """
+
+    def post(self):
+
+        request_data = request.get_json()
+        record = CrawlerFactory.create(CrawlerFactory.setup())
+        stats.save_result(request_data, record)
+
+        return "TestStatsViewResponse"
 
 
 class TestStats(EndpointShared):
@@ -13,27 +31,23 @@ class TestStats(EndpointShared):
 
     def test_save_result(self):
 
+        self.app.add_url_rule(
+            "/api/test/save_result", view_func=TestStatsView.as_view(
+                "save_result"))
 
         user_id = self.user_data["user1"]["user_id"]
 
-        with expungeservice.create_app("development").app_context():
+        request_data = {
+            "first_name":"John",
+            "last_name":"Doe",
+            "middle_name":"Test",
+            "birth_date":"01/01/1980",
+        }
 
-            expungeservice.request.before() #Opens a db connection at g.database
+        self.login(self.user_data["user1"]["email"], self.user_data["user1"]["password"])
 
-            request_data = {
-                "first_name":"John",
-                "last_name":"Doe",
-                "middle_name":"Test",
-                "birth_date":"01/01/1980",
-            }
+        response = self.client.post('/api/test/save_result', json = request_data)
 
-            record = CrawlerFactory.create(CrawlerFactory.setup())
-
-            save_result(user_id, request_data, record)
-
-            g.database.connection.commit()
-
-            self.check_search_result_saved(
-                self.user_data["user1"]["user_id"], request_data,
-                num_eligible_charges=6, num_charges=9)
-
+        self.check_search_result_saved(
+                    self.user_data["user1"]["user_id"], request_data,
+                    num_eligible_charges=6, num_charges=9)

--- a/src/backend/tests/stats/test_stats_save_result.py
+++ b/src/backend/tests/stats/test_stats_save_result.py
@@ -2,28 +2,8 @@ from flask import g, request
 
 
 import expungeservice
-from expungeservice.database.db_util import rollback_errors
-from expungeservice import stats
 from tests.factories.crawler_factory import CrawlerFactory
-from expungeservice.database import get_database
 from tests.endpoints.endpoint_util import EndpointShared
-from flask.views import MethodView
-
-
-class TestStatsView(MethodView):
-    """
-    To get the direct call to stats.save_result() to work,
-    this endpoint wrapper is needed so that the flask.current_user
-    object gets populated with user_id
-    """
-
-    def post(self):
-
-        request_data = request.get_json()
-        record = CrawlerFactory.create(CrawlerFactory.setup())
-        stats.save_result(request_data, record)
-
-        return "TestStatsViewResponse"
 
 
 class TestStats(EndpointShared):
@@ -31,23 +11,25 @@ class TestStats(EndpointShared):
 
     def test_save_result(self):
 
-        self.app.add_url_rule(
-            "/api/test/save_result", view_func=TestStatsView.as_view(
-                "save_result"))
+        with self.client:
+            user_id = self.user_data["user1"]["user_id"]
 
-        user_id = self.user_data["user1"]["user_id"]
+            request_data = {
+                "first_name":"John",
+                "last_name":"Doe",
+                "middle_name":"Test",
+                "birth_date":"01/01/1980",
+            }
 
-        request_data = {
-            "first_name":"John",
-            "last_name":"Doe",
-            "middle_name":"Test",
-            "birth_date":"01/01/1980",
-        }
+            record = CrawlerFactory.create(CrawlerFactory.setup())
 
-        self.login(self.user_data["user1"]["email"], self.user_data["user1"]["password"])
+            self.login(self.user_data["user1"]["email"], self.user_data["user1"]["password"])
 
-        response = self.client.post('/api/test/save_result', json = request_data)
+            expungeservice.request.before()
+
+            expungeservice.stats.save_result(request_data, record)
+            g.database.connection.commit()
 
         self.check_search_result_saved(
-                    self.user_data["user1"]["user_id"], request_data,
-                    num_eligible_charges=6, num_charges=9)
+                self.user_data["user1"]["user_id"], request_data,
+                num_eligible_charges=6, num_charges=9)

--- a/src/backend/tests/stats/test_stats_save_result.py
+++ b/src/backend/tests/stats/test_stats_save_result.py
@@ -4,6 +4,7 @@ from flask import g, request
 import expungeservice
 from tests.factories.crawler_factory import CrawlerFactory
 from tests.endpoints.endpoint_util import EndpointShared
+from expungeservice.database import get_database
 
 
 class TestStats(EndpointShared):
@@ -25,9 +26,10 @@ class TestStats(EndpointShared):
 
             self.login(self.user_data["user1"]["email"], self.user_data["user1"]["password"])
 
-            expungeservice.request.before()
+            g.database = get_database()
 
             expungeservice.stats.save_result(request_data, record)
+
             g.database.connection.commit()
 
         self.check_search_result_saved(

--- a/src/backend/tests/stats/test_stats_save_result.py
+++ b/src/backend/tests/stats/test_stats_save_result.py
@@ -1,0 +1,57 @@
+from flask import g
+
+import expungeservice
+from expungeservice.database.db_util import rollback_errors
+from expungeservice.stats import save_result
+from tests.factories.crawler_factory import CrawlerFactory
+from expungeservice.database import get_database
+from tests.endpoints.endpoint_util import EndpointShared
+
+
+class TestStats():
+
+    def test_save_result(self):
+
+        with expungeservice.create_app("development").app_context():
+
+            expungeservice.request.before()
+            database = get_database()
+            user_id = "user_id"
+            request_data = {
+                "first_name":"first_name",
+                "last_name":"last_name",
+                "middle_name":"middle_name",
+                "birth_date":"birth_date",
+            }
+
+
+            record = CrawlerFactory.create(CrawlerFactory.setup())
+
+            save_result(user_id, request_data, record)
+
+            expungeservice.request.after(None)
+
+            hashed_search_params = hash(
+                user_id +
+                "first_name" +
+                "last_name" +
+                "middle_name" +
+                "birth_date")
+            database.cursor.execute(
+                    """
+                    SELECT * FROM SEARCH_RESULTS
+                    WHERE cast(hashed_search_params as bigint) = %(hashed_search_params)s
+                    ;
+                    """,{'hashed_search_params': hashed_search_params})
+
+            result = database.cursor.fetchone()._asdict()
+            assert result["num_eligible_charges"] == 6
+            assert result["num_charges"] == 9
+
+            database.cursor.execute(
+                    """
+                    DELETE FROM SEARCH_RESULTS
+                    WHERE cast(hashed_search_params as bigint) = %(hashed_search_params)s
+                    ;
+                    """,{'hashed_search_params': hashed_search_params})
+            database.connection.commit()

--- a/src/backend/tests/stats/test_stats_save_result.py
+++ b/src/backend/tests/stats/test_stats_save_result.py
@@ -8,20 +8,22 @@ from expungeservice.database import get_database
 from tests.endpoints.endpoint_util import EndpointShared
 
 
-class TestStats():
+class TestStats(EndpointShared):
+
 
     def test_save_result(self):
+
+        user_id = self.user_data["user1"]["user_id"]
 
         with expungeservice.create_app("development").app_context():
 
             expungeservice.request.before()
             database = get_database()
-            user_id = "user_id"
             request_data = {
-                "first_name":"first_name",
-                "last_name":"last_name",
-                "middle_name":"middle_name",
-                "birth_date":"birth_date",
+                "first_name":"John",
+                "last_name":"Doe",
+                "middle_name":"Test",
+                "birth_date":"01/01/1980",
             }
 
 
@@ -33,10 +35,11 @@ class TestStats():
 
             hashed_search_params = hash(
                 user_id +
-                "first_name" +
-                "last_name" +
-                "middle_name" +
-                "birth_date")
+                request_data["first_name"] +
+                request_data["last_name"] +
+                request_data["middle_name"] +
+                request_data["birth_date"])
+
             database.cursor.execute(
                     """
                     SELECT * FROM SEARCH_RESULTS

--- a/src/backend/tests/stats/test_stats_save_result.py
+++ b/src/backend/tests/stats/test_stats_save_result.py
@@ -18,7 +18,7 @@ class TestStats(EndpointShared):
         with expungeservice.create_app("development").app_context():
 
             expungeservice.request.before()
-            database = get_database()
+
             request_data = {
                 "first_name":"John",
                 "last_name":"Doe",
@@ -40,21 +40,21 @@ class TestStats(EndpointShared):
                 request_data["middle_name"] +
                 request_data["birth_date"])
 
-            database.cursor.execute(
+            g.database.cursor.execute(
                     """
                     SELECT * FROM SEARCH_RESULTS
                     WHERE cast(hashed_search_params as bigint) = %(hashed_search_params)s
                     ;
                     """,{'hashed_search_params': hashed_search_params})
 
-            result = database.cursor.fetchone()._asdict()
+            result = g.database.cursor.fetchone()._asdict()
             assert result["num_eligible_charges"] == 6
             assert result["num_charges"] == 9
 
-            database.cursor.execute(
+            g.database.cursor.execute(
                     """
                     DELETE FROM SEARCH_RESULTS
                     WHERE cast(hashed_search_params as bigint) = %(hashed_search_params)s
                     ;
                     """,{'hashed_search_params': hashed_search_params})
-            database.connection.commit()
+            g.database.connection.commit()

--- a/src/backend/tests/stats/test_stats_save_result.py
+++ b/src/backend/tests/stats/test_stats_save_result.py
@@ -19,7 +19,7 @@ class TestStats(EndpointShared):
 
         with expungeservice.create_app("development").app_context():
 
-            expungeservice.request.before()
+            expungeservice.request.before() #Opens a db connection at g.database
 
             request_data = {
                 "first_name":"John",
@@ -28,12 +28,11 @@ class TestStats(EndpointShared):
                 "birth_date":"01/01/1980",
             }
 
-
             record = CrawlerFactory.create(CrawlerFactory.setup())
 
             save_result(user_id, request_data, record)
 
-            expungeservice.request.after(None)
+            g.database.connection.commit()
 
             search_param_string = (
                 user_id +


### PR DESCRIPTION
This saves some minimal search results data to the database every time the search endpoint is called: 

- Timestamp of search 
- Hash of the current user's user_id and the search params used.
- The number of charges found in the record
- The number of eligible charges found in the record
- Edit: Incuding user_id

The search parameters and user_id are concatenated and then hashed deterministically so that we can keep track of unique searches.

Edit: Michael et al. agreed that holding onto the user_id information is fine. 
~~The search result doesn't include the user_id itself. This is to make individual users' levels of activity hidden, once there is more than one user of the app. The tradeoff is that it doesn't enable a user to check only their own usage statistics. If we want to add that feature but protect that info from other users, we'll need to add an additional security mechanism.~~

I updated the search endpoint test case to mock this added feature, so that the test case doesn't have a side effect on the database.

Something I will change before merging is that `current_user.user_id` is currently being read in **search.py** but should be read from **stats.py** . I was having trouble getting the test case to work that way. Will figure it out though.

Related to #49 and #119 . 
