### PR TITLE
Convert Charge into a dataclass

### DIFF
--- a/src/backend/expungeservice/models/charge_creator.py
+++ b/src/backend/expungeservice/models/charge_creator.py
@@ -1,4 +1,8 @@
 import re
+import weakref
+from datetime import datetime
+
+from dacite import from_dict
 
 from expungeservice.models.charge_classifier import ChargeClassifier
 
@@ -12,10 +16,12 @@ class ChargeCreator:
         chapter = ChargeCreator._set_chapter(kwargs['statute'])
         section = ChargeCreator.__set_section(statute)
         classification = ChargeClassifier(case.violation_type, statute, level, chapter, section).classify()
-        kwargs['chapter'] = chapter
-        kwargs['section'] = section
+        kwargs['date'] = datetime.date(datetime.strptime(kwargs['date'], '%m/%d/%Y'))
+        kwargs['_case'] = weakref.ref(case)
+        kwargs['_chapter'] = chapter
+        kwargs['_section'] = section
         kwargs['statute'] = statute
-        return classification(**kwargs)
+        return from_dict(data_class=classification, data=kwargs)
 
     @staticmethod
     def __strip_non_alphanumeric_chars(statute):

--- a/src/backend/expungeservice/models/charge_types/charge.py
+++ b/src/backend/expungeservice/models/charge_types/charge.py
@@ -34,13 +34,13 @@ class Charge:
     def acquitted(self):
         return self.disposition and self.disposition.ruling[0:9].lower() != 'convicted'
 
-    def convicted(self):
-        return self.disposition and not self.acquitted()
+    def __convicted(self):
+        return not self.acquitted()
 
     def recent_conviction(self):
         ten_years_ago = (date_class.today() + relativedelta(years=-10))
-        if self.convicted() and self.disposition:
-            return self.disposition.date > ten_years_ago
+        if self.__convicted():
+            return self.disposition.date > ten_years_ago # type: ignore
         else:
             return False
 

--- a/src/backend/expungeservice/models/charge_types/charge.py
+++ b/src/backend/expungeservice/models/charge_types/charge.py
@@ -9,7 +9,7 @@ from dateutil.relativedelta import relativedelta
 from expungeservice.models.disposition import Disposition
 from expungeservice.models.expungement_result import ExpungementResult, TimeEligibility, EligibilityStatus
 
-@dataclass
+@dataclass(eq=False)
 class Charge:
     name: str
     statute: str

--- a/src/backend/expungeservice/models/charge_types/charge.py
+++ b/src/backend/expungeservice/models/charge_types/charge.py
@@ -1,24 +1,29 @@
 import weakref
+from dataclasses import dataclass, InitVar, field
 
-from datetime import datetime
-from datetime import date as date_class
+from datetime import date as date_class, datetime
+from typing import Optional
+
 from dateutil.relativedelta import relativedelta
+
+from expungeservice.models.disposition import Disposition
 from expungeservice.models.expungement_result import ExpungementResult, TimeEligibility, EligibilityStatus
 
-
+@dataclass
 class Charge:
+    name: str
+    statute: str
+    level: str
+    date: date_class
+    disposition: Optional[Disposition]
+    expungement_result: ExpungementResult = field(init=False)
+    _chapter: Optional[str]
+    _section: str
+    _case: weakref.ref
 
-    def __init__(self, case, name, statute, level, date, chapter, section, disposition=None):
-        self.name = name
-        self.statute = statute
-        self.level = level
-        self.date = datetime.date(datetime.strptime(date, '%m/%d/%Y'))
-        self.disposition = disposition
+    def __post_init__(self):
         type_eligibility = self._default_type_eligibility()
         self.expungement_result = ExpungementResult(type_eligibility=type_eligibility, time_eligibility=None)
-        self._chapter = chapter
-        self._section = section
-        self._case = weakref.ref(case)
 
     def _default_type_eligibility(self):
         raise NotImplementedError
@@ -34,7 +39,7 @@ class Charge:
 
     def recent_conviction(self):
         ten_years_ago = (date_class.today() + relativedelta(years=-10))
-        if self.convicted():
+        if self.convicted() and self.disposition:
             return self.disposition.date > ten_years_ago
         else:
             return False

--- a/src/backend/tests/models/test_charge.py
+++ b/src/backend/tests/models/test_charge.py
@@ -77,6 +77,13 @@ class TestChargeClass(unittest.TestCase):
 
         assert charge.recent_acquittal() is False
 
+    def test_same_charge_is_not_equal(self):
+        case = CaseFactory.create(case_number="C0000")
+        mrc_charge = ChargeFactory.create(case=case)
+        second_mrc_charge = ChargeFactory.create(case=case)
+
+        assert mrc_charge != second_mrc_charge
+
 
 class TestChargeStatuteSectionAssignment(unittest.TestCase):
 


### PR DESCRIPTION
~~This was not caught in the existing unit tests because we explicitly pass in a datetime object (`charge = ChargeFactory.create(date=self.THREE_YEARS_AGO)`) but the crawler returns a string. Note that we do properly convert to a datetime object when we build the Case object.~~

Edit: As pointed out by @NickSchimek below we do pass in strings in the unit tests; there is no issue here.

Also clarifies that the Disposition may be None (Optional).