### PR TITLE
Fix case where disposition is not set

### DIFF
--- a/src/backend/Pipfile
+++ b/src/backend/Pipfile
@@ -21,6 +21,7 @@ cryptography = "*"
 flask-login = "==0.4.1"
 dacite = "==1.0.2"
 mypy = "==0.740"
+pytest-lazy-fixture = "==0.6.2"
 
 [dev-packages]
 

--- a/src/backend/Pipfile.lock
+++ b/src/backend/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2dff8506b3899ed67bab8e161908e24520c1bd3172658b2883f3bb8449bfadbc"
+            "sha256": "fbcd39767ed6163ef201d263d937956213dd430ab119e966ed24ccacebda8aea"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,13 +16,6 @@
         ]
     },
     "default": {
-        "atomicwrites": {
-            "hashes": [
-                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
-                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
-            ],
-            "version": "==1.3.0"
-        },
         "attrs": {
             "hashes": [
                 "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
@@ -285,10 +278,10 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:0db4b7601aae1d35b4a033282da476845aa19185c1e6964b25cf324b5e4ec3e6",
-                "sha256:fa5fa1622fa6dd5c030e9cad086fa19ef6a0cf6d7a2d12318e10cb49d6d68f34"
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
             ],
-            "version": "==0.13.0"
+            "version": "==0.13.1"
         },
         "psycopg2": {
             "hashes": [
@@ -339,11 +332,19 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:15837d2880cb94821087bc07476892ea740696b20e90288fd6c19e44b435abdb",
-                "sha256:b6cf7ad9064049ee486586b3a0ddd70dc5136c40e1147e7d286efd77ba66c5eb"
+                "sha256:1897d74f60a5d8be02e06d708b41bf2445da2ee777066bd68edf14474fc201eb",
+                "sha256:f6a567e20c04259d41adce9a360bd8991e6aa29dd9695c5e6bd25a9779272673"
             ],
             "index": "pypi",
-            "version": "==5.2.3"
+            "version": "==5.3.0"
+        },
+        "pytest-lazy-fixture": {
+            "hashes": [
+                "sha256:bcdc184ef988abbde2d906330a7f681595c8e9753a5ff07c5a9860389aa3b766",
+                "sha256:eb2f4573b371c690b91e637d09dfa30e2d6ba1234833df1920fc8b7b0d0fcebb"
+            ],
+            "index": "pypi",
+            "version": "==0.6.2"
         },
         "python-dateutil": {
             "hashes": [

--- a/src/backend/expungeservice/serializer/serializer.py
+++ b/src/backend/expungeservice/serializer/serializer.py
@@ -30,12 +30,13 @@ class ExpungeModelEncoder(flask.json.JSONEncoder):
         }
 
     def charge_to_json(self, charge):
+        disposition = self.disposition_to_json(charge.disposition) if charge.disposition else None
         return {
             "name": charge.name,
             "statute": charge.statute,
             "level": charge.level,
             "date": charge.date,
-            "disposition": self.disposition_to_json(charge.disposition),
+            "disposition": disposition,
             "expungement_result": self.expungement_result_to_json(charge.expungement_result)
         }
 

--- a/src/backend/tests/functional_tests/test_crawler_expunger.py
+++ b/src/backend/tests/functional_tests/test_crawler_expunger.py
@@ -1,101 +1,139 @@
-import unittest
-
 from datetime import date as date_class
+
+import pytest
 from dateutil.relativedelta import relativedelta
 from expungeservice.expunger.expunger import Expunger
 from tests.factories.crawler_factory import CrawlerFactory
 from tests.fixtures.case_details import CaseDetails
 from tests.fixtures.john_doe import JohnDoe
 
+ONE_YEAR_AGO = (date_class.today() + relativedelta(years=-1))
+TWO_YEARS_AGO = (date_class.today() + relativedelta(years=-2))
+FIFTEEN_YEARS_AGO = (date_class.today() + relativedelta(years=-15))
 
-class TestCrawlerAndExpunger(unittest.TestCase):
 
-    ONE_YEAR_AGO = (date_class.today() + relativedelta(years=-1))
-    TWO_YEARS_AGO = (date_class.today() + relativedelta(years=-2))
-    FIFTEEN_YEARS_AGO = (date_class.today() + relativedelta(years=-15))
+@pytest.fixture
+def crawler():
+    return CrawlerFactory.setup()
 
-    def setUp(self):
-        self.crawler = CrawlerFactory.setup()
 
-    def test_expunger_with_open_case(self):
-        record = CrawlerFactory.create(self.crawler, JohnDoe.RECORD, {'X0001': CaseDetails.CASE_X1,
-                                                             'X0002': CaseDetails.CASE_WITHOUT_FINANCIAL_SECTION,
-                                                             'X0003': CaseDetails.CASE_WITHOUT_DISPOS})
-        expunger = Expunger(record)
-        assert expunger.run() is False
-        assert expunger.errors == ['Open cases exist']
+@pytest.fixture
+def record_with_open_case(crawler):
+    return CrawlerFactory.create(crawler, JohnDoe.RECORD,
+                                 {'X0001': CaseDetails.CASE_X1,
+                                  'X0002': CaseDetails.CASE_WITHOUT_FINANCIAL_SECTION,
+                                  'X0003': CaseDetails.CASE_WITHOUT_DISPOS})
 
-    def test_expunger_with_an_empty_record(self):
-        record = CrawlerFactory.create(self.crawler, JohnDoe.BLANK_RECORD, {})
-        expunger = Expunger(record)
 
-        assert expunger.run() is True
-        assert expunger.most_recent_dismissal is None
-        assert expunger.most_recent_conviction is None
+def test_expunger_with_open_case(record_with_open_case):
+    expunger = Expunger(record_with_open_case)
 
-    def test_partial_dispos(self):
-        crawler = CrawlerFactory.setup()
-        record = CrawlerFactory.create(crawler, JohnDoe.SINGLE_CASE_RECORD, {'CASEJD1': CaseDetails.CASE_WITH_PARTIAL_DISPOS})
+    assert not expunger.run()
+    assert expunger.errors == ['Open cases exist']
 
-        expunger = Expunger(record)
-        expunger.run()
 
-    def test_case_without_dispos(self):
-        crawler = CrawlerFactory.setup()
-        record = CrawlerFactory.create(crawler, JohnDoe.SINGLE_CASE_RECORD, {'CASEJD1': CaseDetails.CASE_WITHOUT_DISPOS})
+@pytest.fixture
+def empty_record(crawler):
+    return CrawlerFactory.create(crawler, JohnDoe.BLANK_RECORD, {})
 
-        expunger = Expunger(record)
-        expunger.run()
 
-    def test_expunger_categorizes_charges(self):
-        record = CrawlerFactory.create(self.crawler,
-                              cases={'X0001': CaseDetails.case_x(dispo_ruling_1='Convicted - Failure to show',
-                                                                 dispo_ruling_2='Dismissed',
-                                                                 dispo_ruling_3='Acquitted'),
-                                     'X0002': CaseDetails.case_x(dispo_ruling_1='Dismissed',
-                                                                 dispo_ruling_2='Convicted',
-                                                                 dispo_ruling_3='Convicted'),
-                                     'X0003': CaseDetails.case_x(dispo_ruling_1='No Complaint',
-                                                                 dispo_ruling_2='Dismissed',
-                                                                 dispo_ruling_3='Convicted')})
-        expunger = Expunger(record)
+def test_expunger_with_an_empty_record(empty_record):
+    expunger = Expunger(empty_record)
 
-        assert expunger.run() is True
-        assert len(expunger.acquittals) == 5
-        assert len(expunger.convictions) == 4
+    assert expunger.run()
+    assert expunger.most_recent_dismissal is None
+    assert expunger.most_recent_conviction is None
 
-    def test_expunger_runs_time_analyzer(self):
-        record = CrawlerFactory.create(self.crawler,
-                              cases={'X0001': CaseDetails.case_x(arrest_date=self.FIFTEEN_YEARS_AGO.strftime('%m/%d/%Y'),
-                                                                 dispo_date=self.FIFTEEN_YEARS_AGO.strftime('%m/%d/%Y'),
-                                                                 dispo_ruling_1='Dismissed',
-                                                                 dispo_ruling_2='Convicted',
-                                                                 dispo_ruling_3='Acquitted'),
-                                     'X0002': CaseDetails.case_x(arrest_date=self.TWO_YEARS_AGO.strftime('%m/%d/%Y'),
-                                                                 dispo_ruling_1='Dismissed',
-                                                                 dispo_ruling_2='Dismissed',
-                                                                 dispo_ruling_3='Dismissed'),
-                                     'X0003': CaseDetails.case_x(arrest_date=self.ONE_YEAR_AGO.strftime('%m/%d/%Y'),
-                                                                 dispo_ruling_1='No Complaint',
-                                                                 dispo_ruling_2='No Complaint',
-                                                                 dispo_ruling_3='No Complaint')})
-        expunger = Expunger(record)
 
-        assert expunger.run() is True
+@pytest.fixture
+def partial_dispos_record(crawler):
+    return CrawlerFactory.create(crawler, JohnDoe.SINGLE_CASE_RECORD,
+                                 {'CASEJD1': CaseDetails.CASE_WITH_PARTIAL_DISPOS})
 
-        assert expunger.most_recent_conviction is None
-        assert expunger.second_most_recent_conviction is None
-        assert expunger.most_recent_dismissal.disposition.ruling == 'No Complaint'
-        assert len(expunger.acquittals) == 8
 
-        assert record.cases[0].charges[0].expungement_result.time_eligibility.status is False
-        assert record.cases[0].charges[1].expungement_result.time_eligibility.status is True
-        assert record.cases[0].charges[2].expungement_result.time_eligibility.status is False
+def test_partial_dispos(partial_dispos_record):
+    expunger = Expunger(partial_dispos_record)
+    assert expunger.run()
 
-        assert record.cases[1].charges[0].expungement_result.time_eligibility.status is False
-        assert record.cases[1].charges[1].expungement_result.time_eligibility.status is False
-        assert record.cases[1].charges[2].expungement_result.time_eligibility.status is False
 
-        assert record.cases[2].charges[0].expungement_result.time_eligibility.status is True
-        assert record.cases[2].charges[1].expungement_result.time_eligibility.status is True
-        assert record.cases[2].charges[2].expungement_result.time_eligibility.status is True
+@pytest.fixture
+def record_without_dispos(crawler):
+    return CrawlerFactory.create(crawler, JohnDoe.SINGLE_CASE_RECORD,
+                                 {'CASEJD1': CaseDetails.CASE_WITHOUT_DISPOS})
+
+
+def test_case_without_dispos(record_without_dispos):
+    expunger = Expunger(record_without_dispos)
+    assert expunger.run()
+
+
+@pytest.fixture
+def record_with_various_categories(crawler):
+    return CrawlerFactory.create(crawler,
+                                 cases={'X0001': CaseDetails.case_x(
+                                     dispo_ruling_1='Convicted - Failure to show',
+                                     dispo_ruling_2='Dismissed',
+                                     dispo_ruling_3='Acquitted'),
+                                     'X0002': CaseDetails.case_x(
+                                         dispo_ruling_1='Dismissed',
+                                         dispo_ruling_2='Convicted',
+                                         dispo_ruling_3='Convicted'),
+                                     'X0003': CaseDetails.case_x(
+                                         dispo_ruling_1='No Complaint',
+                                         dispo_ruling_2='Dismissed',
+                                         dispo_ruling_3='Convicted')})
+
+
+def test_expunger_categorizes_charges(record_with_various_categories):
+    expunger = Expunger(record_with_various_categories)
+
+    assert expunger.run()
+    assert len(expunger.acquittals) == 5
+    assert len(expunger.convictions) == 4
+
+@pytest.fixture
+def record_with_specific_dates(crawler):
+    return CrawlerFactory.create(crawler,
+                                   cases={'X0001': CaseDetails.case_x(
+                                       arrest_date=FIFTEEN_YEARS_AGO.strftime(
+                                           '%m/%d/%Y'),
+                                       dispo_date=FIFTEEN_YEARS_AGO.strftime(
+                                           '%m/%d/%Y'),
+                                       dispo_ruling_1='Dismissed',
+                                       dispo_ruling_2='Convicted',
+                                       dispo_ruling_3='Acquitted'),
+                                          'X0002': CaseDetails.case_x(
+                                              arrest_date=TWO_YEARS_AGO.strftime(
+                                                  '%m/%d/%Y'),
+                                              dispo_ruling_1='Dismissed',
+                                              dispo_ruling_2='Dismissed',
+                                              dispo_ruling_3='Dismissed'),
+                                          'X0003': CaseDetails.case_x(
+                                              arrest_date=ONE_YEAR_AGO.strftime(
+                                                  '%m/%d/%Y'),
+                                              dispo_ruling_1='No Complaint',
+                                              dispo_ruling_2='No Complaint',
+                                              dispo_ruling_3='No Complaint')})
+
+def test_expunger_runs_time_analyzer(record_with_specific_dates):
+    record = record_with_specific_dates
+    expunger = Expunger(record)
+
+    assert expunger.run()
+
+    assert expunger.most_recent_conviction is None
+    assert expunger.second_most_recent_conviction is None
+    assert expunger.most_recent_dismissal.disposition.ruling == 'No Complaint'
+    assert len(expunger.acquittals) == 8
+
+    assert record.cases[0].charges[0].expungement_result.time_eligibility.status is False
+    assert record.cases[0].charges[1].expungement_result.time_eligibility.status is True
+    assert record.cases[0].charges[2].expungement_result.time_eligibility.status is False
+
+    assert record.cases[1].charges[0].expungement_result.time_eligibility.status is False
+    assert record.cases[1].charges[1].expungement_result.time_eligibility.status is False
+    assert record.cases[1].charges[2].expungement_result.time_eligibility.status is False
+
+    assert record.cases[2].charges[0].expungement_result.time_eligibility.status is True
+    assert record.cases[2].charges[1].expungement_result.time_eligibility.status is True
+    assert record.cases[2].charges[2].expungement_result.time_eligibility.status is True

--- a/src/backend/tests/serializer/test_serializer.py
+++ b/src/backend/tests/serializer/test_serializer.py
@@ -1,15 +1,30 @@
+import pytest
+
+from expungeservice.expunger.expunger import Expunger
 from expungeservice.serializer import ExpungeModelEncoder
 from tests.factories.crawler_factory import CrawlerFactory
 
 import unittest
 import json
 
-class TestRecordObjectSerializer(unittest.TestCase):
+from tests.functional_tests.test_crawler_expunger import record_with_open_case, \
+    empty_record, partial_dispos_record, record_without_dispos, \
+    record_with_various_categories, record_with_specific_dates, crawler
 
-    def test_it_creates_json(self):
 
-        crawler = CrawlerFactory.setup()
-        record = CrawlerFactory.create(crawler)
+@pytest.fixture(params=[
+    pytest.lazy_fixture('record_with_open_case'),
+    pytest.lazy_fixture('empty_record'),
+    pytest.lazy_fixture('partial_dispos_record'),
+    pytest.lazy_fixture('record_without_dispos'),
+    pytest.lazy_fixture('record_with_various_categories'),
+    pytest.lazy_fixture('record_with_specific_dates')
+])
+def _record(request):
+    return request.param
 
-        jsonified_dictionary = json.loads(json.dumps(record, cls=ExpungeModelEncoder))
-        assert type(jsonified_dictionary) == dict
+def test_round_trip_various_records(_record):
+    expunger = Expunger(_record)
+    expunger.run()
+    json.loads(json.dumps(_record, cls=ExpungeModelEncoder))
+

--- a/src/frontend/src/components/Charge/index.tsx
+++ b/src/frontend/src/components/Charge/index.tsx
@@ -17,6 +17,29 @@ export default class Charge extends React.Component<Props> {
       expungement_result
     } = this.props.charge;
 
+    const knownDisposition = (disposition: any) => (
+      <>
+        <li className="mb2">
+          <span className="fw7">Disposition: </span> {disposition.ruling}
+        </li>
+        <li className="mb2">
+          <span className="fw7">Convicted: </span> {disposition.date}
+        </li>
+      </>
+    );
+
+    const dispositionRender = (disposition: any) => {
+      if (disposition === null) {
+        return (
+          <li className="mb2">
+            <span className="fw7">Disposition: </span> Unknown
+          </li>
+        );
+      } else {
+        return knownDisposition(disposition);
+      }
+    };
+
     return (
       <div className="br3 ma2 bg-white">
         <Eligibility expungement_result={expungement_result} />
@@ -31,12 +54,7 @@ export default class Charge extends React.Component<Props> {
                 <span className="fw7">Charge: </span>
                 {`${statute}-${name}`}
               </li>
-              <li className="mb2">
-                <span className="fw7">Disposition: </span> {disposition.ruling}
-              </li>
-              <li className="mb2">
-                <span className="fw7">Convicted: </span> {disposition.date}
-              </li>
+              {dispositionRender(disposition)}
             </ul>
           </div>
         </div>

--- a/src/frontend/src/components/SearchResults/types.ts
+++ b/src/frontend/src/components/SearchResults/types.ts
@@ -2,7 +2,7 @@ export interface ChargeType {
   statute: string;
   expungement_result: any;
   name: string;
-  disposition: {
+  disposition?: {
     ruling: string;
     date: string;
   };


### PR DESCRIPTION
Closes #578 

Sometimes there are charges without a corresponding disposition in the OECI database. This will just crash the server saying that upon attempt at serialization disposition.date didn't exist as disposition was None.

~~TODO: I still owe a non-manual test for this issue. However, I've gone ahead and pushed this to https://recordexpungpdx.herokuapp.com/ so that Michael won't be blocked from testing.~~

Edit: Tests have been added.