### PR TITLE
user component now integrated with /api/users GET endpoint

### DIFF
--- a/config/postgres/initdb/scripts/initial_credentials.dev.sql
+++ b/config/postgres/initdb/scripts/initial_credentials.dev.sql
@@ -1,2 +1,2 @@
 SELECT * FROM USERS_CREATE( 'admin@email.com', 'pbkdf2:sha256:150000$c30CjWVB$d1d6d544dfffd2dee5488cfe89cc2f965a8c4cddbf9180ad206f272237a5fa1a', 'Ima Admin', 'Ima Group', true);
-SELECT * FROM USERS_CREATE('user@email.com', 'pbkdf2:sha256:150000$K5efuBwy$fcaa41a3203fd8f64b5d4aee241365ffa35e0a3a1c02f605bbc20cbea701cf89', 'Ima User', 'Ima Group' , true);
+SELECT * FROM USERS_CREATE('user@email.com', 'pbkdf2:sha256:150000$K5efuBwy$fcaa41a3203fd8f64b5d4aee241365ffa35e0a3a1c02f605bbc20cbea701cf89', 'Ima User', 'Ima Group' , false);

--- a/src/backend/expungeservice/endpoints/usersview.py
+++ b/src/backend/expungeservice/endpoints/usersview.py
@@ -107,10 +107,10 @@ class UsersView(MethodView):
             response_data: Dict[str, List[Dict[str, str]]] = {"users": []}
             for user_entry in user_db_data:
                 response_data["users"].append({
-                    "user_id": user_entry["user_id"],
+                    "id": user_entry["user_id"],
                     "email": user_entry["email"],
                     "name": user_entry["name"],
-                    "group_name": user_entry["group_name"],
+                    "group": user_entry["group_name"],
                     "admin": user_entry["admin"],
                     "timestamp": user_entry["date_created"]
                     })

--- a/src/backend/tests/endpoints/test_users.py
+++ b/src/backend/tests/endpoints/test_users.py
@@ -113,8 +113,8 @@ class TestUsers(EndpointShared):
         assert data["users"][0]["admin"] in [True, False]
         assert data["users"][0]["timestamp"]
         assert data["users"][0]["name"]
-        assert data["users"][0]["group_name"]
-        assert data["users"][0]["user_id"]
+        assert data["users"][0]["group"]
+        assert data["users"][0]["id"]
 
     def test_get_users_not_admin(self):
         self.login(self.user_data["user1"]["email"], self.user_data["user1"]["password"])

--- a/src/frontend/src/components/LoadingSpinner/index.tsx
+++ b/src/frontend/src/components/LoadingSpinner/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface Props {
+  inputString: string;
+}
+
+class LoadingSpinner extends React.Component<Props> {
+  render() {
+    return (
+      <p className="bg-white mv4 pa4 br3 fw6 tc">
+        <span className="spinner mr2"></span>Loading {this.props.inputString}...
+      </p>
+    );
+  }
+}
+
+export default LoadingSpinner;

--- a/src/frontend/src/components/LogIn/index.tsx
+++ b/src/frontend/src/components/LogIn/index.tsx
@@ -153,7 +153,7 @@ class LogIn extends React.Component<Props, State> {
               ) : null}
               {this.state.invalidResponse === true ? (
                 <p id="no_match_msg" className="bg-washed-red mv4 pa3 br3 fw6">
-                  Technical difficulties try again later.
+                  Technical difficulties, please contact system administrator.
                 </p>
               ) : null}
             </div>

--- a/src/frontend/src/components/NotAuthorized/index.tsx
+++ b/src/frontend/src/components/NotAuthorized/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+class NotAuthorized extends React.Component {
+  render() {
+    return (
+      <p className="bg-white mv4 pa4 br3 fw6 tc shadow br3">
+        You are not authorized to view this content, please contact system
+        administraitor.
+      </p>
+    );
+  }
+}
+
+export default NotAuthorized;

--- a/src/frontend/src/components/NotAuthorized/index.tsx
+++ b/src/frontend/src/components/NotAuthorized/index.tsx
@@ -5,7 +5,7 @@ class NotAuthorized extends React.Component {
     return (
       <p className="bg-white mv4 pa4 br3 fw6 tc shadow br3">
         You are not authorized to view this content, please contact system
-        administraitor.
+        administrator.
       </p>
     );
   }

--- a/src/frontend/src/components/OeciLogin/index.tsx
+++ b/src/frontend/src/components/OeciLogin/index.tsx
@@ -133,7 +133,7 @@ class OeciLogin extends React.Component<Props, State> {
               ) : null}
               {this.state.invalidResponse === true ? (
                 <p id="no_match_msg" className="bg-washed-red mv4 pa3 br3 fw6">
-                  Technical difficulties try again later.
+                  Technical difficulties, please contact system administrator.
                 </p>
               ) : null}
             </div>

--- a/src/frontend/src/components/Spinner/index.tsx
+++ b/src/frontend/src/components/Spinner/index.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-
-export default function() {
-  return (
-    <p className="bg-white mv4 pa4 br3 fw6">
-      <span className="spinner mr2"></span>Loading your search results...
-    </p>
-  );
-}

--- a/src/frontend/src/components/TechnicalDifficulties/index.tsx
+++ b/src/frontend/src/components/TechnicalDifficulties/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+class TechnicalDifficulties extends React.Component {
+  render() {
+    return (
+      <p className="bg-white mv4 pa4 br3 fw6 tc shadow br3">
+        Something went wrong, please contact system administraitor to report
+        technical difficulties.
+      </p>
+    );
+  }
+}
+
+export default TechnicalDifficulties;

--- a/src/frontend/src/components/TechnicalDifficulties/index.tsx
+++ b/src/frontend/src/components/TechnicalDifficulties/index.tsx
@@ -4,7 +4,7 @@ class TechnicalDifficulties extends React.Component {
   render() {
     return (
       <p className="bg-white mv4 pa4 br3 fw6 tc shadow br3">
-        Something went wrong, please contact system administraitor to report
+        Something went wrong, please contact system administrator to report
         technical difficulties.
       </p>
     );

--- a/src/frontend/src/components/User/index.tsx
+++ b/src/frontend/src/components/User/index.tsx
@@ -8,14 +8,28 @@ interface Props {
 class User extends React.Component<Props> {
   public render() {
     return (
-      <tr>
-        <td className="pa3 bb b--black-20">
-          <a href="#" className="underline">
+      <tr className="bt b--black-20">
+        <td className="pa3">
+          <a href="/admin" className="underline">
             {this.props.user.name}
           </a>
         </td>
-        <td className="pa3 bb b--black-20">{this.props.user.role}</td>
-        <td className="pa3 bb b--black-20">{this.props.user.group}</td>
+        <td className="pa3">{this.props.user.admin ? 'Admin' : 'Search'}</td>
+        <td className="pa3">{this.props.user.group}</td>
+        <td className="pa3 flex justify-end">
+          <button
+            aria-label={`edit user: ${this.props.user.name}`}
+            className="navy hover-dark-blue"
+          >
+            <i aria-hidden="true" className="fa fa-pen pr3" />
+          </button>
+          <button
+            aria-label={`delete user: ${this.props.user.name}`}
+            className="navy hover-dark-blue"
+          >
+            <i aria-hidden="true" className="fa fa-trash" />
+          </button>
+        </td>
       </tr>
     );
   }

--- a/src/frontend/src/components/UserList/index.tsx
+++ b/src/frontend/src/components/UserList/index.tsx
@@ -34,16 +34,16 @@ class UserList extends React.Component<Props> {
   }
 
   displayNoUsers = () => {
-    return this.state.errorType === 'none' ? (
-      <LoadingSpinner inputString={'Users'} />
-    ) : this.state.errorType === 'unauthorized' ? (
-      <NotAuthorized />
-    ) : (
-      <TechnicalDifficulties />
-    );
+    if (this.state.errorType === 'none') {
+      return <LoadingSpinner inputString={'Users'} />;
+    } else if (this.state.errorType === 'unauthorized') {
+      return <NotAuthorized />;
+    } else {
+      return <TechnicalDifficulties />;
+    }
   };
 
-  displayUsers = () => {
+  displayUserList = () => {
     const returnList = this.props.users.userList.map(user => {
       return <User key={user.id} user={user} />;
     });
@@ -51,33 +51,35 @@ class UserList extends React.Component<Props> {
     return returnList;
   };
 
+  displayUsers = () => (
+    <section className="cf bg-white shadow br3 mb5">
+      <div className="pv4 ph3">
+        <h1 className="f3 fw6 dib">Users</h1>
+        <button className="bg-navy white bg-animate hover-bg-dark-blue fw6 br2 pv2 ph3 fr">
+          New User
+        </button>
+      </div>
+
+      <div className="overflow-auto">
+        <table className="f6 w-100 mw8 center collapse">
+          <thead className="bb b--black-20">
+            <tr>
+              <th className="fw6 tl pb3 ph3 bg-white">Name</th>
+              <th className="fw6 tl pb3 ph3 bg-white">Role</th>
+              <th className="fw6 tl pb3 ph3 bg-white">Group</th>
+            </tr>
+          </thead>
+
+          <tbody className="lh-copy">{this.displayUserList()}</tbody>
+        </table>
+      </div>
+    </section>
+  );
+
   render() {
-    return this.props.users.userList.length > 0 ? (
-      <section className="cf bg-white shadow br3 mb5">
-        <div className="pv4 ph3">
-          <h1 className="f3 fw6 dib">Users</h1>
-          <button className="bg-navy white bg-animate hover-bg-dark-blue fw6 br2 pv2 ph3 fr">
-            New User
-          </button>
-        </div>
-
-        <div className="overflow-auto">
-          <table className="f6 w-100 mw8 center collapse">
-            <thead className="bb b--black-20">
-              <tr>
-                <th className="fw6 tl pb3 ph3 bg-white">Name</th>
-                <th className="fw6 tl pb3 ph3 bg-white">Role</th>
-                <th className="fw6 tl pb3 ph3 bg-white">Group</th>
-              </tr>
-            </thead>
-
-            <tbody className="lh-copy">{this.displayUsers()}</tbody>
-          </table>
-        </div>
-      </section>
-    ) : (
-      this.displayNoUsers()
-    );
+    return this.props.users.userList.length > 0
+      ? this.displayUsers()
+      : this.displayNoUsers();
   }
 }
 

--- a/src/frontend/src/components/UserList/index.tsx
+++ b/src/frontend/src/components/UserList/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { AppState } from '../../redux/store';
-import { loadUsers } from '../../redux/users/actions';
+import { loadUsers, clearUsers } from '../../redux/users/actions';
 import { UserState } from '../../redux/users/types';
 import User from '../User';
 import LoadingSpinner from '../LoadingSpinner';
@@ -11,6 +11,7 @@ import TechnicalDifficulties from '../TechnicalDifficulties';
 interface Props {
   users: UserState;
   loadUsers: () => Promise<void>;
+  clearUsers: Function;
 }
 
 interface State {
@@ -31,6 +32,10 @@ class UserList extends React.Component<Props> {
         this.setState({ errorType: 'technical' });
       }
     });
+  }
+
+  componentWillUnmount() {
+    this.props.clearUsers();
   }
 
   displayNoUsers = () => {
@@ -89,5 +94,5 @@ const mapStateToProps = (state: AppState) => ({
 
 export default connect(
   mapStateToProps,
-  { loadUsers }
+  { loadUsers, clearUsers }
 )(UserList);

--- a/src/frontend/src/containers/AllRecords.tsx
+++ b/src/frontend/src/containers/AllRecords.tsx
@@ -44,7 +44,10 @@ const mapStateToProps = (state: AppState) => {
   };
 };
 
-export default connect(mapStateToProps, {
-  fetchRecords: loadSearchRecords,
-  clearRecords: clearSearchRecords
-})(AllRecords);
+export default connect(
+  mapStateToProps,
+  {
+    fetchRecords: loadSearchRecords,
+    clearRecords: clearSearchRecords
+  }
+)(AllRecords);

--- a/src/frontend/src/containers/AllStatus.tsx
+++ b/src/frontend/src/containers/AllStatus.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { AppState } from '../redux/store';
-import Spinner from '../components/Spinner';
+import LoadingSpinner from '../components/LoadingSpinner';
 import NoSearchResults from '../components/NoSearchResults';
 
 type Props = {
@@ -12,7 +12,11 @@ class AllStatus extends React.Component<Props> {
   render() {
     return (
       <section>
-        {this.props.loading ? <Spinner /> : <NoSearchResults />}
+        {this.props.loading ? (
+          <LoadingSpinner inputString={'your search results'} />
+        ) : (
+          <NoSearchResults />
+        )}
       </section>
     );
   }

--- a/src/frontend/src/redux/groups/actions.ts
+++ b/src/frontend/src/redux/groups/actions.ts
@@ -11,12 +11,12 @@ export const loadGroups = () => (dispatch: Dispatch) => {
           type: LOAD_GROUPS,
           groups
         })
-      )
-
+      );
     }, 1000);
   });
 };
 
+const date = () => new Date();
 // Data for loadGroups action to populate the store with group data
 const placeholderGroupData: Group[] = [
   {
@@ -28,21 +28,24 @@ const placeholderGroupData: Group[] = [
         group: 'Metropolitan Public Defender',
         id: 1,
         name: 'Jane Dolby',
-        role: 'Search'
+        admin: false,
+        timestamp: date()
       },
       {
         email: 'michael@email.com',
         group: 'Metropolitan Public Defender',
         id: 2,
         name: 'Michael Zhang',
-        role: 'Admin'
+        admin: true,
+        timestamp: date()
       },
       {
         email: 'melissa@email.com',
         group: 'Royce, Jennings & Coldwater',
         id: 3,
         name: 'Melissa Jennings',
-        role: 'Search'
+        admin: false,
+        timestamp: date()
       }
     ]
   },
@@ -55,42 +58,48 @@ const placeholderGroupData: Group[] = [
         group: 'Metropolitan Public Defender',
         id: 1,
         name: 'Jane Dolby',
-        role: 'Search'
+        admin: false,
+        timestamp: date()
       },
       {
         email: 'michael@email.com',
         group: 'Metropolitan Public Defender',
         id: 2,
         name: 'Michael Zhang',
-        role: 'Admin'
+        admin: true,
+        timestamp: date()
       },
       {
         email: 'melissa@email.com',
         group: 'Royce, Jennings & Coldwater',
         id: 3,
         name: 'Melissa Jennings',
-        role: 'Search'
+        admin: false,
+        timestamp: date()
       },
       {
         email: 'michael@email.com',
         group: 'Metropolitan Public Defender',
         id: 2,
         name: 'Michael Zhang',
-        role: 'Admin'
+        admin: true,
+        timestamp: date()
       },
       {
         email: 'melissa@email.com',
         group: 'Royce, Jennings & Coldwater',
         id: 3,
         name: 'Melissa Jennings',
-        role: 'Search'
+        admin: false,
+        timestamp: date()
       },
       {
         email: 'terri@email.com',
         group: 'Royce, Jennings & Coldwater',
         id: 4,
         name: 'Terri Royce',
-        role: 'Search'
+        admin: false,
+        timestamp: date()
       }
     ]
   },
@@ -103,28 +112,32 @@ const placeholderGroupData: Group[] = [
         group: 'Metropolitan Public Defender',
         id: 1,
         name: 'Jane Dolby',
-        role: 'Search'
+        admin: false,
+        timestamp: date()
       },
       {
         email: 'michael@email.com',
         group: 'Metropolitan Public Defender',
         id: 2,
         name: 'Michael Zhang',
-        role: 'Admin'
+        admin: true,
+        timestamp: date()
       },
       {
         email: 'melissa@email.com',
         group: 'Royce, Jennings & Coldwater',
         id: 3,
         name: 'Melissa Jennings',
-        role: 'Search'
+        admin: false,
+        timestamp: date()
       },
       {
         email: 'terri@email.com',
         group: 'Royce, Jennings & Coldwater',
         id: 4,
         name: 'Terri Royce',
-        role: 'Search'
+        admin: false,
+        timestamp: date()
       }
     ]
   },
@@ -137,16 +150,17 @@ const placeholderGroupData: Group[] = [
         group: 'Metropolitan Public Defender',
         id: 1,
         name: 'Jane Dolby',
-        role: 'Search'
+        admin: false,
+        timestamp: date()
       },
       {
         email: 'michael@email.com',
         group: 'Metropolitan Public Defender',
         id: 2,
         name: 'Michael Zhang',
-        role: 'Admin'
+        admin: true,
+        timestamp: date()
       }
     ]
   }
-
 ];

--- a/src/frontend/src/redux/system/actions.ts
+++ b/src/frontend/src/redux/system/actions.ts
@@ -2,6 +2,7 @@ import apiService from '../../service/api-service';
 import { removeCookie, hasOeciToken } from '../../service/cookie-service';
 import history from '../../service/history';
 import { LOG_IN, LOG_OUT } from './types';
+import { CLEAR_USERS } from '../users/types';
 import { Dispatch } from 'redux';
 import { AxiosError } from 'axios';
 
@@ -28,6 +29,7 @@ export function logOut(): any {
     })
       .then((response: any) => {
         removeCookie();
+        dispatch({ type: CLEAR_USERS, users: [] });
         dispatch({ type: LOG_OUT });
       })
       .catch((error: AxiosError) => {

--- a/src/frontend/src/redux/system/actions.ts
+++ b/src/frontend/src/redux/system/actions.ts
@@ -2,7 +2,6 @@ import apiService from '../../service/api-service';
 import { removeCookie, hasOeciToken } from '../../service/cookie-service';
 import history from '../../service/history';
 import { LOG_IN, LOG_OUT } from './types';
-import { CLEAR_USERS } from '../users/types';
 import { Dispatch } from 'redux';
 import { AxiosError } from 'axios';
 
@@ -29,7 +28,6 @@ export function logOut(): any {
     })
       .then((response: any) => {
         removeCookie();
-        dispatch({ type: CLEAR_USERS, users: [] });
         dispatch({ type: LOG_OUT });
       })
       .catch((error: AxiosError) => {

--- a/src/frontend/src/redux/users/actions.ts
+++ b/src/frontend/src/redux/users/actions.ts
@@ -1,5 +1,5 @@
 import { Dispatch } from 'redux';
-import { LOAD_USERS } from './types';
+import { LOAD_USERS, CLEAR_USERS } from './types';
 import apiService from '../../service/api-service';
 
 export const loadUsers = () => {
@@ -12,6 +12,14 @@ export const loadUsers = () => {
         type: LOAD_USERS,
         users: response.data.users
       });
+    });
+  };
+};
+
+export const clearUsers = () => {
+  return (dispatch: Dispatch) => {
+    dispatch({
+      type: CLEAR_USERS
     });
   };
 };

--- a/src/frontend/src/redux/users/actions.ts
+++ b/src/frontend/src/redux/users/actions.ts
@@ -1,47 +1,17 @@
 import { Dispatch } from 'redux';
-import { LOAD_USERS, User } from './types';
+import { LOAD_USERS } from './types';
+import apiService from '../../service/api-service';
 
-export const loadUsers = () => (dispatch: Dispatch) => {
-  return new Promise(resolve => {
-    setTimeout(() => {
-      // placeholderUserData will be replaced with the payload from the axios request
-      const users: User[] = placeholderUserData;
+export const loadUsers = () => {
+  return (dispatch: Dispatch) => {
+    return apiService(dispatch, {
+      url: '/api/users',
+      method: 'get'
+    }).then((response: any) => {
       dispatch({
         type: LOAD_USERS,
-        users
+        users: response.data.users
       });
-    }, 1000);
-  });
+    });
+  };
 };
-
-// Data for loadUsers action to populate the store with user data
-const placeholderUserData: User[] = [
-  {
-    email: 'jane@email.com',
-    group: 'Metropolitan Public Defender',
-    id: 1,
-    name: 'Jane Dolby',
-    role: 'Search'
-  },
-  {
-    email: 'michael@email.com',
-    group: 'Metropolitan Public Defender',
-    id: 2,
-    name: 'Michael Zhang',
-    role: 'Admin'
-  },
-  {
-    email: 'melissa@email.com',
-    group: 'Royce, Jennings & Coldwater',
-    id: 3,
-    name: 'Melissa Jennings',
-    role: 'Search'
-  },
-  {
-    email: 'terri@email.com',
-    group: 'Royce, Jennings & Coldwater',
-    id: 4,
-    name: 'Terri Royce',
-    role: 'Search'
-  }
-];

--- a/src/frontend/src/redux/users/reducer.ts
+++ b/src/frontend/src/redux/users/reducer.ts
@@ -1,4 +1,4 @@
-import { LOAD_USERS, UserActionTypes, UserState } from './types';
+import { CLEAR_USERS, LOAD_USERS, UserActionTypes, UserState } from './types';
 
 const initialState: UserState = {
   userList: []
@@ -12,6 +12,10 @@ export function usersReducer(
     case LOAD_USERS:
       return {
         userList: action.users
+      };
+    case CLEAR_USERS:
+      return {
+        userList: []
       };
     default:
       return state;

--- a/src/frontend/src/redux/users/types.ts
+++ b/src/frontend/src/redux/users/types.ts
@@ -3,11 +3,12 @@ export interface UserState {
 }
 
 export interface User {
+  admin: boolean;
   email: string;
   group: string;
   id: number;
   name: string;
-  role: string;
+  timestamp: Date;
 }
 
 export const LOAD_USERS = 'LOAD_USERS';

--- a/src/frontend/src/redux/users/types.ts
+++ b/src/frontend/src/redux/users/types.ts
@@ -12,10 +12,16 @@ export interface User {
 }
 
 export const LOAD_USERS = 'LOAD_USERS';
+export const CLEAR_USERS = 'CLEAR_USERS';
 
 interface LoadUsersAction {
   type: typeof LOAD_USERS;
   users: User[];
 }
 
-export type UserActionTypes = LoadUsersAction;
+interface ClearUserAction {
+  type: typeof CLEAR_USERS;
+  users: User[];
+}
+
+export type UserActionTypes = LoadUsersAction | ClearUserAction;


### PR DESCRIPTION
This PR now is pulling users from our database: #91 



Notes:

- Adjusted the initial users populated in the Developer database: "user@email.com" is no longer an Admin.  
- Adjusted the response object for the `/api/users` GET to match up with expected variable names in the front-end. changed: `user_id` to `id` and `group_name` to `group`.   
Previously I had a function that was converting the *snake_case* to the proper format but this solution allows us to pass the response object in directly.  
- Converted `<Spinner />` component to a generic `<LoadingSpinner inputString={} />` we are now able to use this loading spinner in anywhere we need to have it and pass in a string such as "Users" or "your search results".  


To-Do:

- currently I am displaying errors for this component, it would be good to isolate this logic and connect it to the redux-store so we can plug the error component in wherever we need it. I have created an issue for this: #582