### PR TITLE
Handle case status "Bankruptcy Pending" as closed

### DIFF
--- a/src/backend/expungeservice/models/case.py
+++ b/src/backend/expungeservice/models/case.py
@@ -69,4 +69,5 @@ class Case:
         return 'violation' in self.violation_type.lower() or 'municipal parking' == self.violation_type.lower()
 
     def _closed(self):
-        return self.current_status == 'Closed' or self.current_status == 'Inactive' or self.current_status == 'Purgable' or self.current_status == 'Bankruptcy Pending'
+        CLOSED_STATUS = ['Closed', 'Inactive', 'Purgable', 'Bankruptcy Pending']
+        return self.current_status in CLOSED_STATUS

--- a/src/backend/expungeservice/models/case.py
+++ b/src/backend/expungeservice/models/case.py
@@ -69,4 +69,4 @@ class Case:
         return 'violation' in self.violation_type.lower() or 'municipal parking' == self.violation_type.lower()
 
     def _closed(self):
-        return self.current_status == 'Closed' or self.current_status == 'Inactive' or self.current_status == 'Purgable'
+        return self.current_status == 'Closed' or self.current_status == 'Inactive' or self.current_status == 'Purgable' or self.current_status == 'Bankruptcy Pending'

--- a/src/backend/tests/models/test_case.py
+++ b/src/backend/tests/models/test_case.py
@@ -45,6 +45,10 @@ class TestCaseClosedMethod(unittest.TestCase):
         self.case.current_status = 'Purgable' 
         assert self.case.closed() is True
 
+    def test_it_returns_true_for_a_bankeruptcy_case(self):
+        self.case.current_status = 'Bankruptcy Pending'
+        assert self.case.closed() is True
+
 class TestBirthYearInitializesGivenMultipleValues(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Closes https://github.com/codeforpdx/recordexpungPDX/issues/584

We currently abort all analysis when a person still has an open case. We need to handle cases where the status is "Bankruptcy Pending" as closed.

I will follow up with a test here but for now I'm pushing to production to unblock Michael.