### PR TITLE
Search endpoint: Check for oeci_token before attempting search

### DIFF
--- a/src/backend/expungeservice/endpoints/search.py
+++ b/src/backend/expungeservice/endpoints/search.py
@@ -27,6 +27,9 @@ class Search(MethodView):
         cipher = DataCipher(
             key=current_app.config.get("SECRET_KEY"))
 
+        if not "oeci_token" in request.cookies.keys():
+            error(401, "Missing login credentials to OECI.")
+
         decrypted_credentials = cipher.decrypt(request.cookies["oeci_token"])
 
         crawler = Crawler()

--- a/src/backend/tests/endpoints/test_search.py
+++ b/src/backend/tests/endpoints/test_search.py
@@ -87,6 +87,15 @@ class TestSearch(EndpointShared):
             self.mock_record["john_doe"], cls = ExpungeModelEncoder))
 
 
+    def test_search_fails_without_oeci_token(self):
+        self.login(self.user_data["user1"]["email"], self.user_data["user1"]["password"])
+
+        response = self.client.post("/api/search",
+            json=self.search_request_data)
+
+        assert(response.status_code == 401)
+
+
     def test_search_creates_save_results(self):
         """
         This is the same test as above except it includes the save-results step. Less unit-y,


### PR DESCRIPTION
Is a backend fix to issue #545, whereas PR #587 is a fix to the frontend for the same issue. 