### PR TITLE
Moved errors fields to record object 

### DIFF
--- a/src/backend/expungeservice/expunger/expunger.py
+++ b/src/backend/expungeservice/expunger/expunger.py
@@ -28,7 +28,6 @@ class Expunger:
         """
         self.record = record
         self.charges = record.charges
-        self.errors = []
         self._skipped_charges = []
         self.most_recent_dismissal = None
         self.most_recent_conviction = None
@@ -46,7 +45,7 @@ class Expunger:
         :return: True if there are no open cases; otherwise False
         """
         if self._open_cases():
-            self.errors.append('Open cases exist')
+            self.record.errors.append('Open cases exist')
             return False
 
         self._tag_skipped_charges()

--- a/src/backend/tests/functional_tests/test_crawler_expunger.py
+++ b/src/backend/tests/functional_tests/test_crawler_expunger.py
@@ -29,7 +29,7 @@ def test_expunger_with_open_case(record_with_open_case):
     expunger = Expunger(record_with_open_case)
 
     assert not expunger.run()
-    assert expunger.record.errors == ['Open cases exist']
+    assert record_with_open_case.errors == ['Open cases exist']
 
 
 @pytest.fixture

--- a/src/backend/tests/functional_tests/test_crawler_expunger.py
+++ b/src/backend/tests/functional_tests/test_crawler_expunger.py
@@ -29,7 +29,7 @@ def test_expunger_with_open_case(record_with_open_case):
     expunger = Expunger(record_with_open_case)
 
     assert not expunger.run()
-    assert expunger.errors == ['Open cases exist']
+    assert expunger.record.errors == ['Open cases exist']
 
 
 @pytest.fixture


### PR DESCRIPTION
The Expunger no longer has an `errors` field so any errors that it generates need to be attached to the record object. Closes #261 . 

This is a requirement for #586 , since the errors field now is returned in the search endpoint. 

Expunger errors are unrelated to flask API errors, which addresses the discussion on #261.