### PR TITLE
Convert Disposition into a data class

### DIFF
--- a/src/backend/expungeservice/models/disposition.py
+++ b/src/backend/expungeservice/models/disposition.py
@@ -1,9 +1,14 @@
-from datetime import datetime
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Optional
 
 
+@dataclass(eq=False)
 class Disposition:
+    date: Optional[date]
+    ruling: str
 
-    def __init__(self, date=None, ruling=None):
+    def __init__(self, date: Optional[str] = None, ruling: str = ""):
         self.date = self.__set_date(date)
         self.ruling = ruling
 


### PR DESCRIPTION
Note we set `eq=False` and keep the old `__init__` method to preserve previous behavior. In other words, this is primarily for `__repr__`, the types, and for the consistency with every other class under models/.

Also see #617 