### PR TITLE
Print Date in results as Arrested date

### DIFF
--- a/src/frontend/src/components/Charge/index.tsx
+++ b/src/frontend/src/components/Charge/index.tsx
@@ -11,6 +11,7 @@ interface Props {
 export default class Charge extends React.Component<Props> {
   render() {
     const {
+      date,
       disposition,
       statute,
       name,
@@ -23,7 +24,7 @@ export default class Charge extends React.Component<Props> {
           <span className="fw7">Disposition: </span> {disposition.ruling}
         </li>
         <li className="mb2">
-          <span className="fw7">Convicted: </span> {disposition.date}
+          <span className="fw7">Arrested: </span> {date}
         </li>
       </>
     );

--- a/src/frontend/src/components/SearchResults/types.ts
+++ b/src/frontend/src/components/SearchResults/types.ts
@@ -2,6 +2,7 @@ export interface ChargeType {
   statute: string;
   expungement_result: any;
   name: string;
+  date: string;
   disposition?: {
     ruling: string;
     date: string;


### PR DESCRIPTION
The displayed date now comes from the Charge data object instead of the disposition. 

Closes #605 