### PR TITLE
Display loading spinner while loading a second search

### DIFF
--- a/src/frontend/src/redux/records/reducer.ts
+++ b/src/frontend/src/redux/records/reducer.ts
@@ -25,7 +25,7 @@ export function recordsReducer(
       // When an API call is made for records, loading state is toggled to true.
       // while loading state is true, a spinner is rendered on the screen. If loading
       // state is false, and no records were fetched, no search results found will be displayed.
-      return { ...state, loading: true };
+      return { ...state, records: {}, loading: true };
     case CLEAR_SEARCH_RECORDS:
       return { ...state, records: {}, loading: false };
     default:


### PR DESCRIPTION
The loading spinner component is only shown if the redux `records` object is empty, which is checked here:

 https://github.com/codeforpdx/recordexpungPDX/blob/master/src/frontend/src/containers/AllRecords.tsx#L34 ~~line 34.~~
 
We could change that logic, but this is a smaller and simpler change code-wise, so I'm running with it. 

closes #574 