### PR TITLE
Remove time portion on dates in search results data 

### DIFF
--- a/src/backend/expungeservice/serializer/serializer.py
+++ b/src/backend/expungeservice/serializer/serializer.py
@@ -1,6 +1,7 @@
 import flask
 import expungeservice
 from expungeservice.models.expungement_result import EligibilityStatus
+from datetime import date
 
 
 class ExpungeModelEncoder(flask.json.JSONEncoder):
@@ -84,6 +85,9 @@ class ExpungeModelEncoder(flask.json.JSONEncoder):
     def default(self, o):
         if isinstance(o, expungeservice.models.record.Record):
             return self.record_to_json(o)
+
+        elif isinstance(o, date):
+            return "{0} {1}, {2}".format(o.strftime("%b"), o.day, o.year)
 
         else:
             return flask.json.JSONEncoder.default(self, o)


### PR DESCRIPTION
Closes #573.

This is a backend change because the data serializer is the source of the extended datetime format. 

An alternative to the expression I'm using here is `o.strftime("%b %d, %Y")` but this pads the day of month with a leading 0 which is ugly. The date formatter doesn't provide a directive to show day of month without the leading 0.
