### PR TITLE
Flexible date format validation

### DIFF
--- a/src/frontend/src/components/RecordSearch/index.tsx
+++ b/src/frontend/src/components/RecordSearch/index.tsx
@@ -65,7 +65,7 @@ class RecordSearch extends React.Component<Props, State> {
             this.state.firstName.trim().length === 0 ||
             this.state.lastName.trim().length === 0,
           invalidDate:
-            moment(this.state.dateOfBirth, 'MM/DD/YYYY', true).isValid() ===
+            moment(this.state.dateOfBirth, 'M/D/YYYY', true).isValid() ===
               false && this.state.dateOfBirth.length !== 0
         },
         resolve


### PR DESCRIPTION
The format tokens in  `M/D/YYYY` optionally allow 1 or 2 digits. This is not totally explicit in the [momentjs documentation](https://momentjs.com/docs/)  but someone on SO pointed it out, hooray.
https://stackoverflow.com/questions/6177975/how-to-validate-date-with-format-mm-dd-yyyy-in-javascript 

Closes #571 