### PR TITLE
Unclassified charge always needs more analysis

### DIFF
--- a/src/backend/expungeservice/models/charge_types/unclassified_charge.py
+++ b/src/backend/expungeservice/models/charge_types/unclassified_charge.py
@@ -5,7 +5,4 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 class UnclassifiedCharge(Charge):
 
     def _default_type_eligibility(self):
-        if self.acquitted():
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason='Eligible under 137.225(1)(b)')
-        else:
-            return TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason='Examine')
+        return TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason="Unrecognized Charge : Further Analysis Needed")

--- a/src/backend/tests/models/charge_types/test_type_analyzer_acquitted_charges.py
+++ b/src/backend/tests/models/charge_types/test_type_analyzer_acquitted_charges.py
@@ -51,6 +51,16 @@ class TestSingleChargeDismissals(unittest.TestCase):
         assert felony_class_a_dismissed.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
         assert felony_class_a_dismissed.expungement_result.type_eligibility.reason == 'Eligible under 137.225(1)(b)'
 
+    def test_unclassified_charge(self):
+        self.single_charge['name'] = 'Assault in the ninth degree'
+        self.single_charge['statute'] = '333.333'
+        self.single_charge['level'] = 'Felony Class F'
+        unclassified_dismissed = self.create_recent_charge()
+        self.charges.append(unclassified_dismissed)
+
+        assert unclassified_dismissed.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert unclassified_dismissed.expungement_result.type_eligibility.reason == "Unrecognized Charge : Further Analysis Needed"
+
 
 class TestSingleChargeNoComplaint(unittest.TestCase):
 

--- a/src/backend/tests/models/charge_types/test_type_analyzer_convicted_charges.py
+++ b/src/backend/tests/models/charge_types/test_type_analyzer_convicted_charges.py
@@ -447,7 +447,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         self.charges.append(charge)
 
         assert charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-        assert charge.expungement_result.type_eligibility.reason == 'Examine'
+        assert charge.expungement_result.type_eligibility.reason == "Unrecognized Charge : Further Analysis Needed"
 
     # Test non-traffic violation
 


### PR DESCRIPTION
closes issue #620 

Reason: Certain known charge types are ineligible or need more analysis even if they are not convicted. A charge can be unclassified as a result of OECI data error and might be ineligible, so it should be marked as needing more analysis.