### PR TITLE
Serialized date fields exclude time of day

### DIFF
--- a/src/backend/expungeservice/serializer/serializer.py
+++ b/src/backend/expungeservice/serializer/serializer.py
@@ -1,6 +1,7 @@
 import flask
 import expungeservice
 from expungeservice.models.expungement_result import EligibilityStatus
+from datetime import date
 
 
 class ExpungeModelEncoder(flask.json.JSONEncoder):
@@ -84,6 +85,9 @@ class ExpungeModelEncoder(flask.json.JSONEncoder):
     def default(self, o):
         if isinstance(o, expungeservice.models.record.Record):
             return self.record_to_json(o)
+
+        elif isinstance(o, date):
+            return o.strftime("%b %-d, %Y")
 
         else:
             return flask.json.JSONEncoder.default(self, o)


### PR DESCRIPTION
Closes #573.

This is a backend change because the data serializer is the source of the extended datetime format.

This is a replacement PR for #614 because I got some sort of git snafu over there. 