### PR TITLE
DispositionStatus enum and related refactor

### DIFF
--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from dateutil.relativedelta import relativedelta
 
-from expungeservice.models.disposition import Disposition
+from expungeservice.models.disposition import Disposition, DispositionStatus
 from expungeservice.models.expungement_result import ExpungementResult, TimeEligibility, EligibilityStatus
 
 @dataclass(eq=False)
@@ -32,14 +32,14 @@ class Charge:
         return self._case
 
     def acquitted(self):
-        return self.disposition and self.disposition.ruling[0:9].lower() != 'convicted'
+        return self.disposition and (self.disposition.status == DispositionStatus.DISMISSED or self.disposition.status == DispositionStatus.NO_COMPLAINT)
 
-    def __convicted(self):
-        return not self.acquitted()
+    def convicted(self):
+        return self.disposition and self.disposition.status == DispositionStatus.CONVICTED
 
     def recent_conviction(self):
         ten_years_ago = (date_class.today() + relativedelta(years=-10))
-        if self.__convicted():
+        if self.convicted():
             return self.disposition.date > ten_years_ago # type: ignore
         else:
             return False

--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from dateutil.relativedelta import relativedelta
 
-from expungeservice.models.disposition import Disposition, DispositionStatus
+from expungeservice.models.disposition import Disposition
 from expungeservice.models.expungement_result import ExpungementResult, TimeEligibility, EligibilityStatus
 
 @dataclass(eq=False)
@@ -32,14 +32,14 @@ class Charge:
         return self._case
 
     def acquitted(self):
-        return self.disposition and (self.disposition.status == DispositionStatus.DISMISSED or self.disposition.status == DispositionStatus.NO_COMPLAINT)
+        return self.disposition and self.disposition.ruling[0:9].lower() != 'convicted'
 
-    def convicted(self):
-        return self.disposition and self.disposition.status == DispositionStatus.CONVICTED
+    def __convicted(self):
+        return not self.acquitted()
 
     def recent_conviction(self):
         ten_years_ago = (date_class.today() + relativedelta(years=-10))
-        if self.convicted():
+        if self.__convicted():
             return self.disposition.date > ten_years_ago # type: ignore
         else:
             return False

--- a/src/backend/expungeservice/models/charge_types/duii.py
+++ b/src/backend/expungeservice/models/charge_types/duii.py
@@ -31,10 +31,10 @@ class Duii(Charge):
                     reason="137.225(8)(b) - Diverted DUII charges are ineligible")
 
             cases = {
-                DispositionStatus.CONVICTED: convicted_type_eligibility
-                DispositionStatus.DISMISSED: dismissed_type_eligibility
-                DispositionStatus.NO_COMPLAINT: dismissed_type_eligibility
-                DispositionStatus.DIVERTED: diverted_type_eligibility
+                DispositionStatus.CONVICTED: convicted_type_eligibility,
+                DispositionStatus.DISMISSED: dismissed_type_eligibility,
+                DispositionStatus.NO_COMPLAINT: dismissed_type_eligibility,
+                DispositionStatus.DIVERTED: diverted_type_eligibility,
                 DispositionStatus.UNKNOWN: unknown_type_eligibility
             }
             assert len(cases) == len(DispositionStatus)

--- a/src/backend/expungeservice/models/charge_types/duii.py
+++ b/src/backend/expungeservice/models/charge_types/duii.py
@@ -1,5 +1,6 @@
 from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
+from expungeservice.models.disposition import DispositionStatus
 
 
 class Duii(Charge):
@@ -9,17 +10,18 @@ class Duii(Charge):
         if not self.disposition:
             return TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason='Further Analysis Needed - No disposition')
 
-        elif 'diverted' in self.disposition.ruling.lower():
-            return TypeEligibility(EligibilityStatus.INELIGIBLE, reason='Ineligible under 137.225(8)(b)')
+        elif self.disposition.status == DispositionStatus.DIVERTED:
+            return TypeEligibility(EligibilityStatus.INELIGIBLE, reason='137.225(8)(b) - Diverted DUII charges are ineligible')
 
-        elif self.acquitted():
-            return TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason='Further Analysis Needed')
+        elif self.convicted():
 
-        else:
             """
-            TODO: other dispositions than "convicted" are possible and are not handled here.
-            See issue: https://github.com/codeforpdx/recordexpungPDX/issues/601
-
             TODO: reason can be expanded to "137.225(7)(a) - Traffic offenses are ineligible"
             """
-            return TypeEligibility(EligibilityStatus.INELIGIBLE, reason='Ineligible under 137.225(7)(a)')
+            return TypeEligibility(EligibilityStatus.INELIGIBLE, reason='137.225(7)(a) - Traffic offenses are ineligible')
+
+        elif self.acquitted():
+            return TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason='Further Analysis Needed - Dismissed charge may have been Diverted')
+
+        else:
+            return TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason='Further Analysis Needed - Unrecognized ruling')

--- a/src/backend/expungeservice/models/disposition.py
+++ b/src/backend/expungeservice/models/disposition.py
@@ -20,6 +20,7 @@ class Disposition:
     def __init__(self, date: Optional[str] = None, ruling: str = ""):
         self.date = self.__set_date(date)
         self.ruling = ruling
+        self.__post_init__()
 
     def __post_init__(self):
         self.status = self.__set_status()

--- a/src/backend/expungeservice/models/disposition.py
+++ b/src/backend/expungeservice/models/disposition.py
@@ -1,18 +1,60 @@
 from dataclasses import dataclass
 from datetime import date, datetime
 from typing import Optional
+from enum import Enum
 
+
+class DispositionStatus(str, Enum):
+    CONVICTED = "Convicted"
+    DISMISSED = "Dismissed"
+    NO_COMPLAINT = "No Complaint"
+    DIVERTED = "Diverted"
+    UNKNOWN = "Unknown"
 
 @dataclass(eq=False)
 class Disposition:
     date: Optional[date]
     ruling: str
+    status: DispositionStatus
 
     def __init__(self, date: Optional[str] = None, ruling: str = ""):
         self.date = self.__set_date(date)
         self.ruling = ruling
+        self.status = self.__set_status()
 
     def __set_date(self, date):
         if date:
             return datetime.date(datetime.strptime(date, '%m/%d/%Y'))
         return None
+
+    def __set_status(self):
+        ruling = self.ruling.lower()
+        if any([conviction_ruling in ruling for conviction_ruling in [
+                "convicted",
+                "conviction",
+                "finding - guilty",
+                "conversion",
+                "converted"]]):
+
+            return DispositionStatus.CONVICTED
+
+        elif any([dismissal_ruling in ruling for dismissal_ruling in [
+                "acquitted",
+                "acquittal",
+                "dismissed",
+                "dismissal",
+                "finding - not guilty"]]):
+
+            return  DispositionStatus.DISMISSED
+
+        elif "diverted" in ruling:
+
+            return  DispositionStatus.DIVERTED
+
+        elif "no complaint" in ruling:
+
+            return  DispositionStatus.NO_COMPLAINT
+
+        else:
+
+            return  DispositionStatus.UNKNOWN

--- a/src/backend/expungeservice/models/disposition.py
+++ b/src/backend/expungeservice/models/disposition.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date, datetime
 from typing import Optional
 from enum import Enum
@@ -41,7 +41,7 @@ class Disposition:
         if any([rule in ruling for rule in conviction_rulings]):
             return DispositionStatus.CONVICTED
 
-        elif any([rule in ruling for rule in [ dismissal_rulings]]):
+        elif any([rule in ruling for rule in dismissal_rulings]):
             return  DispositionStatus.DISMISSED
 
         elif "diverted" in ruling:

--- a/src/backend/expungeservice/models/disposition.py
+++ b/src/backend/expungeservice/models/disposition.py
@@ -15,11 +15,13 @@ class DispositionStatus(str, Enum):
 class Disposition:
     date: Optional[date]
     ruling: str
-    status: DispositionStatus
+    status: DispositionStatus = field(init=False)
 
     def __init__(self, date: Optional[str] = None, ruling: str = ""):
         self.date = self.__set_date(date)
         self.ruling = ruling
+
+    def __post_init__(self):
         self.status = self.__set_status()
 
     def __set_date(self, date):
@@ -29,32 +31,24 @@ class Disposition:
 
     def __set_status(self):
         ruling = self.ruling.lower()
-        if any([conviction_ruling in ruling for conviction_ruling in [
-                "convicted",
-                "conviction",
-                "finding - guilty",
-                "conversion",
-                "converted"]]):
+        conviction_rulings = [
+            "convicted", "conviction",
+            "finding - guilty","conversion", "converted"]
+        dismissal_rulings = [
+            "acquitted", "acquittal", "dismissed",
+            "dismissal", "finding - not guilty"]
 
+        if any([rule in ruling for rule in conviction_rulings]):
             return DispositionStatus.CONVICTED
 
-        elif any([dismissal_ruling in ruling for dismissal_ruling in [
-                "acquitted",
-                "acquittal",
-                "dismissed",
-                "dismissal",
-                "finding - not guilty"]]):
-
+        elif any([rule in ruling for rule in [ dismissal_rulings]]):
             return  DispositionStatus.DISMISSED
 
         elif "diverted" in ruling:
-
             return  DispositionStatus.DIVERTED
 
         elif "no complaint" in ruling:
-
             return  DispositionStatus.NO_COMPLAINT
 
         else:
-
             return  DispositionStatus.UNKNOWN

--- a/src/backend/expungeservice/serializer/serializer.py
+++ b/src/backend/expungeservice/serializer/serializer.py
@@ -44,7 +44,8 @@ class ExpungeModelEncoder(flask.json.JSONEncoder):
     def disposition_to_json(self, disposition):
         return {
             "date": disposition.date ,
-            "ruling": disposition.ruling
+            "ruling": disposition.ruling,
+            "status": disposition.status
         }
 
     def expungement_result_to_json(self, expungement_result):

--- a/src/backend/tests/models/charge_types/test_type_analyzer_duii.py
+++ b/src/backend/tests/models/charge_types/test_type_analyzer_duii.py
@@ -20,7 +20,7 @@ def test_duii_acquitted():
     duii_acquitted = build_charge(statute = "813.010", disposition_ruling = "Acquitted")
 
     assert duii_acquitted.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert duii_acquitted.expungement_result.type_eligibility.reason == 'Further Analysis Needed'
+    assert duii_acquitted.expungement_result.type_eligibility.reason == 'Further Analysis Needed - Dismissed charge may have been Diverted'
 
 
 def test_duii_diverted():
@@ -28,7 +28,7 @@ def test_duii_diverted():
     duii_diverted = build_charge(statute = "813.011", disposition_ruling = "Diverted")
 
     assert duii_diverted.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert duii_diverted.expungement_result.type_eligibility.reason == 'Ineligible under 137.225(8)(b)'
+    assert duii_diverted.expungement_result.type_eligibility.reason == '137.225(8)(b) - Diverted DUII charges are ineligible'
 
 
 def test_duii_convicted():
@@ -36,4 +36,4 @@ def test_duii_convicted():
     duii_convicted = build_charge(statute = "813.123", disposition_ruling = "Convicted")
 
     assert duii_convicted.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert duii_convicted.expungement_result.type_eligibility.reason == 'Ineligible under 137.225(7)(a)'
+    assert duii_convicted.expungement_result.type_eligibility.reason == '137.225(7)(a) - Traffic offenses are ineligible'

--- a/src/frontend/src/components/Charge/index.tsx
+++ b/src/frontend/src/components/Charge/index.tsx
@@ -21,7 +21,7 @@ export default class Charge extends React.Component<Props> {
 
     const knownDisposition = (disposition: any, date: any) => {
       let dispositionEvent;
-      if (disposition.ruling.toLowerCase().includes("convicted")) {
+      if (disposition.status == "Convicted") {
         dispositionEvent = "Convicted: " ;
         date = disposition.date;
       } else {


### PR DESCRIPTION
This classifies a variety of disposition rulings into a standardized set of types. 

I still want to keep poking at this and see if the refactor of the  `acquitted` method is a good idea or could use some more work.

I could also add a test that various ruling strings get classified correctly. 

The check that I added for `DispositionStatus.UNKNOWN` (or call it `UNRECOGNIZED`?) is also something that I think should be added to type eligibility for every charge type. That should probably mean checking it once in the `Charge` class.
 
Closes #601 