### PR TITLE
Further Expunger refactorings

### DIFF
--- a/src/backend/expungeservice/expunger/expunger.py
+++ b/src/backend/expungeservice/expunger/expunger.py
@@ -1,6 +1,7 @@
 from more_itertools import padnone, take
 
 from expungeservice.expunger.analyzers.time_analyzer import TimeAnalyzer
+from expungeservice.models.charge_types.felony_class_b import FelonyClassB
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
@@ -129,6 +130,6 @@ class Expunger:
     def _class_b_felonies(charges):
         class_b_felonies = []
         for charge in charges:
-            if charge.__class__.__name__ == "FelonyClassB":
+            if isinstance(charge, FelonyClassB):
                 class_b_felonies.append(charge)
         return class_b_felonies

--- a/src/backend/expungeservice/expunger/expunger.py
+++ b/src/backend/expungeservice/expunger/expunger.py
@@ -55,7 +55,7 @@ class Expunger:
         self._categorize_charges()
         self._extract_most_recent_convictions()
         self._set_most_recent_dismissal()
-        self._set_recent_convictions()
+        self.most_recent_conviction, self.second_most_recent_conviction = self._most_recent_convictions()
         self._assign_most_recent_charge()
         self._assign_class_b_felonies()
         TimeAnalyzer.evaluate(self)
@@ -100,18 +100,15 @@ class Expunger:
         if self.acquittals and self.acquittals[-1].recent_acquittal():
             self.most_recent_dismissal = self.acquittals[-1]
 
-    def _set_recent_convictions(self):
+    def _most_recent_convictions(self):
         self._recent_convictions.sort(key=lambda charge: charge.disposition.date, reverse=True)
         first, second, third = take(3, padnone(self._recent_convictions))
         if first and first.level == "Violation":
-            self.most_recent_conviction = second
-            self.second_most_recent_conviction = third
+            return second, third
         elif second and second.level == "Violation":
-            self.most_recent_conviction = first
-            self.second_most_recent_conviction = third
+            return first, third
         else:
-            self.most_recent_conviction = first
-            self.second_most_recent_conviction = second
+            return first, second
 
     def _assign_most_recent_charge(self):
         self.charges.sort(key=lambda charge: charge.disposition.date, reverse=True)

--- a/src/backend/tests/expunger/test_expunger.py
+++ b/src/backend/tests/expunger/test_expunger.py
@@ -75,7 +75,6 @@ class TestExpungementAnalyzerUnitTests(unittest.TestCase):
         expunger = Expunger(record)
 
         assert expunger.run()
-        assert expunger._skipped_charges[0] == juvenile_charge
         assert expunger.charges == []
 
 


### PR DESCRIPTION
As we start to tackle issues like https://github.com/codeforpdx/recordexpungPDX/issues/642 or https://github.com/codeforpdx/recordexpungPDX/issues/586, we want to ensure that our changes don't have any unintended side-effects. Methods that mutate instance variables are more difficult to reason about than functions with no side-effects. This PR brings Expunger to the state where all "instance-level" reasoning can be done within the ~10 lines in `def run`. Note that `_dispositionless` still has side-effects but that will be taken care of in a following PR.

Note it will probably be easier to review this PR commit by commit.