### PR TITLE
Convicted/acquitted methods on Charge use disposition status

### DIFF
--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from dateutil.relativedelta import relativedelta
 
-from expungeservice.models.disposition import Disposition
+from expungeservice.models.disposition import Disposition, DispositionStatus
 from expungeservice.models.expungement_result import ExpungementResult, TimeEligibility, EligibilityStatus
 
 @dataclass(eq=False)
@@ -32,10 +32,12 @@ class Charge:
         return self._case
 
     def acquitted(self):
-        return self.disposition and self.disposition.ruling[0:9].lower() != 'convicted'
+        #TODO: rename this method and related variables to "dismissed" or similar
+        acquittal_statuses = [DispositionStatus.NO_COMPLAINT, DispositionStatus.DISMISSED]
+        return self.disposition and self.disposition.status in acquittal_statuses
 
     def __convicted(self):
-        return not self.acquitted()
+        return self.disposition and self.disposition.status == DispositionStatus.CONVICTED
 
     def recent_conviction(self):
         ten_years_ago = (date_class.today() + relativedelta(years=-10))

--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -36,12 +36,13 @@ class Charge:
         acquittal_statuses = [DispositionStatus.NO_COMPLAINT, DispositionStatus.DISMISSED]
         return self.disposition and self.disposition.status in acquittal_statuses
 
-    def __convicted(self):
-        return self.disposition and self.disposition.status == DispositionStatus.CONVICTED
+    def convicted(self):
+        conviction_statuses = [DispositionStatus.CONVICTED, DispositionStatus.DIVERTED]
+        return self.disposition and self.disposition.status in conviction_statuses
 
     def recent_conviction(self):
         ten_years_ago = (date_class.today() + relativedelta(years=-10))
-        if self.__convicted():
+        if self.convicted():
             return self.disposition.date > ten_years_ago # type: ignore
         else:
             return False

--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -33,12 +33,14 @@ class Charge:
 
     def acquitted(self):
         #TODO: rename this method and related variables to "dismissed" or similar
-        acquittal_statuses = [DispositionStatus.NO_COMPLAINT, DispositionStatus.DISMISSED]
+        acquittal_statuses = [
+            DispositionStatus.NO_COMPLAINT,
+            DispositionStatus.DISMISSED,
+            DispositionStatus.DIVERTED]
         return self.disposition and self.disposition.status in acquittal_statuses
 
     def convicted(self):
-        conviction_statuses = [DispositionStatus.CONVICTED, DispositionStatus.DIVERTED]
-        return self.disposition and self.disposition.status in conviction_statuses
+        return self.disposition and self.disposition.status == DispositionStatus.CONVICTED
 
     def recent_conviction(self):
         ten_years_ago = (date_class.today() + relativedelta(years=-10))

--- a/src/backend/expungeservice/models/charge_types/duii.py
+++ b/src/backend/expungeservice/models/charge_types/duii.py
@@ -34,7 +34,7 @@ class Duii(Charge):
             DispositionStatus.DIVERTED: diverted_type_eligibility,
             DispositionStatus.UNKNOWN: unknown_type_eligibility
         }
-        assert len(cases) == len(DispositionStatus)
-        # So that if someone adds something to DispositionStatus,
+        # This that if someone adds something to DispositionStatus,
         # it won't automatically go to the Unknown case.
+        assert len(cases) == len(DispositionStatus)
         return cases.get(self.disposition.status, unknown_type_eligibility) # type: ignore

--- a/src/backend/expungeservice/models/charge_types/duii.py
+++ b/src/backend/expungeservice/models/charge_types/duii.py
@@ -6,43 +6,35 @@ from expungeservice.models.disposition import DispositionStatus
 class Duii(Charge):
 
     def _default_type_eligibility(self):
+        """
+        DUII charges can be diverted, and in some cases the Disposition will
+        reflect this and in others it will say Dismissed.  We need to handle
+        both possibilities.
+        """
+        dismissed_type_eligibility = TypeEligibility(
+            EligibilityStatus.NEEDS_MORE_ANALYSIS,
+            reason="Further Analysis Needed - Dismissed charge may have been Diverted")
 
+        unknown_type_eligibility = TypeEligibility(
+            EligibilityStatus.NEEDS_MORE_ANALYSIS,
+            reason="Further Analysis Needed - Unrecognized ruling")
 
-        if self.disposition:
-            """
-            DUII charges can be diverted, and in some cases the Disposition will
-            reflect this and in others it will say Dismissed.  We need to handle
-            both possibilities.
-            """
-            dismissed_type_eligibility = TypeEligibility(
-                EligibilityStatus.NEEDS_MORE_ANALYSIS,
-                reason="Further Analysis Needed - Dismissed charge may have been Diverted")
+        convicted_type_eligibility = TypeEligibility(
+                EligibilityStatus.INELIGIBLE,
+                reason="137.225(7)(a) - Traffic offenses are ineligible")
 
-            unknown_type_eligibility = TypeEligibility(
-                EligibilityStatus.NEEDS_MORE_ANALYSIS,
-                reason="Further Analysis Needed - Unrecognized ruling")
+        diverted_type_eligibility = TypeEligibility(
+                EligibilityStatus.INELIGIBLE,
+                reason="137.225(8)(b) - Diverted DUII charges are ineligible")
 
-            convicted_type_eligibility = TypeEligibility(
-                    EligibilityStatus.INELIGIBLE,
-                    reason="137.225(7)(a) - Traffic offenses are ineligible")
-
-            diverted_type_eligibility = TypeEligibility(
-                    EligibilityStatus.INELIGIBLE,
-                    reason="137.225(8)(b) - Diverted DUII charges are ineligible")
-
-            cases = {
-                DispositionStatus.CONVICTED: convicted_type_eligibility,
-                DispositionStatus.DISMISSED: dismissed_type_eligibility,
-                DispositionStatus.NO_COMPLAINT: dismissed_type_eligibility,
-                DispositionStatus.DIVERTED: diverted_type_eligibility,
-                DispositionStatus.UNKNOWN: unknown_type_eligibility
-            }
-            assert len(cases) == len(DispositionStatus)
-            # So that if someone adds something to DispositionStatus,
-            # it won't automatically go to the Unknown case.
-            return cases.get(self.disposition.status, unknown_type_eligibility)
-
-        else:
-            return TypeEligibility(
-                EligibilityStatus.NEEDS_MORE_ANALYSIS,
-                reason="Further Analysis Needed - No disposition")
+        cases = {
+            DispositionStatus.CONVICTED: convicted_type_eligibility,
+            DispositionStatus.DISMISSED: dismissed_type_eligibility,
+            DispositionStatus.NO_COMPLAINT: dismissed_type_eligibility,
+            DispositionStatus.DIVERTED: diverted_type_eligibility,
+            DispositionStatus.UNKNOWN: unknown_type_eligibility
+        }
+        assert len(cases) == len(DispositionStatus)
+        # So that if someone adds something to DispositionStatus,
+        # it won't automatically go to the Unknown case.
+        return cases.get(self.disposition.status, unknown_type_eligibility) # type: ignore

--- a/src/backend/tests/models/charge_types/test_juvenile_charge.py
+++ b/src/backend/tests/models/charge_types/test_juvenile_charge.py
@@ -1,6 +1,7 @@
 import unittest
 
 from expungeservice.models.expungement_result import EligibilityStatus
+from expungeservice.models.disposition import Disposition
 
 from tests.factories.case_factory import CaseFactory
 from tests.factories.charge_factory import ChargeFactory
@@ -10,7 +11,8 @@ class TestJuvenileCharge(unittest.TestCase):
 
     def test_juvenile_charge(self):
         case = CaseFactory.create(type_status=['Juvenile Delinquency: Misdemeanor', 'Closed'])
-        juvenile_charge = ChargeFactory.create(case=case)
+        juvenile_charge = ChargeFactory.create(case=case, disposition =("Acquitted", "1/1/0001"))
+
 
         assert juvenile_charge.__class__.__name__ == 'JuvenileCharge'
         assert juvenile_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS

--- a/src/backend/tests/models/charge_types/test_juvenile_charge.py
+++ b/src/backend/tests/models/charge_types/test_juvenile_charge.py
@@ -13,7 +13,6 @@ class TestJuvenileCharge(unittest.TestCase):
         case = CaseFactory.create(type_status=['Juvenile Delinquency: Misdemeanor', 'Closed'])
         juvenile_charge = ChargeFactory.create(case=case, disposition =("Acquitted", "1/1/0001"))
 
-
         assert juvenile_charge.__class__.__name__ == 'JuvenileCharge'
         assert juvenile_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
         assert juvenile_charge.expungement_result.type_eligibility.reason == 'Juvenile Charge : Needs further analysis'

--- a/src/backend/tests/models/charge_types/test_type_analyzer_duii.py
+++ b/src/backend/tests/models/charge_types/test_type_analyzer_duii.py
@@ -16,23 +16,18 @@ def build_charge(statute, disposition_ruling):
 
 
 def test_duii_acquitted():
-
     duii_acquitted = build_charge(statute = "813.010", disposition_ruling = "Acquitted")
 
     assert duii_acquitted.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert duii_acquitted.expungement_result.type_eligibility.reason == 'Further Analysis Needed - Dismissed charge may have been Diverted'
 
-
 def test_duii_diverted():
-
     duii_diverted = build_charge(statute = "813.011", disposition_ruling = "Diverted")
 
     assert duii_diverted.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
     assert duii_diverted.expungement_result.type_eligibility.reason == '137.225(8)(b) - Diverted DUII charges are ineligible'
 
-
 def test_duii_convicted():
-
     duii_convicted = build_charge(statute = "813.123", disposition_ruling = "Convicted")
 
     assert duii_convicted.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE

--- a/src/backend/tests/models/test_disposition_status.py
+++ b/src/backend/tests/models/test_disposition_status.py
@@ -1,6 +1,7 @@
 from datetime import date
 
 from expungeservice.models.disposition import Disposition, DispositionStatus
+from expungeservice.models.expungement_result import EligibilityStatus
 
 from tests.factories.charge_factory import ChargeFactory
 
@@ -46,7 +47,15 @@ def test_all_disposition_statuses_are_either_convicted_or_acquitted():
             assert charge.convicted() or charge.acquitted()
 
 def test_dispositionless_charge_is_not_convicted_nor_acquitted():
-
     charge = ChargeFactory.create()
     assert not charge.convicted()
     assert not charge.acquitted()
+    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert charge.expungement_result.type_eligibility.reason == "Disposition not found. Needs further analysis"
+
+def test_charge_with_unknown_disposition_eligibility():
+    charge = ChargeFactory.create(disposition=["What am I", "1/1/0001"])
+    assert not charge.convicted()
+    assert not charge.acquitted()
+    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert charge.expungement_result.type_eligibility.reason == "Disposition not recognized. Needs further analysis"

--- a/src/backend/tests/models/test_disposition_status.py
+++ b/src/backend/tests/models/test_disposition_status.py
@@ -31,9 +31,8 @@ def test_all_disposition_statuses_are_either_convicted_or_acquitted():
     today = date.today().strftime('%m/%d/%Y')
 
     for status in DispositionStatus:
-
-        #Use the status.value to create the disposition,
-        #which happens to always be a valid string for that dispo status.
+        # Use the status.value to create the disposition,
+        # which happens to always be a valid string for that dispo status.
         charge.disposition = Disposition(today, status.value)
 
         if status == DispositionStatus.UNKNOWN:
@@ -41,9 +40,8 @@ def test_all_disposition_statuses_are_either_convicted_or_acquitted():
             assert not charge.acquitted()
 
         else:
-            #Make sure that every DispositionStatus value is covered by this approach.
+            # Make sure that every DispositionStatus value is covered by this approach.
             assert charge.disposition.status == status
-
             assert charge.convicted() or charge.acquitted()
 
 def test_dispositionless_charge_is_not_convicted_nor_acquitted():

--- a/src/backend/tests/models/test_disposition_status.py
+++ b/src/backend/tests/models/test_disposition_status.py
@@ -38,12 +38,12 @@ def test_all_disposition_statuses_are_either_convicted_or_acquitted():
         if status == DispositionStatus.UNKNOWN:
             assert not charge.convicted()
             assert not charge.acquitted()
-            continue
 
-        #Make sure that every DispositionStatus value is covered by this approach.
-        assert charge.disposition.status == status
+        else:
+            #Make sure that every DispositionStatus value is covered by this approach.
+            assert charge.disposition.status == status
 
-        assert charge.convicted() or charge.acquitted()
+            assert charge.convicted() or charge.acquitted()
 
 def test_dispositionless_charge_is_not_convicted_nor_acquitted():
 

--- a/src/backend/tests/models/test_disposition_status.py
+++ b/src/backend/tests/models/test_disposition_status.py
@@ -1,0 +1,52 @@
+from datetime import date
+
+from expungeservice.models.disposition import Disposition, DispositionStatus
+
+from tests.factories.charge_factory import ChargeFactory
+
+
+def test_disposition_status_values():
+    today = date.today().strftime('%m/%d/%Y')
+
+    assert Disposition(today, 'Dismissed').status == DispositionStatus.DISMISSED
+    assert Disposition(today, 'Dismissal').status == DispositionStatus.DISMISSED
+    assert Disposition(today, 'Acquitted').status == DispositionStatus.DISMISSED
+    assert Disposition(today, 'Acquittal').status == DispositionStatus.DISMISSED
+
+    assert Disposition(today, 'Convicted').status == DispositionStatus.CONVICTED
+    assert Disposition(today, 'Reduced to a lesser charge').status == DispositionStatus.CONVICTED
+    assert Disposition(today, 'Conversion - Disposition Types').status == DispositionStatus.CONVICTED
+
+    assert Disposition(today, 'Diverted').status == DispositionStatus.DIVERTED
+
+    assert Disposition(today, 'No complaint').status == DispositionStatus.NO_COMPLAINT
+
+    assert Disposition(today, 'What is this?').status == DispositionStatus.UNKNOWN
+
+
+def test_all_disposition_statuses_are_either_convicted_or_acquitted():
+
+    charge = ChargeFactory.create()
+    today = date.today().strftime('%m/%d/%Y')
+
+    for status in DispositionStatus:
+
+        #Use the status.value to create the disposition,
+        #which happens to always be a valid string for that dispo status.
+        charge.disposition = Disposition(today, status.value)
+
+        if status == DispositionStatus.UNKNOWN:
+            assert not charge.convicted()
+            assert not charge.acquitted()
+            continue
+
+        #Make sure that every DispositionStatus value is covered by this approach.
+        assert charge.disposition.status == status
+
+        assert charge.convicted() or charge.acquitted()
+
+def test_dispositionless_charge_is_not_convicted_nor_acquitted():
+
+    charge = ChargeFactory.create()
+    assert not charge.convicted()
+    assert not charge.acquitted()


### PR DESCRIPTION
This incorporates the new DispositionStatus enum from #637 to evaluate `acquitted()` and `convicted()` for a charge.

Here is where `acquitted()` gets called in time analysis:
https://github.com/codeforpdx/recordexpungPDX/blob/67c4bcc745cb5d4cbbb0c1179a36bf5b7617b5a3/src/backend/expungeservice/expunger/expunger.py#L86

Should we skip UNKNOWN dispositions in time analysis, like we do dispositionless charges? If so, then by the time we reach that `acquitted()` call we will have already purged UNKNOWN dispositions:

Since the new test case ensures everything else is either convicted or acquitted, the `if / else` in the expunger here works the same way as checking `acquitted()` and `convicted()` separately. 

So if that's the case, `convicted()` does nothing for time analysis. Right now I only renamed it from `__convicted()` so that it would be inherited on subclasses and be exposed in the test case (and that's not strictly necessary) . 

That seems fine as a place to leave it. We can also imagine incorporating this more after #645, because this is another way to check missing/unknown dispositions. Do something like:

```
def _categorize_charges(self):
        for charge in self.charges:
            if charge.acquitted():
                self.acquittals.append(charge)
            elif charge.convicted():
                self.convictions.append(charge)
            else:
                ... handle and/or skip charge ...
```

and some refactoring because the expunger already removed dispositionless charges. It's just that now we can handle dispositionless and disposition status unknown at the same time because they both yield  `(acquitted()==False` and `convicted==False)`.