### PR TITLE
Run time analyzer with all closed cases

### DIFF
--- a/src/backend/tests/functional_tests/test_crawler_expunger.py
+++ b/src/backend/tests/functional_tests/test_crawler_expunger.py
@@ -30,7 +30,7 @@ def test_expunger_with_open_case(record_with_open_case):
     expunger = Expunger(record_with_open_case)
 
     assert not expunger.run()
-    assert record_with_open_case.errors == ['All charges are ineligible because there is one or more open case.']
+    assert "All charges are ineligible because there is one or more open case." in record_with_open_case.errors
 
 
 @pytest.fixture


### PR DESCRIPTION
~~Relative to #645~~

As suggested by @wittejm earlier today, we should always run the time analyzer regardless of whether there are open cases. The open cases are treated as if they don't exist. Whether the analysis is shown depends on how the frontend wants to handle it; the frontend can look at `record.errors` to see whether there were any open cases.

Related to https://github.com/codeforpdx/recordexpungPDX/issues/586