### PR TITLE
Check th for header class before creating a new event_table_data entry

### DIFF
--- a/src/backend/expungeservice/crawler/parsers/case_parser/case_parser.py
+++ b/src/backend/expungeservice/crawler/parsers/case_parser/case_parser.py
@@ -36,7 +36,7 @@ class CaseParser(HTMLParser):
             self.within_table_header = True
             self.current_parser_state = DefaultState()
 
-        self.current_parser_state.check_tag(tag)
+        self.current_parser_state.check_tag(tag, attrs)
 
     def handle_endtag(self, tag):
         charge_table = 'Charge Information'

--- a/src/backend/expungeservice/crawler/parsers/case_parser/charge_table_data.py
+++ b/src/backend/expungeservice/crawler/parsers/case_parser/charge_table_data.py
@@ -7,7 +7,7 @@ class ChargeTableData:
         if self.data_tag and data != '\xa0':
             case_parser.charge_table_data.append(data)
 
-    def check_tag(self, tag):
+    def check_tag(self, tag, attrs):
         if tag == 'td':
             self.data_tag = True
         else:

--- a/src/backend/expungeservice/crawler/parsers/case_parser/default_state.py
+++ b/src/backend/expungeservice/crawler/parsers/case_parser/default_state.py
@@ -8,5 +8,5 @@ class DefaultState:
             case_parser.table_title = data
             self.read_table_title = False
 
-    def check_tag(self, tag):
+    def check_tag(self, tag, attrs):
         pass

--- a/src/backend/expungeservice/crawler/parsers/case_parser/event_table_data.py
+++ b/src/backend/expungeservice/crawler/parsers/case_parser/event_table_data.py
@@ -15,6 +15,6 @@ class EventTableData:
         else:
             case_parser.event_table_data[self._event_row].append(data)
 
-    def check_tag(self, tag):
-        if self._header_tag == tag:
+    def check_tag(self, tag, attrs):
+        if self._header_tag == tag and dict(attrs).get('class') in ['ssTableHeaderLabel', 'ssEventsAndOrdersSubTitle']:
             self._dispo_header = True

--- a/src/backend/expungeservice/crawler/parsers/case_parser/financial_table_data.py
+++ b/src/backend/expungeservice/crawler/parsers/case_parser/financial_table_data.py
@@ -9,6 +9,6 @@ class FinancialTableData:
             case_parser.balance_due = data
             self._parse_balance = False
 
-    def check_tag(self,tag):
+    def check_tag(self, tag, attrs):
         if tag == self._balance_due_tag:
             self._parse_balance = True

--- a/src/backend/tests/parser/test_case_parser.py
+++ b/src/backend/tests/parser/test_case_parser.py
@@ -126,7 +126,7 @@ class TestCaseWithoutFinancialTable(unittest.TestCase):
 
     # Tests disposition data is collected from the events table
     def test_it_parses_every_row_of_the_events_table(self):
-        assert len(self.parser.event_table_data) == 14
+        assert len(self.parser.event_table_data) == 13
 
     def test_it_collects_the_disposition_row(self):
         assert self.parser.event_table_data[0][0] == '04/30/1992'
@@ -202,7 +202,7 @@ class TestCaseWithPartialDisposition(unittest.TestCase):
 
     # Tests disposition data is collected from the events table
     def test_it_parses_every_row_of_the_events_table(self):
-        assert len(self.parser.event_table_data) == 20
+        assert len(self.parser.event_table_data) == 17
 
     def test_it_collects_the_disposition_row(self):
         assert self.parser.event_table_data[0][0] == '03/06/2018'
@@ -287,7 +287,7 @@ class TestCaseWithoutDisposition(unittest.TestCase):
 
     # Tests disposition data is collected from the events table
     def test_it_parses_every_row_of_the_events_table(self):
-        assert len(self.parser.event_table_data) == 19
+        assert len(self.parser.event_table_data) == 16
 
     def test_it_collects_the_disposition_row(self):
         dispo_count = 0
@@ -407,7 +407,7 @@ class TestCaseWithRelatedCases(unittest.TestCase):
 
     # Tests disposition data is collected from the events table
     def test_it_parses_every_row_of_the_events_table(self):
-        assert len(self.parser.event_table_data) == 14
+        assert len(self.parser.event_table_data) == 12
 
     def test_it_collects_the_disposition_row(self):
         dispo_count = 0


### PR DESCRIPTION
This ensures a one to one correspondence between the number of items a human can see under the DISPOSITIONS and OTHER EVENTS AND HEARINGS and the length of `event_table_data`. For legacy reasons, the label "OTHER EVENTS AND HEARINGS" is counted as its own entry. While this doesn't cause any visible issues to the user, I do not want to have to touch test files as much as possible when doing the case parser refactor later (in order to clearly show that behavior hasn't changed).

Resolves https://github.com/codeforpdx/recordexpungPDX/issues/656