### PR TITLE
Rename date_of_eligibility to date_will_be_eligible

### DIFF
--- a/src/frontend/src/components/Eligibility/index.tsx
+++ b/src/frontend/src/components/Eligibility/index.tsx
@@ -40,8 +40,8 @@ export default class Eligibility extends React.Component<Props> {
       if (time_eligibility) {
         if (time_eligibility.status === 'Eligible') {
           return eligibleNow;
-        } else if (time_eligibility.date_of_eligibility !== null) {
-          return eligibleOn(time_eligibility.date_of_eligibility);
+        } else if (time_eligibility.date_will_be_eligible !== null) {
+          return eligibleOn(time_eligibility.date_will_be_eligible);
         } else {
           return 'Eligible but no date on time analysis (Please report)';
         }
@@ -56,7 +56,7 @@ export default class Eligibility extends React.Component<Props> {
           return handleWhenTypeEligibile();
         case 'Needs more analysis':
           if (time_eligibility) {
-            return eligibleWithReview(time_eligibility.date_of_eligibility);
+            return eligibleWithReview(time_eligibility.date_will_be_eligible);
           } else {
             return 'Possibly eligible but no time analysis (Please report)';
           }

--- a/src/frontend/src/components/SearchResults/types.ts
+++ b/src/frontend/src/components/SearchResults/types.ts
@@ -41,5 +41,5 @@ export interface TypeEligibility {
 export interface TimeEligibility {
   status: string;
   reason: string;
-  date_of_eligibility: string;
+  date_will_be_eligible: string;
 }

--- a/src/frontend/src/service/__mocks__/axios.ts
+++ b/src/frontend/src/service/__mocks__/axios.ts
@@ -111,7 +111,7 @@ const fakeRecord = {
               time_eligibility: {
                 status: 'Ineligible',
                 reason: '',
-                date_of_eligibility: '2/11/2020'
+                date_will_be_eligible: '2/11/2020'
               }
             }
           },
@@ -132,7 +132,7 @@ const fakeRecord = {
               time_eligibility: {
                 status: 'Ineligible',
                 reason: '',
-                date_of_eligibility: '2/11/2020'
+                date_will_be_eligible: '2/11/2020'
               }
             }
           }

--- a/src/frontend/src/service/api-service.test.ts
+++ b/src/frontend/src/service/api-service.test.ts
@@ -127,7 +127,7 @@ const fakeRecord = {
               time_eligibility: {
                 status: 'Ineligible',
                 reason: '',
-                date_of_eligibility: '2/11/2020'
+                date_will_be_eligible: '2/11/2020'
               }
             }
           },
@@ -148,7 +148,7 @@ const fakeRecord = {
               time_eligibility: {
                 status: 'Ineligible',
                 reason: '',
-                date_of_eligibility: '2/11/2020'
+                date_will_be_eligible: '2/11/2020'
               }
             }
           }


### PR DESCRIPTION
This is a follow up from https://github.com/codeforpdx/recordexpungPDX/pull/557. I forgot to update the `date_of_eligibility` field name on the front-end.

Thanks to @wittejm for the catch.