### PR TITLE
Check 401 error message match before app logout

### DIFF
--- a/src/frontend/src/service/api-service.ts
+++ b/src/frontend/src/service/api-service.ts
@@ -7,7 +7,8 @@ export default function apiService<T>(
   request: AxiosRequestConfig
 ): AxiosPromise {
   return axios.request<T>(request).catch(error => {
-    if (error.response && error.response.status === 401) {
+    if (error.response && error.response.status === 401 && error.response.message === "Invalid username or password") {
+      // To avoid catching the 401 error due to an OECI login failure
       removeCookie();
       dispatch({ type: LOG_OUT });
     }


### PR DESCRIPTION
A 401 error gets thrown for both an app auth failure and an OECI auth failure, and the forntend logs out from the app in both cases. The app should only log out if the error is from the app login attempt. 

The only visible difference between an OECI error and an app error is the attached message, so we do a direct string comparison here.

Closes #560 