### PR TITLE
Cover test code with mypy

### DIFF
--- a/src/backend/expungeservice/request/request.py
+++ b/src/backend/expungeservice/request/request.py
@@ -1,20 +1,5 @@
-from flask import g, abort
-from expungeservice.database import get_database
 from expungeservice.request.error import error
 
-def before():
-
-
-    g.database = get_database()
-
-def after(response):
-    g.database.connection.commit()
-    return response
-
-def teardown(exception):
-    g.database.close_connection()
-
 def check_data_fields(request_json, required_fields):
-
     if not all([field in request_json.keys() for field in required_fields]):
         error(400, "missing one or more required fields: " + str(required_fields))

--- a/src/backend/mypy.ini
+++ b/src/backend/mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
 python_version = 3.7
-files = expungeservice/**/*.py
+files = **/*.py
 namespace_packages = True
 ignore_missing_imports = True
 check_untyped_defs = True

--- a/src/backend/tests/app/test_flask_app.py
+++ b/src/backend/tests/app/test_flask_app.py
@@ -2,6 +2,8 @@ import unittest
 import expungeservice
 from flask import g
 
+from expungeservice.database import get_database
+
 
 class TestFlaskApp(unittest.TestCase):
 
@@ -14,7 +16,7 @@ class TestFlaskApp(unittest.TestCase):
 
         with self.app.app_context():
 
-            expungeservice.request.before()
+            g.database = get_database()
 
             assert g.database
 
@@ -23,5 +25,5 @@ class TestFlaskApp(unittest.TestCase):
             rows = g.database.cursor.fetchall()
             assert rows or rows == []
 
-            expungeservice.request.teardown(None)
+            g.database.close_connection()
             assert g.database.cursor.closed

--- a/src/backend/tests/endpoints/endpoint_util.py
+++ b/src/backend/tests/endpoints/endpoint_util.py
@@ -5,6 +5,7 @@ from flask import g
 import hashlib
 
 import expungeservice
+from expungeservice.database import get_database
 from expungeservice.user import user_db_util
 from expungeservice.user.user import admin_login_required
 
@@ -85,7 +86,7 @@ class EndpointShared:
                 "admin_protected"))
 
         with self.app.app_context():
-            expungeservice.request.before()
+            g.database = get_database()
             self.__db_cleanup()
 
             self.__create_test_user("user1")
@@ -93,14 +94,14 @@ class EndpointShared:
             self.__create_test_user("admin")
             g.database.connection.commit()
 
-            expungeservice.request.teardown(None)
+            g.database.close_connection()
 
     def teardown(self):
         with self.app.app_context():
-            expungeservice.request.before()
+            g.database = get_database()
 
             self.__db_cleanup()
-            expungeservice.request.teardown(None)
+            g.database.close_connection()
 
     def __db_cleanup(self):
 
@@ -133,7 +134,7 @@ class EndpointShared:
 
     def check_search_result_saved(self, user_id, request_data, num_eligible_charges, num_charges):
         with self.app.app_context():
-            expungeservice.request.before()
+            g.database = get_database()
 
             hashed_search_params = self.__hash_search_params(
                 user_id, request_data)

--- a/src/backend/tests/endpoints/endpoint_util.py
+++ b/src/backend/tests/endpoints/endpoint_util.py
@@ -1,5 +1,3 @@
-import unittest
-
 from flask.views import MethodView
 from flask_login import login_required
 from werkzeug.security import generate_password_hash
@@ -27,7 +25,7 @@ class UserProtectedView(MethodView):
                 return "User-level Protected View"
 
 
-class EndpointShared(unittest.TestCase):
+class EndpointShared:
 
     user_data = {
         "user1":

--- a/src/backend/tests/endpoints/test_auth.py
+++ b/src/backend/tests/endpoints/test_auth.py
@@ -2,6 +2,8 @@ from http.cookiejar import Cookie
 
 import time
 import datetime
+
+import pytest
 from flask_login import login_user
 
 from expungeservice.endpoints.auth import *
@@ -11,10 +13,11 @@ from tests.endpoints.endpoint_util import EndpointShared
 
 
 class TestAuth(EndpointShared):
-
+    @pytest.fixture(autouse=True)
     def setUp(self):
-
         EndpointShared.setUp(self)
+        yield
+        EndpointShared.tearDown(self)
 
     def test_auth_token_valid_credentials(self):
         response = self.login(self.user_data["user1"]["email"], self.user_data["user1"]["password"])

--- a/src/backend/tests/endpoints/test_auth.py
+++ b/src/backend/tests/endpoints/test_auth.py
@@ -70,7 +70,7 @@ class TestAuth:
                discard=True,
                comment=None,
                comment_url=None,
-               rest={'HttpOnly': None},
+               rest={'HttpOnly': None}, # type: ignore # TODO: Clean up; this shouldn't require an ignore in theory
                rfc2109=False)
         self.service.client.cookie_jar.set_cookie(cookie)
         response = self.service.client.get('/api/test/user_protected')
@@ -83,13 +83,13 @@ class TestAuth:
     def test_access_expired_auth_token(self, monkeypatch):
         self.__login_user_with_custom_duration(monkeypatch, duration = datetime.timedelta(microseconds=1))
         self.service.client.cookie_jar.clear(domain="localhost.local", path="/", name="session")
-        time.sleep(1)
+        time.sleep(1) # type: ignore
         response = self.service.client.get('/api/test/user_protected')
         assert(response.status_code == 401)
 
         self.__login_user_with_custom_duration(monkeypatch, duration = datetime.timedelta(days=1))
         self.service.client.cookie_jar.clear(domain="localhost.local", path="/", name="session")
-        time.sleep(1)
+        time.sleep(1) # type: ignore
         response = self.service.client.get('/api/test/user_protected')
         assert(response.status_code == 200)
 

--- a/src/backend/tests/endpoints/test_auth.py
+++ b/src/backend/tests/endpoints/test_auth.py
@@ -80,24 +80,22 @@ class TestAuth:
     # and the "remember_token" cookie has expired.
     # Note the "session" cookie lasts the entire session
     # (e.g. user quits browser) and has otherwise no other expiration date.
-    def test_access_expired_auth_token(self):
-        self.__login_user_with_custom_duration(duration = datetime.timedelta(microseconds=1))
+    def test_access_expired_auth_token(self, monkeypatch):
+        self.__login_user_with_custom_duration(monkeypatch, duration = datetime.timedelta(microseconds=1))
         self.service.client.cookie_jar.clear(domain="localhost.local", path="/", name="session")
         time.sleep(1)
         response = self.service.client.get('/api/test/user_protected')
         assert(response.status_code == 401)
 
-        self.__login_user_with_custom_duration(duration = datetime.timedelta(days=1))
+        self.__login_user_with_custom_duration(monkeypatch, duration = datetime.timedelta(days=1))
         self.service.client.cookie_jar.clear(domain="localhost.local", path="/", name="session")
         time.sleep(1)
         response = self.service.client.get('/api/test/user_protected')
         assert(response.status_code == 200)
 
-    def __login_user_with_custom_duration(self, duration):
-        self.service.login_user_wrapper = User.login_user
-        User.login_user = self.__mock_login_user(duration = duration)
+    def __login_user_with_custom_duration(self, monkeypatch, duration):
+        monkeypatch.setattr(User, "login_user", self.__mock_login_user(duration = duration))
         self.service.login(self.service.user_data["user1"]["email"], self.service.user_data["user1"]["password"])
-        User.login_user = self.service.login_user_wrapper
 
     def __mock_login_user(self, duration):
         def new_login_user(user):

--- a/src/backend/tests/endpoints/test_auth.py
+++ b/src/backend/tests/endpoints/test_auth.py
@@ -11,138 +11,139 @@ from expungeservice.endpoints.auth import *
 
 from tests.endpoints.endpoint_util import EndpointShared
 
+@pytest.fixture
+def service():
+    return EndpointShared()
 
-class TestAuth:
-    @pytest.fixture(autouse=True)
-    def setup_and_teardown(self):
-        self.service = EndpointShared()
-        self.service.setup()
-        yield
-        self.service.teardown()
+@pytest.fixture(autouse=True)
+def setup_and_teardown(service):
+    service.setup()
+    yield
+    service.teardown()
 
-    def test_auth_token_valid_credentials(self):
-        response = self.service.login(self.service.user_data["user1"]["email"], self.service.user_data["user1"]["password"])
+def test_auth_token_valid_credentials(service):
+    response = service.login(service.user_data["user1"]["email"], service.user_data["user1"]["password"])
 
-        assert(response.status_code == 200)
-        assert(response.headers.get("Content-type") == "application/json")
-        cookie = self.service.client.cookie_jar._cookies["localhost.local"]["/"]["session"]
-        assert(cookie.version == 0)
-        assert(cookie.name == "session")
-        assert(cookie.path == "/")
-        assert(cookie.path_specified)
-        assert(cookie.domain == "localhost.local")
-        assert(not cookie.domain_specified)
-        assert(not cookie.domain_initial_dot)
+    assert(response.status_code == 200)
+    assert(response.headers.get("Content-type") == "application/json")
+    cookie = service.client.cookie_jar._cookies["localhost.local"]["/"]["session"]
+    assert(cookie.version == 0)
+    assert(cookie.name == "session")
+    assert(cookie.path == "/")
+    assert(cookie.path_specified)
+    assert(cookie.domain == "localhost.local")
+    assert(not cookie.domain_specified)
+    assert(not cookie.domain_initial_dot)
 
-    def test_auth_token_invalid_username(self):
-        response = self.service.login(
-            'wrong_user@test.com', 'test_password')
-        assert(response.status_code == 401)
+def test_auth_token_invalid_username(service):
+    response = service.login(
+        'wrong_user@test.com', 'test_password')
+    assert(response.status_code == 401)
 
-    def test_login_invalid_pasword(self):
-        response = self.service.login(self.service.user_data["user1"]["email"], "wrong_password")
-        assert(response.status_code == 401)
+def test_login_invalid_pasword(service):
+    response = service.login(service.user_data["user1"]["email"], "wrong_password")
+    assert(response.status_code == 401)
 
-    def test_access_valid_auth_token(self):
-        self.service.login(self.service.user_data["user1"]["email"], self.service.user_data["user1"]["password"])
-        response = self.service.client.get('/api/test/user_protected')
-        assert(response.status_code == 200)
+def test_access_valid_auth_token(service):
+    service.login(service.user_data["user1"]["email"], service.user_data["user1"]["password"])
+    response = service.client.get('/api/test/user_protected')
+    assert(response.status_code == 200)
 
-    def test_access_no_auth_token(self):
-        response = self.service.client.get('/api/test/user_protected')
-        assert(response.status_code == 401)
+def test_access_no_auth_token(service):
+    response = service.client.get('/api/test/user_protected')
+    assert(response.status_code == 401)
 
-    def test_access_invalid_auth_token(self):
-        value = """
-        .eJwljksOwyAMBe_COpHABgy5TOWv2m3SrKrevUjdzkjz3ic94vTrmY73efuWHi9LR0LjFl5yWAeSPLJ3BcMGLRBnOChDZR_UPKbU6lYWQ_Yw6BrajKP6Eky5OQQTwbKdSV0r0axD2KaKtT6xkYRAWSHMgkKIaUv35ef_DGig9YJ7UOW96uz7pDJ2WXMU4Rm0pO8PiTE6Yg.XcKUnQ.hm2dNwGedmEPV-q8FHuZvgR3Xfg
-        """
-        cookie = Cookie(version=0, name='session',
-               value=value,
-               port=None,
-               port_specified=False,
-               domain="localhost.local",
-               domain_specified=False,
-               domain_initial_dot=False,
-               path="/",
-               path_specified=True,
-               secure=False,
-               expires=None,
-               discard=True,
-               comment=None,
-               comment_url=None,
-               rest={'HttpOnly': None}, # type: ignore # TODO: Clean up; this shouldn't require an ignore in theory
-               rfc2109=False)
-        self.service.client.cookie_jar.set_cookie(cookie)
-        response = self.service.client.get('/api/test/user_protected')
-        assert(response.status_code == 401)
+def test_access_invalid_auth_token(service):
+    value = """
+    .eJwljksOwyAMBe_COpHABgy5TOWv2m3SrKrevUjdzkjz3ic94vTrmY73efuWHi9LR0LjFl5yWAeSPLJ3BcMGLRBnOChDZR_UPKbU6lYWQ_Yw6BrajKP6Eky5OQQTwbKdSV0r0axD2KaKtT6xkYRAWSHMgkKIaUv35ef_DGig9YJ7UOW96uz7pDJ2WXMU4Rm0pO8PiTE6Yg.XcKUnQ.hm2dNwGedmEPV-q8FHuZvgR3Xfg
+    """
+    cookie = Cookie(version=0, name='session',
+           value=value,
+           port=None,
+           port_specified=False,
+           domain="localhost.local",
+           domain_specified=False,
+           domain_initial_dot=False,
+           path="/",
+           path_specified=True,
+           secure=False,
+           expires=None,
+           discard=True,
+           comment=None,
+           comment_url=None,
+           rest={'HttpOnly': None}, # type: ignore # TODO: Clean up; this shouldn't require an ignore in theory
+           rfc2109=False)
+    service.client.cookie_jar.set_cookie(cookie)
+    response = service.client.get('/api/test/user_protected')
+    assert(response.status_code == 401)
 
-    # We are testing the scenario in which the user's browser session has ended
-    # and the "remember_token" cookie has expired.
-    # Note the "session" cookie lasts the entire session
-    # (e.g. user quits browser) and has otherwise no other expiration date.
-    def test_access_expired_auth_token(self, monkeypatch):
-        self.__login_user_with_custom_duration(monkeypatch, duration = datetime.timedelta(microseconds=1))
-        self.service.client.cookie_jar.clear(domain="localhost.local", path="/", name="session")
-        time.sleep(1) # type: ignore
-        response = self.service.client.get('/api/test/user_protected')
-        assert(response.status_code == 401)
+# We are testing the scenario in which the user's browser session has ended
+# and the "remember_token" cookie has expired.
+# Note the "session" cookie lasts the entire session
+# (e.g. user quits browser) and has otherwise no other expiration date.
+def test_access_expired_auth_token(service, monkeypatch):
+    __login_user_with_custom_duration(service, monkeypatch, duration = datetime.timedelta(microseconds=1))
+    service.client.cookie_jar.clear(domain="localhost.local", path="/", name="session")
+    time.sleep(1) # type: ignore
+    response = service.client.get('/api/test/user_protected')
+    assert(response.status_code == 401)
 
-        self.__login_user_with_custom_duration(monkeypatch, duration = datetime.timedelta(days=1))
-        self.service.client.cookie_jar.clear(domain="localhost.local", path="/", name="session")
-        time.sleep(1) # type: ignore
-        response = self.service.client.get('/api/test/user_protected')
-        assert(response.status_code == 200)
+    __login_user_with_custom_duration(service, monkeypatch, duration = datetime.timedelta(days=1))
+    service.client.cookie_jar.clear(domain="localhost.local", path="/", name="session")
+    time.sleep(1) # type: ignore
+    response = service.client.get('/api/test/user_protected')
+    assert(response.status_code == 200)
 
-    def __login_user_with_custom_duration(self, monkeypatch, duration):
-        monkeypatch.setattr(User, "login_user", self.__mock_login_user(duration = duration))
-        self.service.login(self.service.user_data["user1"]["email"], self.service.user_data["user1"]["password"])
+def __mock_login_user(duration):
+    def new_login_user(user):
+        return login_user(user, remember=True, duration=duration)
+    return new_login_user
 
-    def __mock_login_user(self, duration):
-        def new_login_user(user):
-            return login_user(user, remember=True, duration=duration)
-        return new_login_user
+def __login_user_with_custom_duration(service, monkeypatch, duration):
+    monkeypatch.setattr(User, "login_user", __mock_login_user(duration = duration))
+    service.login(service.user_data["user1"]["email"], service.user_data["user1"]["password"])
 
-    def test_is_admin_auth_token(self):
-        self.service.login(self.service.user_data["admin"]["email"], self.service.user_data["admin"]["password"])
-        response = self.service.client.get('/api/test/admin_protected')
-        assert(response.status_code == 200)
+def test_is_admin_auth_token(service):
+    service.login(service.user_data["admin"]["email"], service.user_data["admin"]["password"])
+    response = service.client.get('/api/test/admin_protected')
+    assert(response.status_code == 200)
 
-    def test_is_not_admin_auth_token(self):
-        self.service.login(self.service.user_data["user1"]["email"], self.service.user_data["user1"]["password"])
-        response = self.service.client.get('/api/test/admin_protected')
-        assert(response.status_code == 403)
+def test_is_not_admin_auth_token(service):
+    service.login(service.user_data["user1"]["email"], service.user_data["user1"]["password"])
+    response = service.client.get('/api/test/admin_protected')
+    assert(response.status_code == 403)
 
-    def test_user_protected_is_unauthorized_after_logout(self):
-        self.service.login(self.service.user_data["user1"]["email"], self.service.user_data["user1"]["password"])
-        response = self.service.client.post('/api/logout')
-        assert(response.status_code == 200)
+def test_user_protected_is_unauthorized_after_logout(service):
+    service.login(service.user_data["user1"]["email"], service.user_data["user1"]["password"])
+    response = service.client.post('/api/logout')
+    assert(response.status_code == 200)
 
-        response = self.service.client.get('/api/test/user_protected')
-        assert(response.status_code == 401)
+    response = service.client.get('/api/test/user_protected')
+    assert(response.status_code == 401)
 
-    # The flask-login library doesn't invalidate the "remember_token" after
-    # logout yet. I do not consider this a critical security flaw as
-    # it only is an issue if an attacker has somehow obtained the remember_token
-    # before the user manages to logout and clear all cookies.
-    def test_cookie_is_invalid_after_logout(self):
-        self.service.login(self.service.user_data["user1"]["email"], self.service.user_data["user1"]["password"])
-        cookie = self.service.client.cookie_jar._cookies["localhost.local"]["/"]["remember_token"]
-        response = self.service.client.post('/api/logout')
-        assert(response.status_code == 200)
-        assert(not self.service.client.cookie_jar._cookies["localhost.local"]["/"].get("remember_token"))
+# The flask-login library doesn't invalidate the "remember_token" after
+# logout yet. I do not consider this a critical security flaw as
+# it only is an issue if an attacker has somehow obtained the remember_token
+# before the user manages to logout and clear all cookies.
+def test_cookie_is_invalid_after_logout(service):
+    service.login(service.user_data["user1"]["email"], service.user_data["user1"]["password"])
+    cookie = service.client.cookie_jar._cookies["localhost.local"]["/"]["remember_token"]
+    response = service.client.post('/api/logout')
+    assert(response.status_code == 200)
+    assert(not service.client.cookie_jar._cookies["localhost.local"]["/"].get("remember_token"))
 
-        self.service.client.cookie_jar.clear(domain="localhost.local", path="/", name="session")
-        self.service.client.cookie_jar.set_cookie(cookie)
+    service.client.cookie_jar.clear(domain="localhost.local", path="/", name="session")
+    service.client.cookie_jar.set_cookie(cookie)
 
-        response = self.service.client.get('/api/test/user_protected')
-        assert(response.status_code == 200) # TODO: Ideally this should be 401
+    response = service.client.get('/api/test/user_protected')
+    assert(response.status_code == 200) # TODO: Ideally this should be 401
 
-    def test_cookie_cannot_be_used_for_fresh_login(self):
-        self.service.login(self.service.user_data["user1"]["email"], self.service.user_data["user1"]["password"])
+def test_cookie_cannot_be_used_for_fresh_login(service):
+    service.login(service.user_data["user1"]["email"], service.user_data["user1"]["password"])
 
-        self.service.client.cookie_jar.clear(domain="localhost.local", path="/", name="session")
+    service.client.cookie_jar.clear(domain="localhost.local", path="/", name="session")
 
-        response = self.service.client.put(
-            "/api/users/%s" % self.service.user_data["user1"]["user_id"],
-            json={"password":"new_password"})
-        assert(response.status_code == 401)
+    response = service.client.put(
+        "/api/users/%s" % service.user_data["user1"]["user_id"],
+        json={"password":"new_password"})
+    assert(response.status_code == 401)

--- a/src/backend/tests/endpoints/test_auth.py
+++ b/src/backend/tests/endpoints/test_auth.py
@@ -14,7 +14,7 @@ from tests.endpoints.endpoint_util import EndpointShared
 
 class TestAuth:
     @pytest.fixture(autouse=True)
-    def setup(self):
+    def setup_and_teardown(self):
         self.service = EndpointShared()
         self.service.setup()
         yield

--- a/src/backend/tests/endpoints/test_oeci_login.py
+++ b/src/backend/tests/endpoints/test_oeci_login.py
@@ -8,7 +8,7 @@ from expungeservice.crypto import DataCipher
 
 class TestOeciLogin:
     @pytest.fixture(autouse=True)
-    def setup(self):
+    def setup_and_teardown(self):
         self.service = EndpointShared()
         self.service.setup()
         self.crawler_login = oeci_login.Crawler.login

--- a/src/backend/tests/endpoints/test_oeci_login.py
+++ b/src/backend/tests/endpoints/test_oeci_login.py
@@ -1,3 +1,4 @@
+import pytest
 from flask import current_app
 
 from expungeservice.endpoints import oeci_login
@@ -6,7 +7,7 @@ from expungeservice.crypto import DataCipher
 
 
 class TestOeciLogin(EndpointShared):
-
+    @pytest.fixture(autouse=True)
     def setUp(self):
         EndpointShared.setUp(self)
         self.crawler_login = oeci_login.Crawler.login
@@ -14,9 +15,9 @@ class TestOeciLogin(EndpointShared):
 
             self.cipher = DataCipher(
                 key=current_app.config.get("SECRET_KEY"))
-
-    def tearDown(self):
+        yield
         oeci_login.Crawler.login = self.crawler_login
+        EndpointShared.tearDown(self)
 
     def mock_login(self, value):
         return lambda s, username, password, close_session: value

--- a/src/backend/tests/endpoints/test_oeci_login.py
+++ b/src/backend/tests/endpoints/test_oeci_login.py
@@ -6,33 +6,34 @@ from tests.endpoints.endpoint_util import EndpointShared
 from expungeservice.crypto import DataCipher
 
 
-class TestOeciLogin(EndpointShared):
+class TestOeciLogin:
     @pytest.fixture(autouse=True)
-    def setUp(self):
-        EndpointShared.setUp(self)
+    def setup(self):
+        self.service = EndpointShared()
+        self.service.setup()
         self.crawler_login = oeci_login.Crawler.login
-        with self.app.app_context():
+        with self.service.app.app_context():
 
             self.cipher = DataCipher(
                 key=current_app.config.get("SECRET_KEY"))
         yield
         oeci_login.Crawler.login = self.crawler_login
-        EndpointShared.tearDown(self)
+        self.service.teardown()
 
     def mock_login(self, value):
         return lambda s, username, password, close_session: value
 
     def test_oeci_login_success(self):
-        self.login(self.user_data["user1"]["email"], self.user_data["user1"]["password"])
+        self.service.login(self.service.user_data["user1"]["email"], self.service.user_data["user1"]["password"])
 
         oeci_login.Crawler.login = self.mock_login(True)
 
-        self.client.post(
+        self.service.client.post(
             "/api/oeci_login",
             json={"oeci_username": "correctname",
                   "oeci_password": "correctpwd"})
 
-        credentials_cookie_string = self.client.cookie_jar._cookies[
+        credentials_cookie_string = self.service.client.cookie_jar._cookies[
             "localhost.local"]["/"]["oeci_token"].value
 
         creds = self.cipher.decrypt(credentials_cookie_string)
@@ -41,11 +42,11 @@ class TestOeciLogin(EndpointShared):
         assert creds["oeci_password"] == "correctpwd"
 
     def test_oeci_login_invalid_credentials(self):
-        self.login(self.user_data["user1"]["email"], self.user_data["user1"]["password"])
+        self.service.login(self.service.user_data["user1"]["email"], self.service.user_data["user1"]["password"])
 
         oeci_login.Crawler.login = self.mock_login(False)
 
-        response = self.client.post(
+        response = self.service.client.post(
             "/api/oeci_login",
             json={"oeci_username": "wrongname",
                   "oeci_password": "wrongpwd"})

--- a/src/backend/tests/endpoints/test_search.py
+++ b/src/backend/tests/endpoints/test_search.py
@@ -11,7 +11,7 @@ from expungeservice.serializer import ExpungeModelEncoder
 class TestSearch:
 
     @pytest.fixture(autouse=True)
-    def setup(self):
+    def setup_and_teardown(self):
         self.service = EndpointShared()
         self.service.setup()
 

--- a/src/backend/tests/endpoints/test_search.py
+++ b/src/backend/tests/endpoints/test_search.py
@@ -8,157 +8,157 @@ from tests.factories.crawler_factory import CrawlerFactory
 from expungeservice.serializer import ExpungeModelEncoder
 
 
-class TestSearch:
+@pytest.fixture
+def service():
+    return EndpointShared()
 
-    @pytest.fixture(autouse=True)
-    def setup_and_teardown(self):
-        self.service = EndpointShared()
-        self.service.setup()
+@pytest.fixture(autouse=True)
+def setup_and_teardown(service):
+    service.setup()
 
-        self.crawler = CrawlerFactory.setup()
-        self.crawler.logged_in = True
-        self.mock_record = {
-            "john_doe": CrawlerFactory.create(self.crawler)
-        }
-        self.search_request_data = {
-            "first_name": "John",
-            "last_name": "Doe",
-            "middle_name": "",
-            "birth_date": "02/02/1990"}
-        yield
-        self.service.teardown()
+    service.crawler = CrawlerFactory.setup()
+    service.crawler.logged_in = True
+    service.mock_record = {
+        "john_doe": CrawlerFactory.create(service.crawler)
+    }
+    service.search_request_data = {
+        "first_name": "John",
+        "last_name": "Doe",
+        "middle_name": "",
+        "birth_date": "02/02/1990"}
+    yield
+    service.teardown()
 
+def mock_login(return_value):
+    return lambda s, username, password, close_session=False: return_value
 
-    def mock_login(self, return_value):
-        return lambda s, username, password, close_session=False: return_value
+def mock_search(service, mocked_record_name):
+    return lambda s, first_name, last_name, middle_name, birth_date: service.mock_record[mocked_record_name]
 
-    def mock_search(self, mocked_record_name):
-        return lambda s, first_name, last_name, middle_name, birth_date: self.mock_record[mocked_record_name]
+def mock_save_result_fail(user_id, request_data, record):
+    raise Exception("Exception to test failing save_result")
 
-    def mock_save_result_fail(self, user_id, request_data, record):
-        raise Exception("Exception to test failing save_result")
+def test_search(service, monkeypatch):
+    service.login(service.user_data["user1"]["email"], service.user_data["user1"]["password"])
 
-    def test_search(self, monkeypatch):
-        self.service.login(self.service.user_data["user1"]["email"], self.service.user_data["user1"]["password"])
+    monkeypatch.setattr(search.Crawler, "login", mock_login(True))
+    monkeypatch.setattr(search.Crawler, "search", mock_search(service, "john_doe"))
 
-        monkeypatch.setattr(search.Crawler, "login", self.mock_login(True))
-        monkeypatch.setattr(search.Crawler, "search", self.mock_search("john_doe"))
+    """
+    A separate test, below, verifies that the save-result step
+    also works. Here, we mock the function to reduce the scope of the test.
+    """
+    monkeypatch.setattr(search, "save_result", lambda user_id, request_data, record : None)
 
-        """
-        A separate test, below, verifies that the save-result step
-        also works. Here, we mock the function to reduce the scope of the test.
-        """
-        monkeypatch.setattr(search, "save_result", lambda user_id, request_data, record : None)
+    """
+    as a more unit-y unit test, we could make the encrypted cookie
+    ""manually" in the test code ...
+    But attaching a cookie client-side isn't really a thing. So, use the oeci endpoint.
+    """
 
-        """
-        as a more unit-y unit test, we could make the encrypted cookie
-        ""manually" in the test code ...
-        But attaching a cookie client-side isn't really a thing. So, use the oeci endpoint.
-        """
+    service.client.post(
+        "/api/oeci_login",
+        json={"oeci_username": "correctusername",
+              "oeci_password": "correctpassword"})
 
-        self.service.client.post(
-            "/api/oeci_login",
-            json={"oeci_username": "correctusername",
-                  "oeci_password": "correctpassword"})
-
-        assert self.service.client.cookie_jar._cookies[
-            "localhost.local"]["/"]["oeci_token"]
-
-
-        response = self.service.client.post("/api/search",
-            json=self.search_request_data)
-
-        assert(response.status_code == 200)
-        data = response.get_json()["data"]
-
-        """
-        Check that the resulting "record" field in the response matches what we gave to the
-        mock search function.
-        (use this json encode-decode approach because it turns a Record into a dict.)
-        """
-        assert data["record"] == json.loads(json.dumps(
-            self.mock_record["john_doe"], cls = ExpungeModelEncoder))
+    assert service.client.cookie_jar._cookies[
+        "localhost.local"]["/"]["oeci_token"]
 
 
-    def test_search_fails_without_oeci_token(self):
-        self.service.login(self.service.user_data["user1"]["email"], self.service.user_data["user1"]["password"])
+    response = service.client.post("/api/search",
+        json=service.search_request_data)
 
-        response = self.service.client.post("/api/search",
-            json=self.search_request_data)
+    assert(response.status_code == 200)
+    data = response.get_json()["data"]
 
-        assert(response.status_code == 401)
-
-
-    def test_search_creates_save_results(self, monkeypatch):
-        """
-        This is the same test as above except it includes the save-results step. Less unit-y,
-        more of a vertical test.
-        """
-
-        self.service.login(self.service.user_data["user1"]["email"], self.service.user_data["user1"]["password"])
-
-        monkeypatch.setattr(search.Crawler, "login", self.mock_login(True))
-        monkeypatch.setattr(search.Crawler, "search", self.mock_search("john_doe"))
-
-        self.service.client.post(
-            "/api/oeci_login",
-            json={"oeci_username": "correctusername",
-                  "oeci_password": "correctpassword"})
-
-        assert self.service.client.cookie_jar._cookies[
-            "localhost.local"]["/"]["oeci_token"]
-
-        response = self.service.client.post("/api/search",
-            json=self.search_request_data)
-
-        assert(response.status_code == 200)
-        data = response.get_json()["data"]
-
-        """
-        Check that the resulting "record" field in the response matches
-        what we gave to the mock search function.
-
-        (use this json encode-decode approach because it turns a Record into a dict.)
-        """
-        assert data["record"] == json.loads(json.dumps(
-            self.mock_record["john_doe"], cls = ExpungeModelEncoder))
+    """
+    Check that the resulting "record" field in the response matches what we gave to the
+    mock search function.
+    (use this json encode-decode approach because it turns a Record into a dict.)
+    """
+    assert data["record"] == json.loads(json.dumps(
+        service.mock_record["john_doe"], cls = ExpungeModelEncoder))
 
 
-        self.service.check_search_result_saved(
-            self.service.user_data["user1"]["user_id"], self.search_request_data,
-            num_eligible_charges = 6, num_charges = 9)
+def test_search_fails_without_oeci_token(service):
+    service.login(service.user_data["user1"]["email"], service.user_data["user1"]["password"])
+
+    response = service.client.post("/api/search",
+        json=service.search_request_data)
+
+    assert(response.status_code == 401)
 
 
-    def test_search_with_failing_save_results(self, monkeypatch):
-        """
-        The search endpoint should succeed even if something goes wrong with the save-result step.
+def test_search_creates_save_results(service, monkeypatch):
+    """
+    This is the same test as above except it includes the save-results step. Less unit-y,
+    more of a vertical test.
+    """
 
-        """
+    service.login(service.user_data["user1"]["email"], service.user_data["user1"]["password"])
 
-        self.service.login(self.service.user_data["user1"]["email"], self.service.user_data["user1"]["password"])
-        monkeypatch.setattr(search.Crawler, "login", self.mock_login(True))
-        monkeypatch.setattr(search.Crawler, "search", self.mock_search("john_doe"))
-        monkeypatch.setattr(search, "save_result", self.mock_save_result_fail)
+    monkeypatch.setattr(search.Crawler, "login", mock_login(True))
+    monkeypatch.setattr(search.Crawler, "search", mock_search(service, "john_doe"))
 
-        self.service.client.post(
-            "/api/oeci_login",
-            json={"oeci_username": "correctusername",
-                  "oeci_password": "correctpassword"})
+    service.client.post(
+        "/api/oeci_login",
+        json={"oeci_username": "correctusername",
+              "oeci_password": "correctpassword"})
 
-        assert self.service.client.cookie_jar._cookies[
-            "localhost.local"]["/"]["oeci_token"]
+    assert service.client.cookie_jar._cookies[
+        "localhost.local"]["/"]["oeci_token"]
+
+    response = service.client.post("/api/search",
+        json=service.search_request_data)
+
+    assert(response.status_code == 200)
+    data = response.get_json()["data"]
+
+    """
+    Check that the resulting "record" field in the response matches
+    what we gave to the mock search function.
+
+    (use this json encode-decode approach because it turns a Record into a dict.)
+    """
+    assert data["record"] == json.loads(json.dumps(
+        service.mock_record["john_doe"], cls = ExpungeModelEncoder))
 
 
-        response = self.service.client.post("/api/search",
-            json=self.search_request_data)
+    service.check_search_result_saved(
+        service.user_data["user1"]["user_id"], service.search_request_data,
+        num_eligible_charges = 6, num_charges = 9)
 
-        assert(response.status_code == 200)
-        data = response.get_json()["data"]
 
-        """
-        Check that the resulting "record" field in the response matches what we gave to the
-        mock search function.
-        (use this json encode-decode approach because it turns a Record into a dict.)
-        """
-        assert data["record"] == json.loads(json.dumps(
-            self.mock_record["john_doe"], cls = ExpungeModelEncoder))
+def test_search_with_failing_save_results(service, monkeypatch):
+    """
+    The search endpoint should succeed even if something goes wrong with the save-result step.
+
+    """
+
+    service.login(service.user_data["user1"]["email"], service.user_data["user1"]["password"])
+    monkeypatch.setattr(search.Crawler, "login", mock_login(True))
+    monkeypatch.setattr(search.Crawler, "search", mock_search(service, "john_doe"))
+    monkeypatch.setattr(search, "save_result", mock_save_result_fail)
+
+    service.client.post(
+        "/api/oeci_login",
+        json={"oeci_username": "correctusername",
+              "oeci_password": "correctpassword"})
+
+    assert service.client.cookie_jar._cookies[
+        "localhost.local"]["/"]["oeci_token"]
+
+
+    response = service.client.post("/api/search",
+        json=service.search_request_data)
+
+    assert(response.status_code == 200)
+    data = response.get_json()["data"]
+
+    """
+    Check that the resulting "record" field in the response matches what we gave to the
+    mock search function.
+    (use this json encode-decode approach because it turns a Record into a dict.)
+    """
+    assert data["record"] == json.loads(json.dumps(
+        service.mock_record["john_doe"], cls = ExpungeModelEncoder))

--- a/src/backend/tests/endpoints/test_search.py
+++ b/src/backend/tests/endpoints/test_search.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from expungeservice.endpoints import search
 from tests.endpoints.endpoint_util import EndpointShared
 from tests.factories.crawler_factory import CrawlerFactory
@@ -10,6 +12,7 @@ from expungeservice import stats
 
 class TestSearch(EndpointShared):
 
+    @pytest.fixture(autouse=True)
     def setUp(self):
         EndpointShared.setUp(self)
 
@@ -28,12 +31,12 @@ class TestSearch(EndpointShared):
             "last_name": "Doe",
             "middle_name": "",
             "birth_date": "02/02/1990"}
-
-
-    def tearDown(self):
+        yield
         search.Crawler.login = self.crawler_login
         search.Crawler.search = self.search
         search.save_result = self.save_result
+
+        EndpointShared.tearDown(self)
 
 
     def mock_login(self, return_value):

--- a/src/backend/tests/endpoints/test_users.py
+++ b/src/backend/tests/endpoints/test_users.py
@@ -5,267 +5,269 @@ from werkzeug.security import generate_password_hash
 
 from tests.endpoints.endpoint_util import EndpointShared
 
-class TestUsers:
 
-    @pytest.fixture(autouse=True)
-    def setup_and_teardown(self):
-        self.service = EndpointShared()
-        self.service.setup()
+@pytest.fixture
+def service():
+    return EndpointShared()
 
-        self.service.user_data["new_user"] = {
-            "email": "pytest_create_user@endpoint_test.com",
-            "password": "new_password",
-            "hashed_password": generate_password_hash("new_password"),
-            "name": "new name",
-            "group_name": "new group name",
-            "admin": False
-        }
-        yield
-        self.service.teardown()
+@pytest.fixture(autouse=True)
+def setup_and_teardown(service):
+    service.setup()
 
-    def check_user_data_match(self, created_user, reference_user):
-        assert created_user["email"] == reference_user["email"]
-        assert created_user["name"] == reference_user["name"]
-        assert created_user["group_name"] == reference_user["group_name"]
-        assert created_user["admin"] == reference_user["admin"]
-        assert created_user["timestamp"]
+    service.user_data["new_user"] = {
+        "email": "pytest_create_user@endpoint_test.com",
+        "password": "new_password",
+        "hashed_password": generate_password_hash("new_password"),
+        "name": "new name",
+        "group_name": "new group name",
+        "admin": False
+    }
+    yield
+    service.teardown()
 
-    def test_create_success(self):
-        self.service.login(self.service.user_data["admin"]["email"], self.service.user_data["admin"]["password"])
-        response = self.service.client.post(
-            "/api/users",
-            json=self.service.user_data["new_user"])
+def check_user_data_match(created_user, reference_user):
+    assert created_user["email"] == reference_user["email"]
+    assert created_user["name"] == reference_user["name"]
+    assert created_user["group_name"] == reference_user["group_name"]
+    assert created_user["admin"] == reference_user["admin"]
+    assert created_user["timestamp"]
 
-        assert(response.status_code == 201)
+def test_create_success(service):
+    service.login(service.user_data["admin"]["email"], service.user_data["admin"]["password"])
+    response = service.client.post(
+        "/api/users",
+        json=service.user_data["new_user"])
 
+    assert(response.status_code == 201)
+
+    data = response.get_json()
+    check_user_data_match(data, service.user_data["new_user"])
+
+def test_create_no_auth(service):
+    response = service.client.post(
+        "/api/users",
+        headers={
+            "Authorization": ""},
+        json=service.user_data["new_user"])
+    assert(response.status_code == 401)
+
+def test_create_missing_data_field(service):
+    service.login(service.user_data["admin"]["email"], service.user_data["admin"]["password"])
+
+    response = service.client.post(
+        "/api/users",
+        json={"email": service.user_data["new_user"]["email"],
+              "name": service.user_data["new_user"]["name"],
+              "group_name": service.user_data["new_user"]["group_name"],
+              # "password": new_password,
+              "admin": True})
+
+    assert(response.status_code == 400)
+
+def test_create_duplicate_email(service):
+    service.login(service.user_data["admin"]["email"], service.user_data["admin"]["password"])
+
+    response = service.client.post(
+        "/api/users",
+        json=service.user_data["new_user"])
+
+    assert(response.status_code == 201)
+
+    response = service.client.post(
+        "/api/users",
+        json=service.user_data["new_user"])
+
+    assert(response.status_code == 422)
+
+def test_create_short_password(service):
+    service.login(service.user_data["admin"]["email"], service.user_data["admin"]["password"])
+
+    new_email = "pytest_create_user@endpoint_test.com"
+    short_password = "shrt_pw"
+
+    response = service.client.post(
+        "/api/users",
+        json={"email": service.user_data["new_user"]["email"],
+              "name": service.user_data["new_user"]["name"],
+              "group_name": service.user_data["new_user"]["group_name"],
+              "password": short_password,
+              "admin": False}
+    )
+
+    assert(response.status_code == 422)
+
+def test_create_not_admin(service):
+    service.login(service.user_data["user1"]["email"], service.user_data["user1"]["password"])
+
+    new_email = "pytest_create_user@endpoint_test.com"
+    new_password = "new_password"
+
+    response = service.client.post(
+        "/api/users",
+        json=service.user_data["new_user"])
+
+    assert(response.status_code == 403)
+
+def test_get_users_success(service):
+    service.login(service.user_data["admin"]["email"], service.user_data["admin"]["password"])
+    response = service.client.get("/api/users")
+
+    assert(response.status_code == 201)
+
+    data = response.get_json()
+
+    assert data["users"][0]["email"]
+    assert data["users"][0]["admin"] in [True, False]
+    assert data["users"][0]["timestamp"]
+    assert data["users"][0]["name"]
+    assert data["users"][0]["group"]
+    assert data["users"][0]["id"]
+
+def test_get_users_not_admin(service):
+    service.login(service.user_data["user1"]["email"], service.user_data["user1"]["password"])
+    response = service.client.get("/api/users")
+    assert(response.status_code == 403)
+
+def test_get_own_user_data_success(service):
+    def check_response_success(response, user_data):
+        assert (response.status_code == 201)
         data = response.get_json()
-        self.check_user_data_match(data, self.service.user_data["new_user"])
-
-    def test_create_no_auth(self):
-        response = self.service.client.post(
-            "/api/users",
-            headers={
-                "Authorization": ""},
-            json=self.service.user_data["new_user"])
-        assert(response.status_code == 401)
-
-    def test_create_missing_data_field(self):
-        self.service.login(self.service.user_data["admin"]["email"], self.service.user_data["admin"]["password"])
-
-        response = self.service.client.post(
-            "/api/users",
-            json={"email": self.service.user_data["new_user"]["email"],
-                  "name": self.service.user_data["new_user"]["name"],
-                  "group_name": self.service.user_data["new_user"]["group_name"],
-                  # "password": new_password,
-                  "admin": True})
-
-        assert(response.status_code == 400)
-
-    def test_create_duplicate_email(self):
-        self.service.login(self.service.user_data["admin"]["email"], self.service.user_data["admin"]["password"])
-
-        response = self.service.client.post(
-            "/api/users",
-            json=self.service.user_data["new_user"])
-
-        assert(response.status_code == 201)
-
-        response = self.service.client.post(
-            "/api/users",
-            json=self.service.user_data["new_user"])
-
-        assert(response.status_code == 422)
-
-    def test_create_short_password(self):
-        self.service.login(self.service.user_data["admin"]["email"], self.service.user_data["admin"]["password"])
-
-        new_email = "pytest_create_user@endpoint_test.com"
-        short_password = "shrt_pw"
-
-        response = self.service.client.post(
-            "/api/users",
-            json={"email": self.service.user_data["new_user"]["email"],
-                  "name": self.service.user_data["new_user"]["name"],
-                  "group_name": self.service.user_data["new_user"]["group_name"],
-                  "password": short_password,
-                  "admin": False}
-        )
-
-        assert(response.status_code == 422)
-
-    def test_create_not_admin(self):
-        self.service.login(self.service.user_data["user1"]["email"], self.service.user_data["user1"]["password"])
-
-        new_email = "pytest_create_user@endpoint_test.com"
-        new_password = "new_password"
-
-        response = self.service.client.post(
-            "/api/users",
-            json=self.service.user_data["new_user"])
-
-        assert(response.status_code == 403)
-
-    def test_get_users_success(self):
-        self.service.login(self.service.user_data["admin"]["email"], self.service.user_data["admin"]["password"])
-        response = self.service.client.get("/api/users")
-
-        assert(response.status_code == 201)
-
-        data = response.get_json()
-
-        assert data["users"][0]["email"]
-        assert data["users"][0]["admin"] in [True, False]
-        assert data["users"][0]["timestamp"]
-        assert data["users"][0]["name"]
-        assert data["users"][0]["group"]
-        assert data["users"][0]["id"]
-
-    def test_get_users_not_admin(self):
-        self.service.login(self.service.user_data["user1"]["email"], self.service.user_data["user1"]["password"])
-        response = self.service.client.get("/api/users")
-        assert(response.status_code == 403)
-
-    def test_get_own_user_data_success(self):
-        def check_response_success(response, user_data):
-            assert (response.status_code == 201)
-            data = response.get_json()
-            assert data["email"] == user_data["user1"]["email"]
-            assert not data["admin"]
-            assert data["name"] == user_data["user1"]["name"]
-            assert data["group_name"] == user_data["user1"]["group_name"]
-            assert data["user_id"] == user_data["user1"]["user_id"]
-            assert data["timestamp"]
-
-        self.service.login(self.service.user_data["user1"]["email"], self.service.user_data["user1"]["password"])
-
-        response = self.service.client.get("/api/users/%s" % self.service.user_data["user1"]["user_id"])
-        check_response_success(response, self.service.user_data)
-
-        response_without_explicit_id = self.service.client.get("/api/user")
-        check_response_success(response_without_explicit_id, self.service.user_data)
-
-    def test_get_user_data_as_admin_success(self):
-        self.service.login(self.service.user_data["admin"]["email"], self.service.user_data["admin"]["password"])
-        response = self.service.client.get(
-            "/api/users/%s" % self.service.user_data["user1"]["user_id"])
-
-        assert(response.status_code == 201)
-
-        data = response.get_json()
-
-        assert data["email"] == self.service.user_data["user1"]["email"]
-        assert data["admin"] is self.service.user_data["user1"]["admin"]
-        assert data["name"] == self.service.user_data["user1"]["name"]
-        assert data["group_name"] == self.service.user_data["user1"]["group_name"]
-        assert data["user_id"] == self.service.user_data["user1"]["user_id"]
+        assert data["email"] == user_data["user1"]["email"]
+        assert not data["admin"]
+        assert data["name"] == user_data["user1"]["name"]
+        assert data["group_name"] == user_data["user1"]["group_name"]
+        assert data["user_id"] == user_data["user1"]["user_id"]
         assert data["timestamp"]
 
-    def test_get_mismatched_user_id_fail(self):
-        self.service.login(self.service.user_data["user2"]["email"], self.service.user_data["user2"]["password"])
-        response = self.service.client.get("/api/users/%s" % self.service.user_data["user1"]["user_id"])
+    service.login(service.user_data["user1"]["email"], service.user_data["user1"]["password"])
 
-        assert(response.status_code == 403)
+    response = service.client.get("/api/users/%s" % service.user_data["user1"]["user_id"])
+    check_response_success(response, service.user_data)
 
-    def test_get_single_user_unrecognized(self):
-        self.service.login(self.service.user_data["user1"]["email"], self.service.user_data["user1"]["password"])
-        response = self.service.client.get("/api/users/%s" % "unrecognized")
+    response_without_explicit_id = service.client.get("/api/user")
+    check_response_success(response_without_explicit_id, service.user_data)
 
-        assert(response.status_code == 404)
+def test_get_user_data_as_admin_success(service):
+    service.login(service.user_data["admin"]["email"], service.user_data["admin"]["password"])
+    response = service.client.get(
+        "/api/users/%s" % service.user_data["user1"]["user_id"])
 
-    def test_update_password_as_admin_success(self):
-        self.service.login(self.service.user_data["admin"]["email"], self.service.user_data["admin"]["password"])
-        response = self.service.client.put(
-            "/api/users/%s" % self.service.user_data["user1"]["user_id"],
-            json={"password":"new_password"})
+    assert(response.status_code == 201)
 
+    data = response.get_json()
+
+    assert data["email"] == service.user_data["user1"]["email"]
+    assert data["admin"] is service.user_data["user1"]["admin"]
+    assert data["name"] == service.user_data["user1"]["name"]
+    assert data["group_name"] == service.user_data["user1"]["group_name"]
+    assert data["user_id"] == service.user_data["user1"]["user_id"]
+    assert data["timestamp"]
+
+def test_get_mismatched_user_id_fail(service):
+    service.login(service.user_data["user2"]["email"], service.user_data["user2"]["password"])
+    response = service.client.get("/api/users/%s" % service.user_data["user1"]["user_id"])
+
+    assert(response.status_code == 403)
+
+def test_get_single_user_unrecognized(service):
+    service.login(service.user_data["user1"]["email"], service.user_data["user1"]["password"])
+    response = service.client.get("/api/users/%s" % "unrecognized")
+
+    assert(response.status_code == 404)
+
+def test_update_password_as_admin_success(service):
+    service.login(service.user_data["admin"]["email"], service.user_data["admin"]["password"])
+    response = service.client.put(
+        "/api/users/%s" % service.user_data["user1"]["user_id"],
+        json={"password":"new_password"})
+
+    response_data = response.get_json()
+
+    check_user_data_match(response_data, service.user_data["user1"])
+
+    assert response.status_code == 200
+
+    """
+    Attempt to log in with the new password
+    """
+
+    auth_response = service.client.post("/api/auth_token",
+        json= {"email": service.user_data["user1"]["email"],
+               "password": "new_password"})
+
+    assert auth_response.status_code == 200
+
+def test_update_nonadmin_self_success(service):
+    def check_response_success(response, user_data, check_user_data_match_fn):
         response_data = response.get_json()
+        existing_user_data = copy.deepcopy(user_data["user1"])
+        existing_user_data["group_name"] = "updated group name"
+        check_user_data_match_fn(response_data, existing_user_data)
+        assert (response.status_code == 200)
 
-        self.check_user_data_match(response_data, self.service.user_data["user1"])
+    service.login(service.user_data["user1"]["email"], service.user_data["user1"]["password"])
+    response = service.client.put(
+        "/api/users/%s" % service.user_data["user1"]["user_id"],
+        json={"group_name":"updated group name"})
+    check_response_success(response, service.user_data, check_user_data_match)
 
-        assert response.status_code == 200
+    response_without_explicit_id = service.client.put(
+        "/api/user",
+        json={"group_name":"updated group name"})
+    check_response_success(response_without_explicit_id, service.user_data, check_user_data_match)
 
-        """
-        Attempt to log in with the new password
-        """
+def test_update_user_id_mismatch_fail(service):
+    service.login(service.user_data["user2"]["email"], service.user_data["user2"]["password"])
+    response = service.client.put(
+        "/api/users/%s" % service.user_data["user1"]["user_id"],
+        json={"password":"new_password"})
 
-        auth_response = self.service.client.post("/api/auth_token",
-            json= {"email": self.service.user_data["user1"]["email"],
-                   "password": "new_password"})
+    assert(response.status_code == 403)
 
-        assert auth_response.status_code == 200
+def test_update_unrecogized_fail(service):
+    service.login(service.user_data["user1"]["email"], service.user_data["user1"]["password"])
+    response = service.client.put(
+        "/api/users/%s" % "unrecognized",
+        json={"password":"new_password"})
+    assert(response.status_code == 404)
 
-    def test_update_nonadmin_self_success(self):
-        def check_response_success(response, user_data, check_user_data_match_fn):
-            response_data = response.get_json()
-            existing_user_data = copy.deepcopy(user_data["user1"])
-            existing_user_data["group_name"] = "updated group name"
-            check_user_data_match_fn(response_data, existing_user_data)
-            assert (response.status_code == 200)
+    response_without_explicit_id = service.client.put(
+        "/api/user/",
+        json={"password":"new_password"})
+    assert(response_without_explicit_id.status_code == 404)
 
-        self.service.login(self.service.user_data["user1"]["email"], self.service.user_data["user1"]["password"])
-        response = self.service.client.put(
-            "/api/users/%s" % self.service.user_data["user1"]["user_id"],
-            json={"group_name":"updated group name"})
-        check_response_success(response, self.service.user_data, self.check_user_data_match)
+def test_update_no_matching_fields_fail(service):
+    service.login(service.user_data["user1"]["email"], service.user_data["user1"]["password"])
+    response = service.client.put(
+        "/api/users/%s" % service.user_data["user1"]["user_id"],
+        json={"random_field":"random_field_value"})
+    assert(response.status_code == 400)
 
-        response_without_explicit_id = self.service.client.put(
-            "/api/user",
-            json={"group_name":"updated group name"})
-        check_response_success(response_without_explicit_id, self.service.user_data, self.check_user_data_match)
+    response_without_explicit_id = service.client.put(
+        "/api/user",
+        json={"random_field":"random_field_value"})
+    assert(response_without_explicit_id.status_code == 400)
 
-    def test_update_user_id_mismatch_fail(self):
-        self.service.login(self.service.user_data["user2"]["email"], self.service.user_data["user2"]["password"])
-        response = self.service.client.put(
-            "/api/users/%s" % self.service.user_data["user1"]["user_id"],
-            json={"password":"new_password"})
+def test_update_duplicated_email_fail(service):
+    service.login(service.user_data["user1"]["email"], service.user_data["user1"]["password"])
+    response = service.client.put(
+        "/api/users/%s" % service.user_data["user1"]["user_id"],
+        json={"email":service.user_data["user2"]["email"]})
+    assert(response.status_code == 422)
 
-        assert(response.status_code == 403)
+    response_without_explicit_id = service.client.put(
+        "/api/user",
+        json={"email": service.user_data["user2"]["email"]})
+    assert (response_without_explicit_id.status_code == 422)
 
-    def test_update_unrecogized_fail(self):
-        self.service.login(self.service.user_data["user1"]["email"], self.service.user_data["user1"]["password"])
-        response = self.service.client.put(
-            "/api/users/%s" % "unrecognized",
-            json={"password":"new_password"})
-        assert(response.status_code == 404)
+def test_update_set_self_admin_fail(service):
+    service.login(service.user_data["user1"]["email"], service.user_data["user1"]["password"])
+    response = service.client.put(
+        "/api/users/%s" % service.user_data["user1"]["user_id"],
+        json={"admin":True})
+    assert(response.status_code == 403)
 
-        response_without_explicit_id = self.service.client.put(
-            "/api/user/",
-            json={"password":"new_password"})
-        assert(response_without_explicit_id.status_code == 404)
-
-    def test_update_no_matching_fields_fail(self):
-        self.service.login(self.service.user_data["user1"]["email"], self.service.user_data["user1"]["password"])
-        response = self.service.client.put(
-            "/api/users/%s" % self.service.user_data["user1"]["user_id"],
-            json={"random_field":"random_field_value"})
-        assert(response.status_code == 400)
-
-        response_without_explicit_id = self.service.client.put(
-            "/api/user",
-            json={"random_field":"random_field_value"})
-        assert(response_without_explicit_id.status_code == 400)
-
-    def test_update_duplicated_email_fail(self):
-        self.service.login(self.service.user_data["user1"]["email"], self.service.user_data["user1"]["password"])
-        response = self.service.client.put(
-            "/api/users/%s" % self.service.user_data["user1"]["user_id"],
-            json={"email":self.service.user_data["user2"]["email"]})
-        assert(response.status_code == 422)
-
-        response_without_explicit_id = self.service.client.put(
-            "/api/user",
-            json={"email": self.service.user_data["user2"]["email"]})
-        assert (response_without_explicit_id.status_code == 422)
-
-    def test_update_set_self_admin_fail(self):
-        self.service.login(self.service.user_data["user1"]["email"], self.service.user_data["user1"]["password"])
-        response = self.service.client.put(
-            "/api/users/%s" % self.service.user_data["user1"]["user_id"],
-            json={"admin":True})
-        assert(response.status_code == 403)
-
-        response_without_explicit_id = self.service.client.put(
-            "/api/user",
-            json={"admin":True})
-        assert(response_without_explicit_id.status_code == 403)
+    response_without_explicit_id = service.client.put(
+        "/api/user",
+        json={"admin":True})
+    assert(response_without_explicit_id.status_code == 403)

--- a/src/backend/tests/endpoints/test_users.py
+++ b/src/backend/tests/endpoints/test_users.py
@@ -8,7 +8,7 @@ from tests.endpoints.endpoint_util import EndpointShared
 class TestUsers:
 
     @pytest.fixture(autouse=True)
-    def setup(self):
+    def setup_and_teardown(self):
         self.service = EndpointShared()
         self.service.setup()
 

--- a/src/backend/tests/endpoints/test_users.py
+++ b/src/backend/tests/endpoints/test_users.py
@@ -1,11 +1,13 @@
 import copy
 
+import pytest
 from werkzeug.security import generate_password_hash
 
 from tests.endpoints.endpoint_util import EndpointShared
 
 class TestUsers(EndpointShared):
 
+    @pytest.fixture(autouse=True)
     def setUp(self):
         EndpointShared.setUp(self)
 
@@ -17,6 +19,8 @@ class TestUsers(EndpointShared):
             "group_name": "new group name",
             "admin": False
         }
+        yield
+        EndpointShared.tearDown(self)
 
     def check_user_data_match(self, created_user, reference_user):
         assert created_user["email"] == reference_user["email"]

--- a/src/backend/tests/functional_tests/test_crawler_expunger.py
+++ b/src/backend/tests/functional_tests/test_crawler_expunger.py
@@ -124,7 +124,7 @@ def test_expunger_runs_time_analyzer(record_with_specific_dates):
 
     assert expunger.most_recent_conviction is None
     assert expunger.second_most_recent_conviction is None
-    assert expunger.most_recent_dismissal.disposition.ruling == 'No Complaint'
+    assert expunger.most_recent_dismissal and expunger.most_recent_dismissal.disposition.ruling == 'No Complaint'
     assert len(expunger.acquittals) == 8
 
     assert record.cases[0].charges[0].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE

--- a/src/backend/tests/stats/test_stats_save_result.py
+++ b/src/backend/tests/stats/test_stats_save_result.py
@@ -1,3 +1,4 @@
+import pytest
 from flask import g, request
 
 
@@ -8,7 +9,11 @@ from expungeservice.database import get_database
 
 
 class TestStats(EndpointShared):
-
+    @pytest.fixture(autouse=True)
+    def setUp(self):
+        EndpointShared.setUp(self)
+        yield
+        EndpointShared.tearDown(self)
 
     def test_save_result(self):
 

--- a/src/backend/tests/stats/test_stats_save_result.py
+++ b/src/backend/tests/stats/test_stats_save_result.py
@@ -9,7 +9,7 @@ from expungeservice.database import get_database
 
 class TestStats:
     @pytest.fixture(autouse=True)
-    def setup(self):
+    def setup_and_teardown(self):
         self.service = EndpointShared()
         self.service.setup()
         yield


### PR DESCRIPTION
Now the entire python codebase is covered by mypy.

All commits in this PR are preparation for enabling mypy on test code in addition to what is in expungeservice. Mainly, mypy was complaining about how we were doing monkeypatches by assigning to methods. Hence, I migrated all test code to use the pytest monkeypatch fixture where applicable. I didn't want to mix the unittest and pytest frameworks, so I removed the dependency on the unittest framework in areas where the pytest monkeypatch fixture will be used.

I've also inlined various methods in requests.

I would recommend reviewing this PR commit by commit.