### PR TITLE
Remove other events and hearings from event_table_data

### DIFF
--- a/src/backend/expungeservice/crawler/parsers/case_parser.py
+++ b/src/backend/expungeservice/crawler/parsers/case_parser.py
@@ -42,10 +42,7 @@ class CaseParser:
     def __build_event_table_data(self, soup):
         events = soup.find("div", class_=SECTION_TITLE_CLASS, string="Events & Orders of the Court")
         for event in events.parent.next_siblings:
-            # TODO: Remove this first case; I inserted this in to preserve legacy behavior.
-            if event.text.replace("\xa0", "") == "OTHER EVENTS AND HEARINGS":
-                self.event_table_data.append(["OTHER EVENTS AND HEARINGS"])
-            elif CaseParser.__valid_event_table(event):
+            if CaseParser.__valid_event_table(event):
                 event_parse = CaseParser.__parse_event_table(event)
                 self.event_table_data.append(event_parse)
 

--- a/src/backend/tests/parser/test_case_parser.py
+++ b/src/backend/tests/parser/test_case_parser.py
@@ -42,7 +42,7 @@ class TestCaseWithDisposition(unittest.TestCase):
 
     # Tests disposition data is collected from the events table
     def test_it_parses_every_row_of_the_events_table(self):
-        assert len(self.parser.event_table_data) == 14
+        assert len(self.parser.event_table_data) == 13
 
     def test_it_collects_the_disposition_row(self):
         assert self.parser.event_table_data[1][0] == '06/12/2017'
@@ -126,7 +126,7 @@ class TestCaseWithoutFinancialTable(unittest.TestCase):
 
     # Tests disposition data is collected from the events table
     def test_it_parses_every_row_of_the_events_table(self):
-        assert len(self.parser.event_table_data) == 13
+        assert len(self.parser.event_table_data) == 12
 
     def test_it_collects_the_disposition_row(self):
         assert self.parser.event_table_data[0][0] == '04/30/1992'
@@ -202,7 +202,7 @@ class TestCaseWithPartialDisposition(unittest.TestCase):
 
     # Tests disposition data is collected from the events table
     def test_it_parses_every_row_of_the_events_table(self):
-        assert len(self.parser.event_table_data) == 17
+        assert len(self.parser.event_table_data) == 16
 
     def test_it_collects_the_disposition_row(self):
         assert self.parser.event_table_data[0][0] == '03/06/2018'
@@ -287,7 +287,7 @@ class TestCaseWithoutDisposition(unittest.TestCase):
 
     # Tests disposition data is collected from the events table
     def test_it_parses_every_row_of_the_events_table(self):
-        assert len(self.parser.event_table_data) == 16
+        assert len(self.parser.event_table_data) == 15
 
     def test_it_collects_the_disposition_row(self):
         dispo_count = 0
@@ -355,7 +355,7 @@ class TestParkingViolationCase(unittest.TestCase):
 
     # Tests disposition data is collected from the events table
     def test_it_parses_every_row_of_the_events_table(self):
-        assert len(self.parser.event_table_data) == 2
+        assert len(self.parser.event_table_data) == 1
 
     def test_it_collects_the_disposition_row(self):
         dispo_count = 0
@@ -407,7 +407,7 @@ class TestCaseWithRelatedCases(unittest.TestCase):
 
     # Tests disposition data is collected from the events table
     def test_it_parses_every_row_of_the_events_table(self):
-        assert len(self.parser.event_table_data) == 12
+        assert len(self.parser.event_table_data) == 11
 
     def test_it_collects_the_disposition_row(self):
         dispo_count = 0


### PR DESCRIPTION
This information is not used in building the hashed_dispo_data and thus can be removed.