### PR TITLE
Remove check on whether balance_due_dollar_amount is str

### DIFF
--- a/src/backend/expungeservice/models/case.py
+++ b/src/backend/expungeservice/models/case.py
@@ -41,10 +41,9 @@ class Case:
     def set_probation_revoked(self, probation_revoked: bool):
         self.__probation_revoked = probation_revoked
 
-    def set_balance_due(self, balance_due_dollar_amount):
-        if type(balance_due_dollar_amount) == str:
-            balance_due_dollar_amount = float(balance_due_dollar_amount.replace(',',''))
-        self.__balance_due_in_cents = int(balance_due_dollar_amount * 100)
+    def set_balance_due(self, balance_due_dollar_amount: str):
+        balance_due_dollar_amount_float = float(balance_due_dollar_amount.replace(',', ''))
+        self.__balance_due_in_cents = int(balance_due_dollar_amount_float * 100)
 
     def get_balance_due(self):
         return self.__balance_due_in_cents / 100

--- a/src/backend/tests/models/test_case.py
+++ b/src/backend/tests/models/test_case.py
@@ -17,9 +17,6 @@ class TestCaseBalanceDue(unittest.TestCase):
         self.case.set_balance_due("2,345.67")
         assert self.case.get_balance_due() == 2345.67
         
-        self.case.set_balance_due(12345.67)
-        assert self.case.get_balance_due() == 12345.67
-
         self.case.set_balance_due("0")
         assert self.case.get_balance_due() == 0  
 


### PR DESCRIPTION
~~Relative to #675~~

Previously, balance_due_dollar_amount could have been an int/float as we had set the default value on balance_due to be 0. However, now the default value is "0". Since we have types on the CaseParserData (specifically `balance_due: str`), mypy will alert us if I am somehow mistaken.

We also remove the corresponding test case as we never pass in a non-string in our production code.