### PR TITLE
Disposition result always shows arrest date

### DIFF
--- a/src/frontend/src/components/Charge/index.tsx
+++ b/src/frontend/src/components/Charge/index.tsx
@@ -20,20 +20,14 @@ export default class Charge extends React.Component<Props> {
 
 
     const knownDisposition = (disposition: any, date: any) => {
-      let dispositionEvent;
-      if (disposition.status == "Convicted") {
-        dispositionEvent = "Convicted: " ;
-        date = disposition.date;
-      } else {
-        dispositionEvent = "Arrested: " ;
-      }
-
+      let dispositionDateInfo = (disposition.status == "Convicted" ? " - " + disposition.date : "");
+      let dispositionEvent = disposition.status + dispositionDateInfo;
       return <>
         <li className="mb2">
-          <span className="fw7">Disposition: </span> {disposition.ruling}
+          <span className="fw7">Disposition:</span> {dispositionEvent}
         </li>
         <li className="mb2">
-          <span className="fw7">{dispositionEvent} </span> {date}
+          <span className="fw7">Arrested: </span> {date}
         </li>
       </>
     };


### PR DESCRIPTION
Fixes #666 

Results display fix. 

Here's a screencap of the new format:
 
![always_showing_arrest_date](https://user-images.githubusercontent.com/2104990/71702103-7038f200-2d82-11ea-99fe-ec74ba328a1b.png)

vs the prior version:

![old_date_without_arrest](https://user-images.githubusercontent.com/2104990/71702295-6663be80-2d83-11ea-8ace-201941b4d291.png)
