### PR TITLE
Display error banner for any error messages on record

### DIFF
--- a/src/backend/expungeservice/expunger/expunger.py
+++ b/src/backend/expungeservice/expunger/expunger.py
@@ -46,7 +46,7 @@ class Expunger:
         :return: True if there are no open cases; otherwise False
         """
         if self._open_cases():
-            self.record.errors.append('Open cases exist')
+            self.record.errors.append('All charges are ineligible because there is one or more open case.')
             return False
 
         self.charges = Expunger._without_skippable_charges(self.charges)

--- a/src/backend/tests/functional_tests/test_crawler_expunger.py
+++ b/src/backend/tests/functional_tests/test_crawler_expunger.py
@@ -30,7 +30,7 @@ def test_expunger_with_open_case(record_with_open_case):
     expunger = Expunger(record_with_open_case)
 
     assert not expunger.run()
-    assert record_with_open_case.errors == ['Open cases exist']
+    assert record_with_open_case.errors == ['All charges are ineligible because there is one or more open case.']
 
 
 @pytest.fixture

--- a/src/frontend/src/components/SearchResults/index.tsx
+++ b/src/frontend/src/components/SearchResults/index.tsx
@@ -8,12 +8,26 @@ interface Props {
 
 export default class SearchResults extends React.Component<Props> {
   render() {
+    const errors = ( this.props.records.errors ?
+      this.props.records.errors.map(((errorMessage: string, errorIndex: number) => {
+        let id= "record_error_" + errorIndex;
+        return <p id={id} className="bg-washed-red mv4 pa3 br3 fw6">
+                  {errorMessage}
+               </p>
+        }
+        )
+      )
+      : null
+    );
     return (
+      <>
+      {errors}
       <section className="bg-gray-blue-2 shadow br3 overflow-auto">
         {this.props.records.cases ? (
           <Cases cases={this.props.records.cases} />
         ) : null}
       </section>
+      </>
     );
   }
 }

--- a/src/frontend/src/components/SearchResults/types.ts
+++ b/src/frontend/src/components/SearchResults/types.ts
@@ -26,6 +26,7 @@ export interface CaseType {
 export interface Record {
   total_balance_Due?: number;
   cases?: any[];
+  errors?: string[];
 }
 
 export interface ExpungementResultType {

--- a/src/frontend/src/redux/records/types.ts
+++ b/src/frontend/src/redux/records/types.ts
@@ -23,7 +23,7 @@ export interface SearchResponse {
 export interface Record {
   total_balance_Due?: number;
   cases?: any[];
-  errors?: any;
+  errors?: string[];
 }
 
 // These constants are used as the 'type' field in Redux actions.


### PR DESCRIPTION
Closes #684 

This is a small amount of code added mainly just to the SearchResults component. An approach that would more closely fit the existing style of the frontend code would be to create a new RecordErrors component that wraps the set of RecordError components. 

It will definitely be worthwhile later to make a RecordError component when they get more sophisticated, namely with the added button described in issue #586

Here's what the displayed banner looks like:
![example_error_banner](https://user-images.githubusercontent.com/2104990/71704266-2950f980-2d8e-11ea-8033-7198ee123be5.png)
 