### PR TITLE
Append record errors for missing or unknown dispositions

### DIFF
--- a/src/backend/expungeservice/expunger/expunger.py
+++ b/src/backend/expungeservice/expunger/expunger.py
@@ -1,8 +1,10 @@
 from more_itertools import padnone, take
+from typing import Set
 
 from expungeservice.expunger.analyzers.time_analyzer import TimeAnalyzer
 from expungeservice.models.charge_types.felony_class_b import FelonyClassB
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
+from expungeservice.models.disposition import DispositionStatus
 
 
 class Expunger:
@@ -48,6 +50,7 @@ class Expunger:
         if self._open_cases():
             self.record.errors.append('All charges are ineligible because there is one or more open case.')
             return False
+        self.record.errors += self._build_disposition_errors(self.charges)
 
         self.charges = Expunger._without_skippable_charges(self.charges)
         self.acquittals, self.convictions, _ = Expunger._categorize_charges(self.charges)
@@ -124,3 +127,42 @@ class Expunger:
             if isinstance(charge, FelonyClassB):
                 class_b_felonies.append(charge)
         return class_b_felonies
+
+    @staticmethod
+    def _build_disposition_errors(charges):
+        record_errors = []
+        cases_with_missing_disposition, cases_with_unknown_disposition = Expunger._filter_cases_with_errors(charges)
+        if cases_with_missing_disposition:
+            record_errors.append(Expunger._build_disposition_error_message(
+                cases_with_missing_disposition, "a missing"))
+        if cases_with_unknown_disposition:
+            record_errors.append(Expunger._build_disposition_error_message(
+                cases_with_unknown_disposition, "an unrecognized"))
+        return record_errors
+
+    @staticmethod
+    def _filter_cases_with_errors(charges):
+        cases_with_missing_disposition : Set[str] = set()
+        cases_with_unknown_disposition : Set[str] = set()
+        for charge in charges:
+            if not charge.skip_analysis():
+                case_number = charge.case()().case_number
+                if not charge.disposition:
+                    cases_with_missing_disposition.add(case_number)
+                elif charge.disposition.status == DispositionStatus.UNKNOWN:
+                    cases_with_unknown_disposition.add(case_number)
+        return cases_with_missing_disposition, cases_with_unknown_disposition
+
+    @staticmethod
+    def _build_disposition_error_message(error_cases, disposition_error_name):
+        if len(error_cases) == 1:
+                error_message = (
+f"""Case {error_cases.pop()} has a charge with {disposition_error_name} disposition.
+This is likely an error in the OECI database. Time analysis is ignoring this charge and may be inaccurate for other charges.""")
+        else:
+            cases_list_string = ", ".join(error_cases)
+            error_message = (
+f"""The following cases have charges with {disposition_error_name} disposition.
+This is likely an error in the OECI database. Time analysis is ignoring these charges and may be inaccurate for other charges.
+Case numbers: {cases_list_string}""")
+        return error_message


### PR DESCRIPTION
A missing or unknown disposition generates a record error unless the charge is "skippable" because it never affects time analysis, e.g. a traffic violation.
 
The test cases here (expanding the functional test case file) check for examples where a single error message is generated. 

Two more tests that would be useful:
- Test the case of multiple missing/unknown dispos and that the correct error messages are all present.
- Test that a traffic violation charge with a missing / unknown disposition doesn't generate a record error. 

Related to PR #684, which will show these error messages in the search results.

Closes #652 and #358 (which are mostly the same issue)
 