### PR TITLE
Force frontend to logout state if not invalid OECI auth

### DIFF
--- a/src/backend/expungeservice/request/error.py
+++ b/src/backend/expungeservice/request/error.py
@@ -1,6 +1,6 @@
-from flask import abort
+from flask import abort, jsonify, make_response
 import logging
 
 def error(code, message):
     logging.error("code %i %s" % (code, message), stack_info = True)
-    abort(code, message)
+    abort(make_response(jsonify(message=message), code))

--- a/src/frontend/src/service/api-service.ts
+++ b/src/frontend/src/service/api-service.ts
@@ -7,7 +7,11 @@ export default function apiService<T>(
   request: AxiosRequestConfig
 ): AxiosPromise {
   return axios.request<T>(request).catch(error => {
-    if (error.response && error.response.status === 401 && error.response.message === "Invalid username or password") {
+    if (
+      error.response &&
+      error.response.status === 401 &&
+      error.response.data.message !== 'Invalid OECI username or password.'
+    ) {
       // This logs the app out if any endpoint request is denied app authorization
       // The exact string comparison ensures that it catches only the errors thrown by
       // app authorization, and not from an OECI login failure which also has a 401 code.


### PR DESCRIPTION
Follow up from https://github.com/codeforpdx/recordexpungPDX/pull/664

`error.response.message` doesn't exist (now or previously). Previously the error message was embedded in the HTML response body. Now the jsonified error message is at `error.response.data.message`.