### PR TITLE
Replace redux toolkit package dependency

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1177,6 +1177,26 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
+    "@reduxjs/toolkit": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.2.1.tgz",
+      "integrity": "sha512-mVvcjAyPS91wbAG2JoLIVP0JiWoLYHCA5WYevjHBjxhTlBPa3lYbUS9/IqanGPIt9TmSYON42l3BTPfWsfr2wg==",
+      "requires": {
+        "immer": "^4.0.1",
+        "redux": "^4.0.0",
+        "redux-devtools-extension": "^2.13.8",
+        "redux-immutable-state-invariant": "^2.1.0",
+        "redux-thunk": "^2.3.0",
+        "reselect": "^4.0.0"
+      },
+      "dependencies": {
+        "immer": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/immer/-/immer-4.0.2.tgz",
+          "integrity": "sha512-Q/tm+yKqnKy4RIBmmtISBlhXuSDrB69e9EKTYiIenIKQkXBQir43w+kN/eGiax3wt1J0O1b2fYcNqLSbEcXA7w=="
+        }
+      }
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -11622,26 +11642,6 @@
       "integrity": "sha512-ryhkkb/4D4CUGpAV2ln1GOY/uh51aczjcRz9k2L2bPx/Xja3c5pSGJJPyR25GNVRXtKIExScdAgFdiXp68GmJA==",
       "requires": {
         "lodash.isplainobject": "^4.0.6"
-      }
-    },
-    "redux-starter-kit": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/redux-starter-kit/-/redux-starter-kit-2.0.0.tgz",
-      "integrity": "sha512-s/63wbRB1Az4pnTD36JtBld7C/Wrxu73Lckf3Je6RKHFk9GoIkJG5OfEZdMm6WukSPYoloKtkUjrWpF1gc/VgA==",
-      "requires": {
-        "immer": "^4.0.1",
-        "redux": "^4.0.0",
-        "redux-devtools-extension": "^2.13.8",
-        "redux-immutable-state-invariant": "^2.1.0",
-        "redux-thunk": "^2.3.0",
-        "reselect": "^4.0.0"
-      },
-      "dependencies": {
-        "immer": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/immer/-/immer-4.0.2.tgz",
-          "integrity": "sha512-Q/tm+yKqnKy4RIBmmtISBlhXuSDrB69e9EKTYiIenIKQkXBQir43w+kN/eGiax3wt1J0O1b2fYcNqLSbEcXA7w=="
-        }
       }
     },
     "redux-thunk": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -5,6 +5,7 @@
   "proxy": "http://localhost:5000",
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.11.2",
+    "@reduxjs/toolkit": "^1.2.1",
     "@types/jest": "24.0.23",
     "@types/lodash": "^4.14.149",
     "@types/node": "12.12.14",
@@ -29,7 +30,6 @@
     "react-test-renderer": "^16.11.0",
     "redux": "^4.0.5",
     "redux-mock-store": "^1.5.3",
-    "redux-starter-kit": "^2.0.0",
     "tachyons": "^4.11.1",
     "typescript": "3.7.2"
   },

--- a/src/frontend/src/redux/store.tsx
+++ b/src/frontend/src/redux/store.tsx
@@ -1,7 +1,7 @@
 // See the following guides for an explanation:
 // https://redux-starter-kit.js.org/usage/usage-guide
 // https://redux.js.org/recipes/usage-with-typescript
-import { configureStore, getDefaultMiddleware } from 'redux-starter-kit';
+import { configureStore, getDefaultMiddleware } from '@reduxjs/toolkit';
 import { combineReducers } from 'redux';
 
 // Reducers:


### PR DESCRIPTION
The npm production build throws the following error, apparently due to the version bump (PR #677) for `redux-starter-kit`.

> /usr/src/app/src/redux/store.tsx
TypeScript error in /usr/src/app/src/redux/store.tsx(4,10):
Module '"../../node_modules/redux-starter-kit/dist"' has no exported member 'configureStore'.  TS2305
    2 | // https://redux-starter-kit.js.org/usage/usage-guide
    3 | // https://redux.js.org/recipes/usage-with-typescript
  > 4 | import { configureStore, getDefaultMiddleware } from 'redux-starter-kit';

This PR replaces the obsolete packaged dependency with the one described in the package documentation  (linked above).

The dependency `redux-starter-kit` is no longer used, so it is removed.
 