### PR TITLE
Extract ChargesWithSummary from Expunger

### DIFF
--- a/src/backend/expungeservice/expunger/analyzers/time_analyzer.py
+++ b/src/backend/expungeservice/expunger/analyzers/time_analyzer.py
@@ -1,33 +1,36 @@
 from datetime import date
+from typing import List
+
 from dateutil.relativedelta import relativedelta
 
-from expungeservice.models.expungement_result import TypeEligibility, ExpungementResult, EligibilityStatus
+from expungeservice.expunger.charges_summarizer import ChargesWithSummary
+from expungeservice.models.charge import Charge
 
 
 class TimeAnalyzer:
-
     TWENTY_YEARS = 20
     TEN_YEARS = 10
     THREE_YEARS = 3
 
+    # TODO: Change to `def evaluate(record: Record, charges_with_summary: ChargesWithSummary) -> RecordWithAnalysis:`
     @staticmethod
-    def evaluate(expunger):
-        if expunger.most_recent_conviction:
-            elig_date = TimeAnalyzer._calc_elig_date(expunger.most_recent_conviction, TimeAnalyzer.TEN_YEARS)
-            TimeAnalyzer._mark_as_time_ineligible(expunger.charges, 'Time-ineligible under 137.225(7)(b)', elig_date)
-            TimeAnalyzer._check_mrc_time_eligibility(expunger)
-        elif expunger.most_recent_dismissal:
-            TimeAnalyzer._mark_all_acquittals_ineligible_using_mrd_date(expunger)
-            TimeAnalyzer._mark_as_time_eligible(expunger.most_recent_dismissal.case()().charges)
-            TimeAnalyzer._mark_as_time_eligible(expunger.convictions)
+    def evaluate(charges_with_summary: ChargesWithSummary):
+        if charges_with_summary.most_recent_conviction:
+            elig_date = TimeAnalyzer._calc_elig_date(charges_with_summary.most_recent_conviction, TimeAnalyzer.TEN_YEARS)
+            TimeAnalyzer._mark_as_time_ineligible(charges_with_summary.charges, 'Time-ineligible under 137.225(7)(b)', elig_date)
+            TimeAnalyzer._check_mrc_time_eligibility(charges_with_summary)
+        elif charges_with_summary.most_recent_dismissal:
+            TimeAnalyzer._mark_all_acquittals_ineligible_using_mrd_date(charges_with_summary)
+            TimeAnalyzer._mark_as_time_eligible(charges_with_summary.most_recent_dismissal.case()().charges)
+            TimeAnalyzer._mark_as_time_eligible(charges_with_summary.convictions)
         else:
             # There is no MRC and no MRD. But the record might still have a single recent violation conviction,
             # Which is subject to the three-year single conviction rule.
             recent_violation_convictions = [
-                charge for charge in expunger.charges if charge not in
-                    expunger.unknowns +
-                    expunger.old_convictions +
-                    expunger.acquittals
+                charge for charge in charges_with_summary.charges if charge not in
+                                                                     charges_with_summary.unknowns +
+                                                                     charges_with_summary.old_convictions +
+                                                                     charges_with_summary.acquittals
                     ]
 
             if len(recent_violation_convictions) == 0:
@@ -35,86 +38,86 @@ class TimeAnalyzer:
             elif len(recent_violation_convictions) == 1:
                 recent_violation_conviction = recent_violation_convictions[0]
                 three_years_ago = date.today() + relativedelta(years=-3)
-                older_than_three_years = recent_violation_conviction.disposition.date <= three_years_ago
+                older_than_three_years = recent_violation_conviction.disposition.date <= three_years_ago # type: ignore
                 if older_than_three_years:
                     recent_violation_conviction.set_time_eligible()
                 else:
-                    date_eligible = recent_violation_conviction.disposition.date + relativedelta(years=+3)
+                    date_eligible = recent_violation_conviction.disposition.date + relativedelta(years=+3) # type: ignore
                     recent_violation_conviction.set_time_ineligible("Time-ineligible under 137.225(1)(a)", date_eligible)
             else:
                 raise ValueError("There is no MRC and no MRD, so the recent known charges should only contain a single violation or nothing.")
-            TimeAnalyzer._mark_as_time_eligible(expunger.old_convictions + expunger.acquittals)
+            TimeAnalyzer._mark_as_time_eligible(charges_with_summary.old_convictions + charges_with_summary.acquittals)
 
-        TimeAnalyzer._evaluate_class_b_felonies(expunger)
+        TimeAnalyzer._evaluate_class_b_felonies(charges_with_summary)
 
     @staticmethod
-    def _check_mrc_time_eligibility(expunger):
-        eligibility_date = TimeAnalyzer._calc_furthest_out_elig_date(expunger)
-        if expunger.second_most_recent_conviction:
-            expunger.most_recent_conviction.set_time_ineligible('Multiple convictions within last ten years', eligibility_date)
-        elif TimeAnalyzer._most_recent_conviction_is_greater_than_three_years_old(expunger):
-            expunger.most_recent_conviction.set_time_eligible()
+    def _check_mrc_time_eligibility(charges: ChargesWithSummary):
+        eligibility_date = TimeAnalyzer._calc_furthest_out_elig_date(charges)
+        if charges.second_most_recent_conviction:
+            charges.most_recent_conviction.set_time_ineligible('Multiple convictions within last ten years', eligibility_date) # type: ignore
+        elif TimeAnalyzer._most_recent_conviction_is_greater_than_three_years_old(charges):
+            charges.most_recent_conviction.set_time_eligible() # type: ignore
         else:
-            expunger.most_recent_conviction.set_time_ineligible('Most recent conviction is less than three years old', eligibility_date)
+            charges.most_recent_conviction.set_time_ineligible('Most recent conviction is less than three years old', eligibility_date) # type: ignore
 
     @staticmethod
-    def _calc_furthest_out_elig_date(expunger):
-        if expunger.second_most_recent_conviction:
-            date_1 = TimeAnalyzer._calc_elig_date(expunger.second_most_recent_conviction, TimeAnalyzer.TEN_YEARS)
-            date_2 = TimeAnalyzer._calc_elig_date(expunger.most_recent_conviction, TimeAnalyzer.THREE_YEARS)
+    def _calc_furthest_out_elig_date(charges_with_summary: ChargesWithSummary):
+        if charges_with_summary.second_most_recent_conviction:
+            date_1 = TimeAnalyzer._calc_elig_date(charges_with_summary.second_most_recent_conviction, TimeAnalyzer.TEN_YEARS)
+            date_2 = TimeAnalyzer._calc_elig_date(charges_with_summary.most_recent_conviction, TimeAnalyzer.THREE_YEARS) # type: ignore
             return max(date_1, date_2)
         else:
-            return TimeAnalyzer._calc_elig_date(expunger.most_recent_conviction, TimeAnalyzer.THREE_YEARS)
+            return TimeAnalyzer._calc_elig_date(charges_with_summary.most_recent_conviction, TimeAnalyzer.THREE_YEARS) # type: ignore
 
     @staticmethod
-    def _calc_elig_date(charge, years):
-        return charge.disposition.date + relativedelta(years=years)
+    def _calc_elig_date(charge: Charge, years: int) -> date:
+        return charge.disposition.date + relativedelta(years=years) # type: ignore
 
     @staticmethod
-    def _most_recent_conviction_is_greater_than_three_years_old(expunger):
+    def _most_recent_conviction_is_greater_than_three_years_old(charges: ChargesWithSummary):
         three_years_ago = date.today() + relativedelta(years=-3)
-        return expunger.most_recent_conviction.disposition.date <= three_years_ago
+        return charges.most_recent_conviction.disposition.date <= three_years_ago # type: ignore
 
     @staticmethod
-    def _mark_all_acquittals_ineligible_using_mrd_date(expunger):
-        eligibility_date = expunger.most_recent_dismissal.date + relativedelta(years=+TimeAnalyzer.THREE_YEARS)
-        for charge in expunger.acquittals:
+    def _mark_all_acquittals_ineligible_using_mrd_date(charges_with_summary: ChargesWithSummary):
+        eligibility_date = charges_with_summary.most_recent_dismissal.date + relativedelta(years=+TimeAnalyzer.THREE_YEARS) # type: ignore
+        for charge in charges_with_summary.acquittals:
             charge.set_time_ineligible('Recommend sequential expungement', eligibility_date)
 
     @staticmethod
-    def _calculate_has_subsequent_charge(class_b_felony, charges):
+    def _calculate_has_subsequent_charge(class_b_felony: Charge, charges: List[Charge]) -> bool:
         other_charges = [charge for charge in charges if charge != class_b_felony]
         for other_charge in other_charges:
             if other_charge.acquitted():
                 date_of_other_charge = other_charge.date
             else:
-                date_of_other_charge = other_charge.disposition.date
+                date_of_other_charge = other_charge.disposition.date # type: ignore
 
-            if date_of_other_charge > class_b_felony.disposition.date:
+            if date_of_other_charge > class_b_felony.disposition.date: # type: ignore
                 return True
         return False
 
     @staticmethod
-    def _evaluate_class_b_felonies(expunger):
-        for class_b_felony in expunger.class_b_felonies:
+    def _evaluate_class_b_felonies(charges_with_summary: ChargesWithSummary):
+        for class_b_felony in charges_with_summary.class_b_felonies:
             # If the class B felony is acquitted, then we have already handled its time eligibility.
             # If it's convicted, it is subject to these additional rules.
             # If its disposition is unknown, we don't apply any time analysis.
             if class_b_felony.convicted():
-                if TimeAnalyzer._calculate_has_subsequent_charge(class_b_felony, expunger.charges):
+                if TimeAnalyzer._calculate_has_subsequent_charge(class_b_felony, charges_with_summary.charges):
                     class_b_felony.set_time_ineligible('137.225(5)(a)(A)(ii) - Class B felony can have no subsequent arrests or convictions', None)
                 else:
-                    eligibility_date = class_b_felony.disposition.date + relativedelta(years=+TimeAnalyzer.TWENTY_YEARS)
+                    eligibility_date = class_b_felony.disposition.date + relativedelta(years=+TimeAnalyzer.TWENTY_YEARS) # type: ignore
                     if eligibility_date > date.today():
                         class_b_felony.set_time_ineligible('137.225(5)(a)(A)(i) - Twenty years from class B felony conviction', eligibility_date)
                     # else do nothing, because the charge has already been set as time eligible by the TimeAnalyzer.
 
     @staticmethod
-    def _mark_as_time_ineligible(charges, reason, eligibility_date):
+    def _mark_as_time_ineligible(charges: List[Charge], reason: str, eligibility_date: date):
         for charge in charges:
             charge.set_time_ineligible(reason, eligibility_date)
 
     @staticmethod
-    def _mark_as_time_eligible(charges):
+    def _mark_as_time_eligible(charges: List[Charge]):
         for charge in charges:
             charge.set_time_eligible()

--- a/src/backend/expungeservice/expunger/charges_summarizer.py
+++ b/src/backend/expungeservice/expunger/charges_summarizer.py
@@ -1,0 +1,97 @@
+from dataclasses import dataclass, field
+from typing import List, Optional
+from more_itertools import padnone, take
+
+from expungeservice.models.charge import Charge
+from expungeservice.models.charge_types.felony_class_b import FelonyClassB
+
+
+@dataclass
+class ChargesWithSummary:
+    """
+    most_recent_conviction: Most recent conviction if one exists from within the last ten years
+    second_most_recent_conviction: Second most recent conviction if one exists from within the last ten years
+    most_recent_dismissal: Most recent dismissal if one exists from within the last three years
+    class_b_felonies: A list of class B felonies; excluding person crimes or firearm crimes
+    most_recent_charge: The most recent charge within the last 20yrs; excluding traffic violations # (NB Kent): Why within the last 20yrs?
+    """
+    charges: List[Charge]
+    acquittals: List[Charge] = field(default_factory=list)
+    convictions: List[Charge] = field(default_factory=list)
+    unknowns: List[Charge] = field(default_factory=list)
+    old_convictions: List[Charge] = field(default_factory=list)
+    most_recent_dismissal: Optional[Charge] = None
+    most_recent_conviction: Optional[Charge] = None
+    second_most_recent_conviction: Optional[Charge] = None
+    most_recent_charge: Optional[Charge] = None
+    class_b_felonies: List[Charge] = field(default_factory=list)
+
+
+class ChargesSummarizer:
+    @staticmethod
+    def summarize(charges: List[Charge]) -> ChargesWithSummary:
+        acquittals, convictions, unknowns = ChargesSummarizer._categorize_charges(charges)
+        recent_convictions, old_convictions = ChargesSummarizer._categorize_convictions_by_recency(convictions)
+        most_recent_dismissal = ChargesSummarizer._most_recent_dismissal(acquittals)
+        most_recent_conviction, second_most_recent_conviction = ChargesSummarizer._most_recent_convictions(recent_convictions)
+        most_recent_charge = ChargesSummarizer._most_recent_charge(charges)
+        class_b_felonies = ChargesSummarizer._class_b_felonies(charges)
+        return ChargesWithSummary(charges, acquittals, convictions, unknowns, old_convictions, most_recent_dismissal, most_recent_conviction, second_most_recent_conviction, most_recent_charge, class_b_felonies)
+
+    @staticmethod
+    def _categorize_charges(charges):
+        acquittals, convictions, unknowns = [], [], []
+        for charge in charges:
+            if charge.acquitted():
+                acquittals.append(charge)
+            elif charge.convicted():
+                convictions.append(charge)
+            else:
+                unknowns.append(charge)
+        return acquittals, convictions, unknowns
+
+    @staticmethod
+    def _categorize_convictions_by_recency(convictions):
+        recent_convictions = []
+        old_convictions = []
+        for charge in convictions:
+            if charge.recent_conviction():
+                recent_convictions.append(charge)
+            else:
+                old_convictions.append(charge)
+        return recent_convictions, old_convictions
+
+    @staticmethod
+    def _most_recent_dismissal(acquittals):
+        acquittals.sort(key=lambda charge: charge.date)
+        if acquittals and acquittals[-1].recent_acquittal():
+            return acquittals[-1]
+        else:
+            return None
+
+    @staticmethod
+    def _most_recent_convictions(recent_convictions):
+        recent_convictions.sort(key=lambda charge: charge.disposition.date, reverse=True)
+        first, second, third = take(3, padnone(recent_convictions))
+        if first and "violation" in first.level.lower():
+            return second, third
+        elif second and "violation" in second.level.lower():
+            return first, third
+        else:
+            return first, second
+
+    @staticmethod
+    def _most_recent_charge(charges):
+        charges.sort(key=lambda charge: charge.disposition.date, reverse=True)
+        if charges:
+            return charges[0]
+        else:
+            return None
+
+    @staticmethod
+    def _class_b_felonies(charges):
+        class_b_felonies = []
+        for charge in charges:
+            if isinstance(charge, FelonyClassB):
+                class_b_felonies.append(charge)
+        return class_b_felonies

--- a/src/backend/tests/functional_tests/test_crawler_expunger.py
+++ b/src/backend/tests/functional_tests/test_crawler_expunger.py
@@ -42,8 +42,8 @@ def test_expunger_with_an_empty_record(empty_record):
     expunger = Expunger(empty_record)
 
     assert expunger.run()
-    assert expunger.most_recent_dismissal is None
-    assert expunger.most_recent_conviction is None
+    assert expunger.charges_with_summary.most_recent_dismissal is None
+    assert expunger.charges_with_summary.most_recent_conviction is None
 
 
 @pytest.fixture
@@ -132,8 +132,8 @@ def test_expunger_categorizes_charges(record_with_various_categories):
     expunger = Expunger(record_with_various_categories)
 
     assert expunger.run()
-    assert len(expunger.acquittals) == 5
-    assert len(expunger.convictions) == 4
+    assert len(expunger.charges_with_summary.acquittals) == 5
+    assert len(expunger.charges_with_summary.convictions) == 4
 
 @pytest.fixture
 def record_with_specific_dates(crawler):
@@ -162,13 +162,16 @@ def record_with_specific_dates(crawler):
 def test_expunger_runs_time_analyzer(record_with_specific_dates):
     record = record_with_specific_dates
     expunger = Expunger(record)
+    charges_with_summary = expunger.charges_with_summary
 
     assert expunger.run()
 
-    assert expunger.most_recent_conviction is None
-    assert expunger.second_most_recent_conviction is None
-    assert expunger.most_recent_dismissal and expunger.most_recent_dismissal.disposition.ruling == 'No Complaint'
-    assert len(expunger.acquittals) == 8
+    assert charges_with_summary.most_recent_conviction is None
+    assert charges_with_summary.second_most_recent_conviction is None
+    assert charges_with_summary.most_recent_dismissal and \
+           charges_with_summary.most_recent_dismissal.disposition and \
+           charges_with_summary.most_recent_dismissal.disposition.ruling == 'No Complaint'
+    assert len(charges_with_summary.acquittals) == 8
 
     assert record.cases[0].charges[0].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
     assert record.cases[0].charges[1].expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE


### PR DESCRIPTION
We ultimately aim to make the TimeAnalyzer more functional. This commit is a step towards that. Instead of passing in the entire Expunger, we extract a dataclass ChargesWithSummary that contains the fields that the TimeAnalyzer operates on.