### PR TITLE
Display Charge Type in the search results

### DIFF
--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -26,6 +26,7 @@ class Charge:
     _chapter: Optional[str]
     _section: str
     _case: weakref.ref
+    type_name: str = "Unknown"
 
     def __post_init__(self):
         type_eligibility = self._build_type_eligibility()

--- a/src/backend/expungeservice/models/charge_types/duii.py
+++ b/src/backend/expungeservice/models/charge_types/duii.py
@@ -1,9 +1,14 @@
+from dataclasses import dataclass
+
 from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 from expungeservice.models.disposition import DispositionStatus
 
 
+@dataclass(eq=False)
 class Duii(Charge):
+    type_name: str = "DUII"
+
     def _default_type_eligibility(self):
         """
         DUII charges can be diverted, and in some cases the Disposition will

--- a/src/backend/expungeservice/models/charge_types/felony_class_a.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_a.py
@@ -1,8 +1,13 @@
+from dataclasses import dataclass
+
 from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
+@dataclass(eq=False)
 class FelonyClassA(Charge):
+    type_name: str = "Felony Class A"
+
     def _default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.225(1)(b)")

--- a/src/backend/expungeservice/models/charge_types/felony_class_b.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_b.py
@@ -1,8 +1,13 @@
+from dataclasses import dataclass
+
 from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
+@dataclass(eq=False)
 class FelonyClassB(Charge):
+    type_name: str = "Felony Class B"
+
     def _default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.225(1)(b)")

--- a/src/backend/expungeservice/models/charge_types/felony_class_c.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_c.py
@@ -1,8 +1,13 @@
+from dataclasses import dataclass
+
 from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
+@dataclass(eq=False)
 class FelonyClassC(Charge):
+    type_name: str = "Felony Class C"
+
     def _default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.225(1)(b)")

--- a/src/backend/expungeservice/models/charge_types/juvenile_charge.py
+++ b/src/backend/expungeservice/models/charge_types/juvenile_charge.py
@@ -1,10 +1,15 @@
+from dataclasses import dataclass
+
 from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
+@dataclass(eq=False)
 class JuvenileCharge(Charge):
+    type_name: str = "Juvenile"
+
     def _default_type_eligibility(self):
-        return TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason="Juvenile Charge : Needs further analysis")
+        return TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason="Potentially eligible under 419A.262")
 
     def skip_analysis(self):
         return True

--- a/src/backend/expungeservice/models/charge_types/level_800_traffic_crime.py
+++ b/src/backend/expungeservice/models/charge_types/level_800_traffic_crime.py
@@ -1,8 +1,13 @@
+from dataclasses import dataclass
+
 from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
+@dataclass(eq=False)
 class Level800TrafficCrime(Charge):
+    type_name: str = "Level 800 Traffic Crime"
+
     def _default_type_eligibility(self):
         if self._expungeable():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.225(1)(b)")

--- a/src/backend/expungeservice/models/charge_types/marijuana_ineligible.py
+++ b/src/backend/expungeservice/models/charge_types/marijuana_ineligible.py
@@ -1,8 +1,13 @@
+from dataclasses import dataclass
+
 from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
+@dataclass(eq=False)
 class MarijuanaIneligible(Charge):
+    type_name: str = "Marijuana Ineligible"
+
     def _default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.225(1)(b)")

--- a/src/backend/expungeservice/models/charge_types/misdemeanor.py
+++ b/src/backend/expungeservice/models/charge_types/misdemeanor.py
@@ -1,8 +1,13 @@
+from dataclasses import dataclass
+
 from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
+@dataclass(eq=False)
 class Misdemeanor(Charge):
+    type_name: str = "Misdemeanor"
+
     def _default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.225(1)(b)")

--- a/src/backend/expungeservice/models/charge_types/non_traffic_violation.py
+++ b/src/backend/expungeservice/models/charge_types/non_traffic_violation.py
@@ -1,8 +1,13 @@
+from dataclasses import dataclass
+
 from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
+@dataclass(eq=False)
 class NonTrafficViolation(Charge):
+    type_name: str = "Non-traffic Violation"
+
     def _default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.225(1)(b)")

--- a/src/backend/expungeservice/models/charge_types/parking_ticket.py
+++ b/src/backend/expungeservice/models/charge_types/parking_ticket.py
@@ -1,8 +1,13 @@
+from dataclasses import dataclass
+
 from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
+@dataclass(eq=False)
 class ParkingTicket(Charge):
+    type_name: str = "Parking Ticket"
+
     def _default_type_eligibility(self):
         return TypeEligibility(EligibilityStatus.INELIGIBLE, reason="Ineligible under 137.225(5)")
 

--- a/src/backend/expungeservice/models/charge_types/person_crime.py
+++ b/src/backend/expungeservice/models/charge_types/person_crime.py
@@ -1,8 +1,13 @@
+from dataclasses import dataclass
+
 from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
+@dataclass(eq=False)
 class PersonCrime(Charge):
+    type_name: str = "Person Crime"
+
     def _default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.225(1)(b)")

--- a/src/backend/expungeservice/models/charge_types/schedule_1_p_c_s.py
+++ b/src/backend/expungeservice/models/charge_types/schedule_1_p_c_s.py
@@ -1,8 +1,13 @@
+from dataclasses import dataclass
+
 from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
+@dataclass(eq=False)
 class Schedule1PCS(Charge):
+    type_name: str = "Schedule 1 PCS"
+
     def _default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.225(1)(b)")

--- a/src/backend/expungeservice/models/charge_types/subsection_12.py
+++ b/src/backend/expungeservice/models/charge_types/subsection_12.py
@@ -1,8 +1,13 @@
+from dataclasses import dataclass
+
 from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
-class ListB(Charge):
+@dataclass(eq=False)
+class Subsection12(Charge):
+    type_name: str = "Subsection 12"
+
     def _default_type_eligibility(self):
         if self.acquitted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.225(1)(b)")

--- a/src/backend/expungeservice/models/charge_types/unclassified_charge.py
+++ b/src/backend/expungeservice/models/charge_types/unclassified_charge.py
@@ -1,8 +1,13 @@
+from dataclasses import dataclass
+
 from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
+@dataclass(eq=False)
 class UnclassifiedCharge(Charge):
+    type_name: str = "Unclassified"
+
     def _default_type_eligibility(self):
         return TypeEligibility(
             EligibilityStatus.NEEDS_MORE_ANALYSIS, reason="Unrecognized Charge : Further Analysis Needed"

--- a/src/backend/expungeservice/models/helpers/charge_classifier.py
+++ b/src/backend/expungeservice/models/helpers/charge_classifier.py
@@ -6,7 +6,7 @@ from expungeservice.models.charge_types.felony_class_b import FelonyClassB
 from expungeservice.models.charge_types.felony_class_c import FelonyClassC
 from expungeservice.models.charge_types.level_800_traffic_crime import Level800TrafficCrime
 from expungeservice.models.charge_types.duii import Duii
-from expungeservice.models.charge_types.list_b import ListB
+from expungeservice.models.charge_types.subsection_12 import Subsection12
 from expungeservice.models.charge_types.marijuana_ineligible import MarijuanaIneligible
 from expungeservice.models.charge_types.misdemeanor import Misdemeanor
 from expungeservice.models.charge_types.non_traffic_violation import NonTrafficViolation
@@ -47,7 +47,7 @@ class ChargeClassifier:
     @staticmethod
     def _classification_by_statute(statute, chapter, section):
         yield ChargeClassifier._marijuana_ineligible(statute, section)
-        yield ChargeClassifier._list_b(section)
+        yield ChargeClassifier._subsection_12(section)
         yield ChargeClassifier._crime_against_person(section)
         yield ChargeClassifier._traffic_crime(statute)
         yield ChargeClassifier._parking_ticket(statute, chapter)
@@ -68,7 +68,7 @@ class ChargeClassifier:
             return MarijuanaIneligible
 
     @staticmethod
-    def _list_b(section):
+    def _subsection_12(section):
         ineligible_statutes = [
             "163200",
             "163205",
@@ -86,7 +86,7 @@ class ChargeClassifier:
             "163165",
         ]
         if section in ineligible_statutes:
-            return ListB
+            return Subsection12
 
     @staticmethod
     def _crime_against_person(section):

--- a/src/backend/expungeservice/serializer/serializer.py
+++ b/src/backend/expungeservice/serializer/serializer.py
@@ -36,6 +36,7 @@ class ExpungeModelEncoder(flask.json.JSONEncoder):
             "name": charge.name,
             "statute": charge.statute,
             "level": charge.level,
+            "type_name": charge.type_name,
             "date": charge.date,
             "disposition": disposition,
             "expungement_result": dataclasses.asdict(charge.expungement_result),

--- a/src/backend/tests/models/charge_types/test_juvenile_charge.py
+++ b/src/backend/tests/models/charge_types/test_juvenile_charge.py
@@ -13,5 +13,6 @@ class TestJuvenileCharge(unittest.TestCase):
         juvenile_charge = ChargeFactory.create(case=case, disposition=("Acquitted", "1/1/0001"))
 
         assert juvenile_charge.__class__.__name__ == "JuvenileCharge"
+        assert juvenile_charge.type_name == "Juvenile"
         assert juvenile_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-        assert juvenile_charge.expungement_result.type_eligibility.reason == "Juvenile Charge : Needs further analysis"
+        assert juvenile_charge.expungement_result.type_eligibility.reason == "Potentially eligible under 419A.262"

--- a/src/backend/tests/models/charge_types/test_level_800_traffic_crime.py
+++ b/src/backend/tests/models/charge_types/test_level_800_traffic_crime.py
@@ -37,6 +37,7 @@ class TestLevel800Charges(unittest.TestCase):
         self.charges.append(charge)
 
         assert charge.__class__.__name__ == "Level800TrafficCrime"
+        assert charge.type_name == "Level 800 Traffic Crime"
 
     def test_traffic_violation_max_statute(self):
         self.single_charge["statute"] = "825.999"
@@ -50,6 +51,7 @@ class TestLevel800Charges(unittest.TestCase):
         charge = self.create_recent_charge()
 
         assert charge.__class__.__name__ == "Duii"
+        assert charge.type_name == "DUII"
 
 
 class TestLevel800MisdemeanorFelonyEligibility(unittest.TestCase):

--- a/src/backend/tests/models/charge_types/test_parking_ticket.py
+++ b/src/backend/tests/models/charge_types/test_parking_ticket.py
@@ -16,6 +16,7 @@ class TestParkingTicket(unittest.TestCase):
 
         assert self.parking_ticket.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
         assert self.parking_ticket.expungement_result.type_eligibility.reason == "Ineligible under 137.225(5)"
+        assert self.parking_ticket.type_name == "Parking Ticket"
 
     def test_parking_tickets_skip_analysis(self):
         self.build()

--- a/src/backend/tests/models/charge_types/test_type_analyzer_convicted_charges.py
+++ b/src/backend/tests/models/charge_types/test_type_analyzer_convicted_charges.py
@@ -25,6 +25,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         felony_class_a_convicted = self.create_recent_charge()
         self.charges.append(felony_class_a_convicted)
 
+        assert felony_class_a_convicted.type_name == "Felony Class A"
         assert felony_class_a_convicted.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
         assert felony_class_a_convicted.expungement_result.type_eligibility.reason == "Ineligible under 137.225(5)"
 
@@ -35,6 +36,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         misdemeanor_class_a_convicted = self.create_recent_charge()
         self.charges.append(misdemeanor_class_a_convicted)
 
+        assert misdemeanor_class_a_convicted.type_name == "Person Crime"
         assert misdemeanor_class_a_convicted.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
         assert misdemeanor_class_a_convicted.expungement_result.type_eligibility.reason == "Ineligible under 137.225(5)"
 
@@ -43,6 +45,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         convicted_charge = self.create_recent_charge()
         self.charges.append(convicted_charge)
 
+        assert convicted_charge.type_name == "Person Crime"
         assert convicted_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
         assert convicted_charge.expungement_result.type_eligibility.reason == "Ineligible under 137.225(5)"
 
@@ -51,6 +54,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         convicted_charge = self.create_recent_charge()
         self.charges.append(convicted_charge)
 
+        assert convicted_charge.type_name == "Person Crime"
         assert convicted_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
         assert convicted_charge.expungement_result.type_eligibility.reason == "Ineligible under 137.225(5)"
 
@@ -59,6 +63,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         convicted_charge = self.create_recent_charge()
         self.charges.append(convicted_charge)
 
+        assert convicted_charge.type_name == "Person Crime"
         assert convicted_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
         assert convicted_charge.expungement_result.type_eligibility.reason == "Ineligible under 137.225(5)"
 
@@ -67,6 +72,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         convicted_charge = self.create_recent_charge()
         self.charges.append(convicted_charge)
 
+        assert convicted_charge.type_name == "Person Crime"
         assert convicted_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
         assert convicted_charge.expungement_result.type_eligibility.reason == "Ineligible under 137.225(5)"
 
@@ -75,6 +81,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         convicted_charge = self.create_recent_charge()
         self.charges.append(convicted_charge)
 
+        assert convicted_charge.type_name == "Person Crime"
         assert convicted_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
         assert convicted_charge.expungement_result.type_eligibility.reason == "Ineligible under 137.225(5)"
 
@@ -83,6 +90,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         convicted_charge = self.create_recent_charge()
         self.charges.append(convicted_charge)
 
+        assert convicted_charge.type_name == "Person Crime"
         assert convicted_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
         assert convicted_charge.expungement_result.type_eligibility.reason == "Ineligible under 137.225(5)"
 
@@ -91,6 +99,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         convicted_charge = self.create_recent_charge()
         self.charges.append(convicted_charge)
 
+        assert convicted_charge.type_name == "Person Crime"
         assert convicted_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
         assert convicted_charge.expungement_result.type_eligibility.reason == "Ineligible under 137.225(5)"
 
@@ -99,6 +108,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         convicted_charge = self.create_recent_charge()
         self.charges.append(convicted_charge)
 
+        assert convicted_charge.type_name == "Person Crime"
         assert convicted_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
         assert convicted_charge.expungement_result.type_eligibility.reason == "Ineligible under 137.225(5)"
 
@@ -109,6 +119,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         misdemeanor_charge = self.create_recent_charge()
         self.charges.append(misdemeanor_charge)
 
+        assert misdemeanor_charge.type_name == "Misdemeanor"
         assert misdemeanor_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
         assert misdemeanor_charge.expungement_result.type_eligibility.reason == "Eligible under 137.225(5)(b)"
 
@@ -119,6 +130,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         sex_crime_charge = self.create_recent_charge()
         self.charges.append(sex_crime_charge)
 
+        assert sex_crime_charge.type_name == "Person Crime"
         assert sex_crime_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
         assert sex_crime_charge.expungement_result.type_eligibility.reason == "Ineligible under 137.225(5)"
 
@@ -129,6 +141,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         marijuana_felony_class_c = self.create_recent_charge()
         self.charges.append(marijuana_felony_class_c)
 
+        assert marijuana_felony_class_c.type_name == "Marijuana Ineligible"
         assert marijuana_felony_class_c.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
         assert marijuana_felony_class_c.expungement_result.type_eligibility.reason == "Ineligible under 137.226"
 
@@ -139,6 +152,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         marijuana_felony_class_a = self.create_recent_charge()
         self.charges.append(marijuana_felony_class_a)
 
+        assert marijuana_felony_class_a.type_name == "Marijuana Ineligible"
         assert marijuana_felony_class_a.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
         assert marijuana_felony_class_a.expungement_result.type_eligibility.reason == "Ineligible under 137.226"
 
@@ -149,6 +163,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         marijuana_felony_class_a = self.create_recent_charge()
         self.charges.append(marijuana_felony_class_a)
 
+        assert marijuana_felony_class_a.type_name == "Marijuana Ineligible"
         assert marijuana_felony_class_a.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
         assert marijuana_felony_class_a.expungement_result.type_eligibility.reason == "Ineligible under 137.226"
 
@@ -159,6 +174,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         marijuana_felony_class_a = self.create_recent_charge()
         self.charges.append(marijuana_felony_class_a)
 
+        assert marijuana_felony_class_a.type_name == "Marijuana Ineligible"
         assert marijuana_felony_class_a.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
         assert marijuana_felony_class_a.expungement_result.type_eligibility.reason == "Ineligible under 137.226"
 
@@ -169,162 +185,178 @@ class TestSingleChargeConvictions(unittest.TestCase):
         marijuana_misdemeanor_class_a = self.create_recent_charge()
         self.charges.append(marijuana_misdemeanor_class_a)
 
+        assert marijuana_misdemeanor_class_a.type_name == "Marijuana Ineligible"
         assert marijuana_misdemeanor_class_a.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
         assert marijuana_misdemeanor_class_a.expungement_result.type_eligibility.reason == "Ineligible under 137.226"
 
     # List B Tests - Currently being marked as "Further Analysis Needed"
 
-    def test_list_b_163200(self):
+    def test_subsection_12_163200(self):
         self.single_charge["name"] = "Criminal mistreatment in the second degree"
         self.single_charge["statute"] = "163.200"
         self.single_charge["level"] = "Misdemeanor Class A"
-        list_b_charge = self.create_recent_charge()
-        self.charges.append(list_b_charge)
+        subsection_12_charge = self.create_recent_charge()
+        self.charges.append(subsection_12_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-        assert list_b_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
+        assert subsection_12_charge.type_name == "Subsection 12"
+        assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert subsection_12_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
 
-    def test_list_b_163205(self):
+    def test_subsection_12_163205(self):
         self.single_charge["name"] = "Criminal mistreatment in the first degree"
         self.single_charge["statute"] = "163.205"
         self.single_charge["level"] = "Felony Class C"
-        list_b_charge = self.create_recent_charge()
-        self.charges.append(list_b_charge)
+        subsection_12_charge = self.create_recent_charge()
+        self.charges.append(subsection_12_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-        assert list_b_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
+        assert subsection_12_charge.type_name == "Subsection 12"
+        assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert subsection_12_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
 
-    def test_list_b_163575(self):
+    def test_subsection_12_163575(self):
         self.single_charge["name"] = "Endangering the welfare of a minor"
         self.single_charge["statute"] = "163.575"
         self.single_charge["level"] = "Misdemeanor Class A"
-        list_b_charge = self.create_recent_charge()
-        self.charges.append(list_b_charge)
+        subsection_12_charge = self.create_recent_charge()
+        self.charges.append(subsection_12_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-        assert list_b_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
+        assert subsection_12_charge.type_name == "Subsection 12"
+        assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert subsection_12_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
 
-    def test_list_b_163535(self):
+    def test_subsection_12_163535(self):
         self.single_charge["name"] = "Abandonment of a child"
         self.single_charge["statute"] = "163.535"
         self.single_charge["level"] = "Felony Class C"
-        list_b_charge = self.create_recent_charge()
-        self.charges.append(list_b_charge)
+        subsection_12_charge = self.create_recent_charge()
+        self.charges.append(subsection_12_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-        assert list_b_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
+        assert subsection_12_charge.type_name == "Subsection 12"
+        assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert subsection_12_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
 
-    def test_list_b_163175(self):
+    def test_subsection_12_163175(self):
         self.single_charge["name"] = "Assault in the second degree"
         self.single_charge["statute"] = "163.175"
         self.single_charge["level"] = "Felony Class B"
-        list_b_charge = self.create_recent_charge()
-        self.charges.append(list_b_charge)
+        subsection_12_charge = self.create_recent_charge()
+        self.charges.append(subsection_12_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-        assert list_b_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
+        assert subsection_12_charge.type_name == "Subsection 12"
+        assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert subsection_12_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
 
-    def test_list_b_163275(self):
+    def test_subsection_12_163275(self):
         self.single_charge["name"] = "Coercion"
         self.single_charge["statute"] = "163.275"
         self.single_charge["level"] = "Felony Class C"
-        list_b_charge = self.create_recent_charge()
-        self.charges.append(list_b_charge)
+        subsection_12_charge = self.create_recent_charge()
+        self.charges.append(subsection_12_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-        assert list_b_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
+        assert subsection_12_charge.type_name == "Subsection 12"
+        assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert subsection_12_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
 
-    def test_list_b_162165(self):
+    def test_subsection_12_162165(self):
         self.single_charge["name"] = "Escape in the first degree"
         self.single_charge["statute"] = "162.165"
         self.single_charge["level"] = "Felony Class B"
-        list_b_charge = self.create_recent_charge()
-        self.charges.append(list_b_charge)
+        subsection_12_charge = self.create_recent_charge()
+        self.charges.append(subsection_12_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-        assert list_b_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
+        assert subsection_12_charge.type_name == "Subsection 12"
+        assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert subsection_12_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
 
-    def test_list_b_163525(self):
+    def test_subsection_12_163525(self):
         self.single_charge["name"] = "Incest"
         self.single_charge["statute"] = "163.525"
         self.single_charge["level"] = "Felony Class C"
-        list_b_charge = self.create_recent_charge()
-        self.charges.append(list_b_charge)
+        subsection_12_charge = self.create_recent_charge()
+        self.charges.append(subsection_12_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-        assert list_b_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
+        assert subsection_12_charge.type_name == "Subsection 12"
+        assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert subsection_12_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
 
-    def test_list_b_164405(self):
+    def test_subsection_12_164405(self):
         self.single_charge["name"] = "Robbery in the second degree"
         self.single_charge["statute"] = "164.405"
         self.single_charge["level"] = "Felony Class B"
-        list_b_charge = self.create_recent_charge()
-        self.charges.append(list_b_charge)
+        subsection_12_charge = self.create_recent_charge()
+        self.charges.append(subsection_12_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-        assert list_b_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
+        assert subsection_12_charge.type_name == "Subsection 12"
+        assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert subsection_12_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
 
-    def test_list_b_164395(self):
+    def test_subsection_12_164395(self):
         self.single_charge["name"] = "Robbery in the third degree"
         self.single_charge["statute"] = "164.395"
         self.single_charge["level"] = "Felony Class C"
-        list_b_charge = self.create_recent_charge()
-        self.charges.append(list_b_charge)
+        subsection_12_charge = self.create_recent_charge()
+        self.charges.append(subsection_12_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-        assert list_b_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
+        assert subsection_12_charge.type_name == "Subsection 12"
+        assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert subsection_12_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
 
-    def test_list_b_162185(self):
+    def test_subsection_12_162185(self):
         self.single_charge["name"] = "Supplying contraband"
         self.single_charge["statute"] = "162.185"
         self.single_charge["level"] = "Felony Class C"
-        list_b_charge = self.create_recent_charge()
-        self.charges.append(list_b_charge)
+        subsection_12_charge = self.create_recent_charge()
+        self.charges.append(subsection_12_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-        assert list_b_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
+        assert subsection_12_charge.type_name == "Subsection 12"
+        assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert subsection_12_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
 
-    def test_list_b_163225(self):
+    def test_subsection_12_163225(self):
         self.single_charge["name"] = "Kidnapping in the second degree"
         self.single_charge["statute"] = "163.225"
         self.single_charge["level"] = "Felony Class B"
-        list_b_charge = self.create_recent_charge()
-        self.charges.append(list_b_charge)
+        subsection_12_charge = self.create_recent_charge()
+        self.charges.append(subsection_12_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-        assert list_b_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
+        assert subsection_12_charge.type_name == "Subsection 12"
+        assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert subsection_12_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
 
-    def test_list_b_163165(self):
+    def test_subsection_12_163165(self):
         self.single_charge["name"] = "Assault in the third degree"
         self.single_charge["statute"] = "163.165"
         self.single_charge["level"] = "Felony Class C"
-        list_b_charge = self.create_recent_charge()
-        self.charges.append(list_b_charge)
+        subsection_12_charge = self.create_recent_charge()
+        self.charges.append(subsection_12_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-        assert list_b_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
+        assert subsection_12_charge.type_name == "Subsection 12"
+        assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert subsection_12_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
 
-    def test_list_b_166220(self):
+    def test_subsection_12_166220(self):
         self.single_charge["name"] = "Unlawful use of weapon"
         self.single_charge["statute"] = "166.220"
         self.single_charge["level"] = "Felony Class C"
-        list_b_charge = self.create_recent_charge()
-        self.charges.append(list_b_charge)
+        subsection_12_charge = self.create_recent_charge()
+        self.charges.append(subsection_12_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-        assert list_b_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
+        assert subsection_12_charge.type_name == "Subsection 12"
+        assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert subsection_12_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
 
     # Test sub-chapters are not compared when not necessary.
 
-    def test_list_b_charge_that_includes_sub_chapter(self):
+    def test_subsection_12_charge_that_includes_sub_chapter(self):
         self.single_charge["name"] = "Unlawful use of weapon"
         self.single_charge["statute"] = "166.220(1)(b)"
         self.single_charge["level"] = "Felony Class C"
-        list_b_charge = self.create_recent_charge()
-        self.charges.append(list_b_charge)
+        subsection_12_charge = self.create_recent_charge()
+        self.charges.append(subsection_12_charge)
 
-        assert list_b_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-        assert list_b_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
+        assert subsection_12_charge.type_name == "Subsection 12"
+        assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+        assert subsection_12_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
 
     def test_marijuana_ineligible_statute_475b3592a(self):
         self.single_charge["name"] = "Arson incident to manufacture of cannabinoid extract in first degree"
@@ -333,6 +365,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         marijuana_felony_class_a = self.create_recent_charge()
         self.charges.append(marijuana_felony_class_a)
 
+        assert marijuana_felony_class_a.type_name == "Marijuana Ineligible"
         assert marijuana_felony_class_a.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
         assert marijuana_felony_class_a.expungement_result.type_eligibility.reason == "Ineligible under 137.226"
 
@@ -345,6 +378,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         pcs_charge = self.create_recent_charge()
         self.charges.append(pcs_charge)
 
+        assert pcs_charge.type_name == "Schedule 1 PCS"
         assert pcs_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
         assert pcs_charge.expungement_result.type_eligibility.reason == "Eligible under 137.225(5)(C)"
 
@@ -355,6 +389,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         pcs_charge = self.create_recent_charge()
         self.charges.append(pcs_charge)
 
+        assert pcs_charge.type_name == "Schedule 1 PCS"
         assert pcs_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
         assert pcs_charge.expungement_result.type_eligibility.reason == "Eligible under 137.225(5)(C)"
 
@@ -365,6 +400,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         pcs_charge = self.create_recent_charge()
         self.charges.append(pcs_charge)
 
+        assert pcs_charge.type_name == "Schedule 1 PCS"
         assert pcs_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
         assert pcs_charge.expungement_result.type_eligibility.reason == "Eligible under 137.225(5)(C)"
 
@@ -375,6 +411,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         pcs_charge = self.create_recent_charge()
         self.charges.append(pcs_charge)
 
+        assert pcs_charge.type_name == "Schedule 1 PCS"
         assert pcs_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
         assert pcs_charge.expungement_result.type_eligibility.reason == "Eligible under 137.225(5)(C)"
 
@@ -385,6 +422,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         pcs_charge = self.create_recent_charge()
         self.charges.append(pcs_charge)
 
+        assert pcs_charge.type_name == "Schedule 1 PCS"
         assert pcs_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
         assert pcs_charge.expungement_result.type_eligibility.reason == "Eligible under 137.225(5)(C)"
 
@@ -397,6 +435,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         charge = self.create_recent_charge()
         self.charges.append(charge)
 
+        assert charge.type_name == "Misdemeanor"
         assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
         assert charge.expungement_result.type_eligibility.reason == "Eligible under 137.225(5)(b)"
 
@@ -407,6 +446,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         charge = self.create_recent_charge()
         self.charges.append(charge)
 
+        assert charge.type_name == "Felony Class C"
         assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
         assert charge.expungement_result.type_eligibility.reason == "Eligible under 137.225(5)(b)"
 
@@ -417,6 +457,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         charge = self.create_recent_charge()
         self.charges.append(charge)
 
+        assert charge.type_name == "Misdemeanor"
         assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
         assert charge.expungement_result.type_eligibility.reason == "Eligible under 137.225(5)(b)"
 
@@ -427,6 +468,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         charge = self.create_recent_charge()
         self.charges.append(charge)
 
+        assert charge.type_name == "Misdemeanor"
         assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
         assert charge.expungement_result.type_eligibility.reason == "Eligible under 137.225(5)(b)"
 
@@ -437,6 +479,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         charge = self.create_recent_charge()
         self.charges.append(charge)
 
+        assert charge.type_name == "Felony Class B"
         assert charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
         assert charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
 
@@ -455,6 +498,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         charge = self.create_recent_charge()
         self.charges.append(charge)
 
+        assert charge.type_name == "Unclassified"
         assert charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
         assert charge.expungement_result.type_eligibility.reason == "Unrecognized Charge : Further Analysis Needed"
 
@@ -467,6 +511,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         charge = self.create_recent_charge()
         self.charges.append(charge)
 
+        assert charge.type_name == "Non-traffic Violation"
         assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
         assert charge.expungement_result.type_eligibility.reason == "Eligible under 137.225(5)(d)"
 

--- a/src/frontend/src/components/Charge/index.tsx
+++ b/src/frontend/src/components/Charge/index.tsx
@@ -15,6 +15,7 @@ export default class Charge extends React.Component<Props> {
       disposition,
       statute,
       name,
+      type_name,
       expungement_result
     } = this.props.charge;
 
@@ -60,6 +61,7 @@ export default class Charge extends React.Component<Props> {
             {recordTimeRender()}
             <RecordType
               type_eligibility={expungement_result.type_eligibility}
+              type_name={type_name}
             />
           </div>
           <div className="w-100 w-70-l pr3">

--- a/src/frontend/src/components/Eligibility/index.tsx
+++ b/src/frontend/src/components/Eligibility/index.tsx
@@ -26,7 +26,7 @@ export default class Eligibility extends React.Component<Props> {
 
     const eligibleWithReview = (date: string) => (
       <h2 className="fw6 purple bg-washed-purple pv2 ph3 ma2 mb3 dib br3">
-        Eligible {date} (review)
+        Possibly Eligible {date} (review)
       </h2>
     );
 

--- a/src/frontend/src/components/RecordType/index.tsx
+++ b/src/frontend/src/components/RecordType/index.tsx
@@ -3,6 +3,7 @@ import { TypeEligibility } from '../SearchResults/types';
 
 interface Props {
   type_eligibility: TypeEligibility;
+  type_name: string;
 }
 
 export default class RecordType extends React.Component<Props> {
@@ -16,7 +17,7 @@ export default class RecordType extends React.Component<Props> {
           className="absolute fas fa-check-circle green"
         ></i>
         <div className="ml3 pl1">
-          <span className="fw7">Type:</span> Eligible{' '}
+          <span className="fw7">Type:</span> {this.props.type_name + ' '}
           <span className="nowrap">({reason})</span>
         </div>
       </div>
@@ -29,7 +30,7 @@ export default class RecordType extends React.Component<Props> {
           className="absolute fas fa-question-circle purple"
         ></i>
         <div className="ml3 pl1">
-          <span className="fw7">Type:</span> List B
+          <span className="fw7">Type:</span> {this.props.type_name + ' '}
         </div>
       </div>
     );
@@ -38,7 +39,7 @@ export default class RecordType extends React.Component<Props> {
       <div className="relative mb3">
         <i aria-hidden="true" className="absolute fas fa-times-circle red"></i>
         <div className="ml3 pl1">
-          <span className="fw7">Type:</span> Ineligible{' '}
+          <span className="fw7">Type:</span> {this.props.type_name + ' '}
           <span className="nowrap">({reason})</span>
         </div>
       </div>

--- a/src/frontend/src/components/SearchResults/types.ts
+++ b/src/frontend/src/components/SearchResults/types.ts
@@ -2,6 +2,7 @@ export interface ChargeType {
   statute: string;
   expungement_result: any;
   name: string;
+  type_name: string;
   date: string;
   disposition?: {
     ruling: string;


### PR DESCRIPTION
The backend Charge dataclass and its subclasses have the new field of `type_name`.

I also renamed the `ListB` charge type to `Subsection12`, because that's the actual source of its list of statutes.