### PR TITLE
Show ruling string when disposition is unrecognized

### DIFF
--- a/src/backend/expungeservice/expunger/analyzers/time_analyzer.py
+++ b/src/backend/expungeservice/expunger/analyzers/time_analyzer.py
@@ -34,7 +34,7 @@ class TimeAnalyzer:
                 charge
                 for charge in charges_with_summary.charges
                 if charge
-                not in charges_with_summary.unknowns
+                not in charges_with_summary.unrecognized
                 + charges_with_summary.old_convictions
                 + charges_with_summary.acquittals
             ]
@@ -114,7 +114,7 @@ class TimeAnalyzer:
         for class_b_felony in charges_with_summary.class_b_felonies:
             # If the class B felony is acquitted, then we have already handled its time eligibility.
             # If it's convicted, it is subject to these additional rules.
-            # If its disposition is unknown, we don't apply any time analysis.
+            # If its disposition is unrecognized, we don't apply any time analysis.
             if class_b_felony.convicted():
                 if TimeAnalyzer._calculate_has_subsequent_charge(class_b_felony, charges_with_summary.charges):
                     class_b_felony.set_time_ineligible(

--- a/src/backend/expungeservice/expunger/charges_summarizer.py
+++ b/src/backend/expungeservice/expunger/charges_summarizer.py
@@ -19,7 +19,7 @@ class ChargesWithSummary:
     charges: List[Charge]
     acquittals: List[Charge] = field(default_factory=list)
     convictions: List[Charge] = field(default_factory=list)
-    unknowns: List[Charge] = field(default_factory=list)
+    unrecognized: List[Charge] = field(default_factory=list)
     old_convictions: List[Charge] = field(default_factory=list)
     most_recent_dismissal: Optional[Charge] = None
     most_recent_conviction: Optional[Charge] = None
@@ -31,7 +31,7 @@ class ChargesWithSummary:
 class ChargesSummarizer:
     @staticmethod
     def summarize(charges: List[Charge]) -> ChargesWithSummary:
-        acquittals, convictions, unknowns = ChargesSummarizer._categorize_charges(charges)
+        acquittals, convictions, unrecognized = ChargesSummarizer._categorize_charges(charges)
         recent_convictions, old_convictions = ChargesSummarizer._categorize_convictions_by_recency(convictions)
         most_recent_dismissal = ChargesSummarizer._most_recent_dismissal(acquittals)
         most_recent_conviction, second_most_recent_conviction = ChargesSummarizer._most_recent_convictions(
@@ -43,7 +43,7 @@ class ChargesSummarizer:
             charges,
             acquittals,
             convictions,
-            unknowns,
+            unrecognized,
             old_convictions,
             most_recent_dismissal,
             most_recent_conviction,
@@ -54,15 +54,15 @@ class ChargesSummarizer:
 
     @staticmethod
     def _categorize_charges(charges):
-        acquittals, convictions, unknowns = [], [], []
+        acquittals, convictions, unrecognized = [], [], []
         for charge in charges:
             if charge.acquitted():
                 acquittals.append(charge)
             elif charge.convicted():
                 convictions.append(charge)
             else:
-                unknowns.append(charge)
-        return acquittals, convictions, unknowns
+                unrecognized.append(charge)
+        return acquittals, convictions, unrecognized
 
     @staticmethod
     def _categorize_convictions_by_recency(convictions):

--- a/src/backend/expungeservice/expunger/expunger.py
+++ b/src/backend/expungeservice/expunger/expunger.py
@@ -45,27 +45,29 @@ class Expunger:
     @staticmethod
     def _build_disposition_errors(charges: List[Charge]):
         record_errors = []
-        cases_with_missing_disposition, cases_with_unknown_disposition = Expunger._filter_cases_with_errors(charges)
+        cases_with_missing_disposition, cases_with_unrecognized_disposition = Expunger._filter_cases_with_errors(
+            charges
+        )
         if cases_with_missing_disposition:
             record_errors.append(Expunger._build_disposition_error_message(cases_with_missing_disposition, "a missing"))
-        if cases_with_unknown_disposition:
+        if cases_with_unrecognized_disposition:
             record_errors.append(
-                Expunger._build_disposition_error_message(cases_with_unknown_disposition, "an unrecognized")
+                Expunger._build_disposition_error_message(cases_with_unrecognized_disposition, "an unrecognized")
             )
         return record_errors
 
     @staticmethod
     def _filter_cases_with_errors(charges: List[Charge]):
         cases_with_missing_disposition: Set[str] = set()
-        cases_with_unknown_disposition: Set[str] = set()
+        cases_with_unrecognized_disposition: Set[str] = set()
         for charge in charges:
             if not charge.skip_analysis():
                 case_number = charge.case()().case_number
                 if not charge.disposition:
                     cases_with_missing_disposition.add(case_number)
-                elif charge.disposition.status == DispositionStatus.UNKNOWN:
-                    cases_with_unknown_disposition.add(f"{case_number}: {charge.disposition.ruling}")
-        return cases_with_missing_disposition, cases_with_unknown_disposition
+                elif charge.disposition.status == DispositionStatus.UNRECOGNIZED:
+                    cases_with_unrecognized_disposition.add(f"{case_number}: {charge.disposition.ruling}")
+        return cases_with_missing_disposition, cases_with_unrecognized_disposition
 
     @staticmethod
     def _build_disposition_error_message(error_cases: Set[str], disposition_error_name: str):

--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -37,7 +37,7 @@ class Charge:
             return TypeEligibility(
                 EligibilityStatus.NEEDS_MORE_ANALYSIS, reason="Disposition not found. Needs further analysis"
             )
-        elif self.disposition.status == DispositionStatus.UNKNOWN:
+        elif self.disposition.status == DispositionStatus.UNRECOGNIZED:
             return TypeEligibility(
                 EligibilityStatus.NEEDS_MORE_ANALYSIS, reason="Disposition not recognized. Needs further analysis"
             )

--- a/src/backend/expungeservice/models/charge_types/duii.py
+++ b/src/backend/expungeservice/models/charge_types/duii.py
@@ -20,7 +20,7 @@ class Duii(Charge):
             reason="Further Analysis Needed - Dismissed charge may have been Diverted",
         )
 
-        unknown_type_eligibility = TypeEligibility(
+        unrecognized_type_eligibility = TypeEligibility(
             EligibilityStatus.NEEDS_MORE_ANALYSIS, reason="Further Analysis Needed - Unrecognized ruling"
         )
 
@@ -37,9 +37,9 @@ class Duii(Charge):
             DispositionStatus.DISMISSED: dismissed_type_eligibility,
             DispositionStatus.NO_COMPLAINT: dismissed_type_eligibility,
             DispositionStatus.DIVERTED: diverted_type_eligibility,
-            DispositionStatus.UNKNOWN: unknown_type_eligibility,
+            DispositionStatus.UNRECOGNIZED: unrecognized_type_eligibility,
         }
         # This that if someone adds something to DispositionStatus,
-        # it won't automatically go to the Unknown case.
+        # it won't automatically go to the Unrecognized case.
         assert len(cases) == len(DispositionStatus)
-        return cases.get(self.disposition.status, unknown_type_eligibility)  # type: ignore
+        return cases.get(self.disposition.status, unrecognized_type_eligibility)  # type: ignore

--- a/src/backend/expungeservice/models/disposition.py
+++ b/src/backend/expungeservice/models/disposition.py
@@ -9,7 +9,7 @@ class DispositionStatus(str, Enum):
     DISMISSED = "Dismissed"
     NO_COMPLAINT = "No Complaint"
     DIVERTED = "Diverted"
-    UNKNOWN = "Unknown"
+    UNRECOGNIZED = "Unrecognized"
 
 
 @dataclass(eq=False)
@@ -47,4 +47,4 @@ class Disposition:
             return DispositionStatus.NO_COMPLAINT
 
         else:
-            return DispositionStatus.UNKNOWN
+            return DispositionStatus.UNRECOGNIZED

--- a/src/backend/tests/models/test_disposition_status.py
+++ b/src/backend/tests/models/test_disposition_status.py
@@ -22,7 +22,7 @@ def test_disposition_status_values():
 
     assert Disposition(today, "No complaint").status == DispositionStatus.NO_COMPLAINT
 
-    assert Disposition(today, "What is this?").status == DispositionStatus.UNKNOWN
+    assert Disposition(today, "What is this?").status == DispositionStatus.UNRECOGNIZED
 
 
 def test_all_disposition_statuses_are_either_convicted_or_acquitted():
@@ -35,7 +35,7 @@ def test_all_disposition_statuses_are_either_convicted_or_acquitted():
         # which happens to always be a valid string for that dispo status.
         charge.disposition = Disposition(today, status.value)
 
-        if status == DispositionStatus.UNKNOWN:
+        if status == DispositionStatus.UNRECOGNIZED:
             assert not charge.convicted()
             assert not charge.acquitted()
 
@@ -53,7 +53,7 @@ def test_dispositionless_charge_is_not_convicted_nor_acquitted():
     assert charge.expungement_result.type_eligibility.reason == "Disposition not found. Needs further analysis"
 
 
-def test_charge_with_unknown_disposition_eligibility():
+def test_charge_with_unrecognized_disposition_eligibility():
     charge = ChargeFactory.create(disposition=["What am I", date(2001, 1, 1)])
     assert not charge.convicted()
     assert not charge.acquitted()

--- a/src/frontend/src/components/Charge/index.tsx
+++ b/src/frontend/src/components/Charge/index.tsx
@@ -21,8 +21,12 @@ export default class Charge extends React.Component<Props> {
 
 
     const knownDisposition = (disposition: any, date: any) => {
-      let dispositionDateInfo = (disposition.status == "Convicted" ? " - " + disposition.date : "");
-      let dispositionEvent = disposition.status + dispositionDateInfo;
+      let dispositionEvent = disposition.status;
+      if (disposition.status === "Convicted") {
+        dispositionEvent += " - " + disposition.date;
+      } else if (disposition.status === "Unrecognized") {
+        dispositionEvent += " (\"" + disposition.ruling + "\")";
+      }
       return <>
         <li className="mb2">
           <span className="fw7">Disposition:</span> {dispositionEvent}


### PR DESCRIPTION
closes #694. 

Here's a screenshot example:
![unrecognized_ruling](https://user-images.githubusercontent.com/2104990/72095464-5b51e680-32cd-11ea-902b-6856ccf3eaec.png)

Depends on PR #709.