### PR TITLE
Minor wording and format changes to rendered results

### DIFF
--- a/src/frontend/src/components/Charge/index.tsx
+++ b/src/frontend/src/components/Charge/index.tsx
@@ -41,7 +41,7 @@ export default class Charge extends React.Component<Props> {
       if (disposition === null) {
         return (
           <li className="mb2">
-            <span className="fw7">Disposition: </span> Unknown
+            <span className="fw7">Disposition: </span> Missing
           </li>
         );
       } else {
@@ -61,14 +61,14 @@ export default class Charge extends React.Component<Props> {
       <div className="br3 ma2 bg-white">
         <Eligibility expungement_result={expungement_result} />
         <div className="flex-l ph3 pb3">
-          <div className="w-100 w-30-l pr3">
+          <div className="w-100 w-40-l pr3">
             {recordTimeRender()}
             <RecordType
               type_eligibility={expungement_result.type_eligibility}
               type_name={type_name}
             />
           </div>
-          <div className="w-100 w-70-l pr3">
+          <div className="w-100 w-60-l pr3">
             <ul className="list">
               <li className="mb2">
                 <span className="fw7">Charge: </span>

--- a/src/frontend/src/components/RecordType/index.tsx
+++ b/src/frontend/src/components/RecordType/index.tsx
@@ -18,7 +18,7 @@ export default class RecordType extends React.Component<Props> {
         ></i>
         <div className="ml3 pl1">
           <span className="fw7">Type:</span> {this.props.type_name + ' '}
-          <span className="nowrap">({reason})</span>
+          <div>({reason})</div>
         </div>
       </div>
     );
@@ -31,6 +31,8 @@ export default class RecordType extends React.Component<Props> {
         ></i>
         <div className="ml3 pl1">
           <span className="fw7">Type:</span> {this.props.type_name + ' '}
+          <div>({reason})</div>
+
         </div>
       </div>
     );
@@ -40,7 +42,7 @@ export default class RecordType extends React.Component<Props> {
         <i aria-hidden="true" className="absolute fas fa-times-circle red"></i>
         <div className="ml3 pl1">
           <span className="fw7">Type:</span> {this.props.type_name + ' '}
-          <span className="nowrap">({reason})</span>
+          <div>({reason})</div>
         </div>
       </div>
     );


### PR DESCRIPTION
 * if the disposition is missing, it's shown as Missing, not Unknown
 * the 'reason' string wraps around to not overlap other text
 * adjusted the Charge detail column widths to 40/60%, not 30/70%, to make more room for our lengthier (and more informative) reason strings

 The text wrap fixes the following example:
![b_felony_correctly_ineligible_if_expressed_with_type_eligibility](https://user-images.githubusercontent.com/2104990/72107259-d32c0b00-32e5-11ea-9857-2d68f5765144.png)


And here's the effect of the width change. I tried 50/50 but that added way too much awkward whitespace. 

old:

![narrow](https://user-images.githubusercontent.com/2104990/72107597-8268e200-32e6-11ea-8c09-b4960b66950e.png)

vs new:

![extra_space_for_reason_string](https://user-images.githubusercontent.com/2104990/72107381-0a9ab780-32e6-11ea-9bc7-e2b86d4851b4.png)

I'm tagging @hmarcks since it includes a design change.
