### PR TITLE
show charge as 'ineligible' if it's time ineligible and has no eligibility date

### DIFF
--- a/src/backend/expungeservice/expunger/analyzers/time_analyzer.py
+++ b/src/backend/expungeservice/expunger/analyzers/time_analyzer.py
@@ -118,7 +118,8 @@ class TimeAnalyzer:
             if class_b_felony.convicted():
                 if TimeAnalyzer._calculate_has_subsequent_charge(class_b_felony, charges_with_summary.charges):
                     class_b_felony.set_time_ineligible(
-                        "137.225(5)(a)(A)(ii) - Class B felony can have no subsequent arrests or convictions", None
+                        "Never. Class B felony can have no subsequent arrests or convictions (137.225(5)(a)(A)(ii))",
+                        None,
                     )
                 else:
                     eligibility_date = class_b_felony.disposition.date + relativedelta(years=+TimeAnalyzer.TWENTY_YEARS)  # type: ignore

--- a/src/backend/tests/expunger/test_time_analyzer.py
+++ b/src/backend/tests/expunger/test_time_analyzer.py
@@ -291,7 +291,7 @@ def test_felony_class_b_with_subsequent_conviction():
     assert b_felony_charge.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
     assert (
         b_felony_charge.expungement_result.time_eligibility.reason
-        == "137.225(5)(a)(A)(ii) - Class B felony can have no subsequent arrests or convictions"
+        == "Never. Class B felony can have no subsequent arrests or convictions (137.225(5)(a)(A)(ii))"
     )
     assert b_felony_charge.expungement_result.time_eligibility.date_will_be_eligible == None
 

--- a/src/frontend/src/components/Eligibility/index.tsx
+++ b/src/frontend/src/components/Eligibility/index.tsx
@@ -51,6 +51,12 @@ export default class Eligibility extends React.Component<Props> {
     };
 
     const eligibility = () => {
+
+      // Time ineligibility without a date (meaning "never eligible") beats all other rules for eligibility
+      if (time_eligibility && time_eligibility.status === 'Ineligible' && time_eligibility.date_will_be_eligible == null) {
+        return ineligible;
+      }
+
       switch (type_eligibility.status) {
         case 'Eligible':
           return handleWhenTypeEligibile();

--- a/src/frontend/src/components/Eligibility/index.tsx
+++ b/src/frontend/src/components/Eligibility/index.tsx
@@ -53,6 +53,7 @@ export default class Eligibility extends React.Component<Props> {
     const eligibility = () => {
 
       // Time ineligibility without a date (meaning "never eligible") beats all other rules for eligibility
+      // Currently this only occurs on Class B felonies, but the rule theoretically applies always, so it is checked first.
       if (time_eligibility && time_eligibility.status === 'Ineligible' && time_eligibility.date_will_be_eligible == null) {
         return ineligible;
       }


### PR DESCRIPTION
In theory, any charge that is time-ineligible and has no date should be interpreted as "never eligible". In practice, this only ever happens in one case which is a Class B Felony that has subsequent convictions on the record. 

So this might seem a bit hacky to handle this single case in the frontend. But at least B felonies look nice now:

![fixed_b_felony](https://user-images.githubusercontent.com/2104990/72115575-6708d180-32fc-11ea-8c92-0433660d8305.png)

The top-level eligibility label on a charge is just an interpretation of the type and time eligibility. It could be generated in the backend, which also eliminates the need for the frontend to handle "unexpected data from backend" issues.

Closes #702 