### PR TITLE
new charge_eligibility value computed from type and time eligibility

### DIFF
--- a/src/backend/expungeservice/models/expungement_result.py
+++ b/src/backend/expungeservice/models/expungement_result.py
@@ -10,6 +10,15 @@ class EligibilityStatus(str, Enum):
     INELIGIBLE = "Ineligible"
 
 
+class ChargeEligibilityStatus(str, Enum):
+    UNKNOWN = "Unknown"
+    ELIGIBLE_NOW = "Eligible now"
+    POSSIBLY_ELIGIBILE = "Possibly eligible"
+    WILL_BE_ELIGIBLE = "Will be eligible"
+    POSSIBLY_WILL_BE_ELIGIBLE = "Possibly will be eligible"
+    INELIGIBLE = "Ineligible"
+
+
 @dataclass
 class TypeEligibility:
     status: EligibilityStatus
@@ -24,9 +33,60 @@ class TimeEligibility:
 
 
 @dataclass
+class ChargeEligibility:
+    status: ChargeEligibilityStatus
+    label: str
+    date_will_be_eligible: Optional[date]
+
+
+@dataclass
 class ExpungementResult:
     type_eligibility: TypeEligibility
     time_eligibility: Optional[TimeEligibility]
 
     def set_type_eligibility(self, type_eligibility):
         self.type_eligibility = type_eligibility
+
+    @property
+    def charge_eligibility(self):
+        if self.type_eligibility.status == EligibilityStatus.ELIGIBLE:
+            if self.time_eligibility and self.time_eligibility.status == EligibilityStatus.ELIGIBLE:
+                return ChargeEligibility(ChargeEligibilityStatus.ELIGIBLE_NOW, "Eligible", None)
+
+            elif self.time_eligibility and self.time_eligibility.status == EligibilityStatus.INELIGIBLE:
+                if self.time_eligibility.date_will_be_eligible:
+                    return ChargeEligibility(
+                        ChargeEligibilityStatus.WILL_BE_ELIGIBLE,
+                        f"Eligible {self.time_eligibility.date_will_be_eligible.strftime('%b %-d, %Y')}",
+                        self.time_eligibility.date_will_be_eligible,
+                    )
+                else:
+                    # Currently, no charge types that are type-eligible can be disqualified due to a time-ineligibility date of None, meaning "never"
+                    # So this else block has no applicable cases and never runs. But it will apply if a new charge type that qualifies gets added.
+                    return ChargeEligibility(ChargeEligibilityStatus.INELIGIBLE, "Ineligible", None)
+            else:
+                return ChargeEligibility(
+                    ChargeEligibilityStatus.UNKNOWN, "Type-eligible but time analysis is missing", None
+                )
+
+        elif self.type_eligibility.status == EligibilityStatus.NEEDS_MORE_ANALYSIS:
+            if self.time_eligibility and self.time_eligibility.status == EligibilityStatus.ELIGIBLE:
+                return ChargeEligibility(ChargeEligibilityStatus.POSSIBLY_ELIGIBILE, "Possibly Eligible (review)", None)
+
+            elif self.time_eligibility and self.time_eligibility.status == EligibilityStatus.INELIGIBLE:
+                if self.time_eligibility.date_will_be_eligible:
+                    return ChargeEligibility(
+                        ChargeEligibilityStatus.POSSIBLY_WILL_BE_ELIGIBLE,
+                        f"Possibly Eligible {self.time_eligibility.date_will_be_eligible.strftime('%b %-d, %Y')} (review)",
+                        self.time_eligibility.date_will_be_eligible,
+                    )
+                else:
+                    # Currently, this occurs with Class B Felonies only, which can be time ineligible with a date of None, meaning "never"
+                    return ChargeEligibility(ChargeEligibilityStatus.INELIGIBLE, "Ineligible", None)
+            else:
+                return ChargeEligibility(
+                    ChargeEligibilityStatus.UNKNOWN, "Possibly eligible but time analysis is missing", None
+                )
+
+        elif self.type_eligibility.status == EligibilityStatus.INELIGIBLE:
+            return ChargeEligibility(ChargeEligibilityStatus.INELIGIBLE, "Ineligible", None)

--- a/src/backend/expungeservice/serializer/serializer.py
+++ b/src/backend/expungeservice/serializer/serializer.py
@@ -39,11 +39,18 @@ class ExpungeModelEncoder(flask.json.JSONEncoder):
             "type_name": charge.type_name,
             "date": charge.date,
             "disposition": disposition,
-            "expungement_result": dataclasses.asdict(charge.expungement_result),
+            "expungement_result": self.expungement_result_to_json(charge.expungement_result),
         }
 
     def disposition_to_json(self, disposition):
         return {"date": disposition.date, "ruling": disposition.ruling, "status": disposition.status}
+
+    def expungement_result_to_json(self, expungement_result):
+        return {
+            "type_eligibility": expungement_result.type_eligibility,
+            "time_eligibility": expungement_result.time_eligibility,
+            "charge_eligibility": expungement_result.charge_eligibility,
+        }
 
     def default(self, o):
         if isinstance(o, expungeservice.models.record.Record):

--- a/src/backend/tests/models/test_expungement_result.py
+++ b/src/backend/tests/models/test_expungement_result.py
@@ -1,0 +1,86 @@
+from expungeservice.models.expungement_result import *
+
+
+def test_eligible():
+    type_eligibility = TypeEligibility(EligibilityStatus.ELIGIBLE, "Eligible under some statute")
+    time_eligibility = TimeEligibility(EligibilityStatus.ELIGIBLE, "Eligible under some statute", None)
+    expungement_result = ExpungementResult(type_eligibility, time_eligibility)
+
+    assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.ELIGIBLE_NOW
+    assert expungement_result.charge_eligibility.label == "Eligible"
+    assert expungement_result.charge_eligibility.date_will_be_eligible is None
+
+
+def test_will_be_eligible():
+    today = date.today()
+    type_eligibility = TypeEligibility(EligibilityStatus.ELIGIBLE, "Eligible under some statute")
+    time_eligibility = TimeEligibility(EligibilityStatus.INELIGIBLE, "Ineligible under some statute", today)
+    expungement_result = ExpungementResult(type_eligibility, time_eligibility)
+
+    assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.WILL_BE_ELIGIBLE
+    assert expungement_result.charge_eligibility.label == f"Eligible {today.strftime('%b %-d, %Y')}"
+    assert expungement_result.charge_eligibility.date_will_be_eligible == today
+
+
+def test_possibly_eligible():
+    today = date.today()
+    type_eligibility = TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, "Unrecognized charge")
+    time_eligibility = TimeEligibility(EligibilityStatus.ELIGIBLE, "Eligible under some statute", None)
+    expungement_result = ExpungementResult(type_eligibility, time_eligibility)
+
+    assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.POSSIBLY_ELIGIBILE
+    assert expungement_result.charge_eligibility.label == "Possibly Eligible (review)"
+    assert expungement_result.charge_eligibility.date_will_be_eligible is None
+
+
+def test_possibly_will_be_eligible():
+    today = date.today()
+    type_eligibility = TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, "Unrecognized charge")
+    time_eligibility = TimeEligibility(EligibilityStatus.INELIGIBLE, "Ineligible under some statute", today)
+    expungement_result = ExpungementResult(type_eligibility, time_eligibility)
+
+    assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.POSSIBLY_WILL_BE_ELIGIBLE
+    assert expungement_result.charge_eligibility.label == f"Possibly Eligible {today.strftime('%b %-d, %Y')} (review)"
+    assert expungement_result.charge_eligibility.date_will_be_eligible == today
+
+
+def test_ineligible():
+    type_eligibility = TypeEligibility(EligibilityStatus.INELIGIBLE, "Ineligible under some statute")
+    expungement_result = ExpungementResult(type_eligibility, None)
+
+    assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.INELIGIBLE
+    assert expungement_result.charge_eligibility.label == "Ineligible"
+
+
+def test_type_eligible_never_becomes_eligible():
+    type_eligibility = TypeEligibility(EligibilityStatus.ELIGIBLE, "Eligible under some statute")
+    time_eligibility = TimeEligibility(EligibilityStatus.INELIGIBLE, "Never eligible under some statute", None)
+    expungement_result = ExpungementResult(type_eligibility, time_eligibility)
+
+    assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.INELIGIBLE
+    assert expungement_result.charge_eligibility.label == "Ineligible"
+
+
+def test_type_possibly_eligible_never_becomes_eligible():
+    type_eligibility = TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, "Unrecognized charge")
+    time_eligibility = TimeEligibility(EligibilityStatus.INELIGIBLE, "Never eligible under some statute", None)
+    expungement_result = ExpungementResult(type_eligibility, time_eligibility)
+
+    assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.INELIGIBLE
+    assert expungement_result.charge_eligibility.label == "Ineligible"
+
+
+def test_type_eligible_but_time_eligibility_missing():
+    type_eligibility = TypeEligibility(EligibilityStatus.ELIGIBLE, "Eligible under some statute")
+    expungement_result = ExpungementResult(type_eligibility, None)
+
+    assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.UNKNOWN
+    assert expungement_result.charge_eligibility.label == "Type-eligible but time analysis is missing"
+
+
+def test_possibly_type_eligible_but_time_eligibility_missing():
+    type_eligibility = TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, "Unrecognized charge")
+    expungement_result = ExpungementResult(type_eligibility, None)
+
+    assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.UNKNOWN
+    assert expungement_result.charge_eligibility.label == "Possibly eligible but time analysis is missing"

--- a/src/frontend/src/components/Eligibility/index.tsx
+++ b/src/frontend/src/components/Eligibility/index.tsx
@@ -6,72 +6,33 @@ interface Props {
 }
 
 export default class Eligibility extends React.Component<Props> {
+
   render() {
     const {
-      type_eligibility,
-      time_eligibility
+      charge_eligibility
     } = this.props.expungement_result;
 
-    const eligibleNow = (
-      <h2 className="fw6 green bg-washed-green pv2 ph3 ma2 mb3 dib br3">
-        Eligible now
-      </h2>
-    );
-
-    const eligibleOn = (date: string) => (
-      <h2 className="fw6 dark-blue bg-washed-blue pv2 ph3 ma2 mb3 dib br3">
-        Eligible {date}
-      </h2>
-    );
-
-    const eligibleWithReview = (date: string) => (
-      <h2 className="fw6 purple bg-washed-purple pv2 ph3 ma2 mb3 dib br3">
-        Possibly Eligible {date} (review)
-      </h2>
-    );
-
-    const ineligible = (
-      <h2 className="fw6 red bg-washed-red pv2 ph3 ma2 mb3 dib br3">
-        Ineligible
-      </h2>
-    );
-
-    const handleWhenTypeEligibile = () => {
-      if (time_eligibility) {
-        if (time_eligibility.status === 'Eligible') {
-          return eligibleNow;
-        } else if (time_eligibility.date_will_be_eligible !== null) {
-          return eligibleOn(time_eligibility.date_will_be_eligible);
-        } else {
-          return  <h2 className="fw6 purple bg-washed-purple pv2 ph3 ma2 mb3 dib br3">Eligible but no date on time analysis - please report</h2>;
-        }
-      } else {
-        return <h2 className="fw6 purple bg-washed-purple pv2 ph3 ma2 mb3 dib br3">Eligible but no time analysis - please report</h2>;
-      }
-    };
+  const label_color = (charge_eligibility_status: string) => {
+    switch (charge_eligibility_status) {
+      case "Unknown":
+        return "purple bg-washed-purple";
+      case "Eligible now":
+        return "green bg-washed-green";
+      case "Possibly eligible":
+        return "purple bg-washed-purple"
+      case "Will be eligible":
+        return "dark-blue bg-washed-blue"
+      case "Possibly will be eligible":
+        return "purple bg-washed-purple"
+      case "Ineligible":
+        return "red bg-washed-red"
+    }
+  };
 
     const eligibility = () => {
-
-      // Time ineligibility without a date (meaning "never eligible") beats all other rules for eligibility
-      // Currently this only occurs on Class B felonies, but the rule theoretically applies always, so it is checked first.
-      if (time_eligibility && time_eligibility.status === 'Ineligible' && time_eligibility.date_will_be_eligible == null) {
-        return ineligible;
-      }
-
-      switch (type_eligibility.status) {
-        case 'Eligible':
-          return handleWhenTypeEligibile();
-        case 'Needs more analysis':
-          if (time_eligibility) {
-            return eligibleWithReview(time_eligibility.date_will_be_eligible);
-          } else {
-            return <h2 className="fw6 purple bg-washed-purple pv2 ph3 ma2 mb3 dib br3">Possibly eligible but no time analysis - please report</h2>;
-          }
-        case 'Ineligible':
-          return ineligible;
-        default:
-          return <h2 className="fw6 purple bg-washed-purple pv2 ph3 ma2 mb3 dib br3">Unknown type eligibility - please report</h2>;
-      }
+      return <h2 className= {label_color(charge_eligibility.status) + ' fw6 pv2 ph3 ma2 mb3 dib br3' }>
+        {charge_eligibility.label}
+      </h2>;
     };
 
     return eligibility();

--- a/src/frontend/src/components/SearchResults/types.ts
+++ b/src/frontend/src/components/SearchResults/types.ts
@@ -33,6 +33,7 @@ export interface Record {
 export interface ExpungementResultType {
   type_eligibility: TypeEligibility;
   time_eligibility?: TimeEligibility;
+  charge_eligibility: ChargeEligibility;
 }
 
 export interface TypeEligibility {
@@ -44,4 +45,9 @@ export interface TimeEligibility {
   status: string;
   reason: string;
   date_will_be_eligible: string;
+}
+
+export interface ChargeEligibility {
+  status: string;
+  label: string;
 }


### PR DESCRIPTION
ExpungementResult now computes a stateless Charge Eligibility value based on the charge's type and time eligibility.   

This replaces and simplifies the corresponding frontend logic for visualizing eligibility results. It will also make it easier to generate a record Summary component (#630, #631).

Closes #717 
