### PR TITLE
Include results summary in search endpoint

### DIFF
--- a/src/backend/expungeservice/endpoints/search.py
+++ b/src/backend/expungeservice/endpoints/search.py
@@ -10,6 +10,7 @@ from expungeservice.expunger.expunger import Expunger
 from expungeservice.serializer import ExpungeModelEncoder
 from expungeservice.crypto import DataCipher
 from expungeservice.stats import save_result
+from expungeservice.models.helpers.record_summarizer import RecordSummarizer
 
 
 class Search(MethodView):
@@ -53,7 +54,8 @@ class Search(MethodView):
         except Exception as ex:
             logging.error("Saving search result failed with exception: %s" % ex, stack_info=True)
 
-        response_data = {"data": {"record": record}}
+        summary = RecordSummarizer.summarize(record)
+        response_data = {"data": {"record": record, "summary": summary}}
 
         current_app.json_encoder = ExpungeModelEncoder
 

--- a/src/backend/expungeservice/models/helpers/record_summarizer.py
+++ b/src/backend/expungeservice/models/helpers/record_summarizer.py
@@ -48,6 +48,8 @@ class RecordSummarizer:
             "partially_eligible": partially_eligible_cases,
             "other": other_cases,
         }
+        for county in county_balances.keys():
+            county_balances[county] = round(county_balances[county], 2)
         total_charges = len(record.charges)
         eligible_charges = [
             c.name

--- a/src/backend/expungeservice/models/helpers/record_summarizer.py
+++ b/src/backend/expungeservice/models/helpers/record_summarizer.py
@@ -1,0 +1,62 @@
+from expungeservice.models.expungement_result import ChargeEligibilityStatus
+from expungeservice.models.record_summary import RecordSummary
+
+
+class RecordSummarizer:
+    @staticmethod
+    def summarize(record):
+
+        fully_eligible_cases = []
+        fully_ineligible_cases = []
+        partially_eligible_cases = []
+        other_cases = []
+
+        county_balances = {}
+        for case in record.cases:
+            if not case.location in county_balances.keys():
+                county_balances[case.location] = case.get_balance_due()
+            else:
+                county_balances[case.location] += case.get_balance_due()
+
+            if all(
+                [
+                    c.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.ELIGIBLE_NOW
+                    for c in case.charges
+                ]
+            ):
+                fully_eligible_cases.append(case.case_number)
+            elif any(
+                [
+                    c.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.ELIGIBLE_NOW
+                    for c in case.charges
+                ]
+            ):
+                partially_eligible_cases.append(case.case_number)
+            elif all(
+                [
+                    c.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.INELIGIBLE
+                    for c in case.charges
+                ]
+            ):
+                fully_ineligible_cases.append(case.case_number)
+            else:
+                other_cases.append(case.case_number)
+
+        cases_sorted = {
+            "fully_eligible": fully_eligible_cases,
+            "fully_ineligible": fully_ineligible_cases,
+            "partially_eligible": partially_eligible_cases,
+            "other": other_cases,
+        }
+        total_charges = len(record.charges)
+        eligible_charges = [
+            c.name
+            for c in record.charges
+            if c.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.ELIGIBLE_NOW
+        ]
+        return RecordSummary(
+            cases_sorted=cases_sorted,
+            eligible_charges=eligible_charges,
+            total_charges=total_charges,
+            county_balances=county_balances,
+        )

--- a/src/backend/expungeservice/models/helpers/record_summarizer.py
+++ b/src/backend/expungeservice/models/helpers/record_summarizer.py
@@ -1,5 +1,6 @@
 from expungeservice.models.expungement_result import ChargeEligibilityStatus
 from expungeservice.models.record_summary import RecordSummary
+from typing import Dict
 
 
 class RecordSummarizer:
@@ -11,7 +12,7 @@ class RecordSummarizer:
         partially_eligible_cases = []
         other_cases = []
 
-        county_balances = {}
+        county_balances: Dict[str, float] = {}
         for case in record.cases:
             if not case.location in county_balances.keys():
                 county_balances[case.location] = case.get_balance_due()

--- a/src/backend/expungeservice/models/helpers/record_summarizer.py
+++ b/src/backend/expungeservice/models/helpers/record_summarizer.py
@@ -5,8 +5,7 @@ from typing import Dict
 
 class RecordSummarizer:
     @staticmethod
-    def summarize(record):
-
+    def summarize(record) -> RecordSummary:
         fully_eligible_cases = []
         fully_ineligible_cases = []
         partially_eligible_cases = []
@@ -49,8 +48,8 @@ class RecordSummarizer:
             "partially_eligible": partially_eligible_cases,
             "other": other_cases,
         }
-        for county in county_balances.keys():
-            county_balances[county] = round(county_balances[county], 2)
+        for county, balance in county_balances.items():
+            county_balances[county] = round(balance, 2)
         total_charges = len(record.charges)
         eligible_charges = [
             c.name

--- a/src/backend/expungeservice/models/record_summary.py
+++ b/src/backend/expungeservice/models/record_summary.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass, field
+from typing import List, Dict
+
+from expungeservice.models.case import Case
+from expungeservice.models.charge import Charge
+
+
+@dataclass
+class RecordSummary:
+    total_charges: int
+    cases_sorted: Dict[str, List[str]]
+    eligible_charges: List[str]
+    county_balances: Dict[str, float]
+
+    @property
+    def total_balance_due(self):
+        total_in_cents = 0
+        for county in self.county_balances.keys():
+            total_in_cents += round(self.county_balances[county] * 100)
+        return round(total_in_cents / 100.0, 2)
+
+    @property
+    def total_cases(self):
+        return sum([len(self.cases_sorted[key]) for key in self.cases_sorted.keys()])

--- a/src/backend/expungeservice/models/record_summary.py
+++ b/src/backend/expungeservice/models/record_summary.py
@@ -14,11 +14,8 @@ class RecordSummary:
 
     @property
     def total_balance_due(self):
-        total_in_cents = 0
-        for county in self.county_balances.keys():
-            total_in_cents += round(self.county_balances[county] * 100)
-        return round(total_in_cents / 100.0, 2)
+        return sum(self.county_balances.values())
 
     @property
     def total_cases(self):
-        return sum([len(self.cases_sorted[key]) for key in self.cases_sorted.keys()])
+        return sum([len(cases) for cases in self.cases_sorted.values()])

--- a/src/backend/expungeservice/serializer/serializer.py
+++ b/src/backend/expungeservice/serializer/serializer.py
@@ -52,6 +52,16 @@ class ExpungeModelEncoder(flask.json.JSONEncoder):
             "charge_eligibility": expungement_result.charge_eligibility,
         }
 
+    def record_summary_to_json(self, record_summary):
+        return {
+            "total_charges": record_summary.total_charges,
+            "cases_sorted": record_summary.cases_sorted,
+            "eligible_charges": record_summary.eligible_charges,
+            "county_balances": record_summary.county_balances,
+            "total_balance_due": record_summary.total_balance_due,
+            "total_cases": record_summary.total_cases,
+        }
+
     def default(self, o):
         if isinstance(o, expungeservice.models.record.Record):
             return self.record_to_json(o)

--- a/src/backend/tests/endpoints/test_search.py
+++ b/src/backend/tests/endpoints/test_search.py
@@ -6,6 +6,7 @@ from expungeservice.endpoints import search
 from tests.endpoints.endpoint_util import EndpointShared
 from tests.factories.crawler_factory import CrawlerFactory
 from expungeservice.serializer import ExpungeModelEncoder
+from expungeservice.models.helpers.record_summarizer import RecordSummarizer
 
 
 @pytest.fixture
@@ -74,9 +75,12 @@ def test_search(service, monkeypatch):
     """
     Check that the resulting "record" field in the response matches what we gave to the
     mock search function.
-    (use this json encode-decode approach because it turns a Record into a dict.)
+    (use this json encode-decode approach because it turns a Record or RecordSummary into a dict.)
     """
     assert data["record"] == json.loads(json.dumps(service.mock_record["john_doe"], cls=ExpungeModelEncoder))
+    assert data["summary"] == json.loads(
+        json.dumps(RecordSummarizer.summarize(service.mock_record["john_doe"]), cls=ExpungeModelEncoder)
+    )
 
 
 def test_search_fails_without_oeci_token(service):

--- a/src/backend/tests/models/test_record_summarizer.py
+++ b/src/backend/tests/models/test_record_summarizer.py
@@ -1,0 +1,88 @@
+import unittest
+import json
+
+from expungeservice.models.helpers.record_summarizer import RecordSummarizer
+from expungeservice.serializer import ExpungeModelEncoder
+from expungeservice.expunger.expunger import Expunger
+from tests.factories.case_factory import CaseFactory
+from tests.factories.charge_factory import ChargeFactory
+from tests.factories.record_factory import RecordFactory
+from tests.utilities.time import Time
+
+
+def test_record_summarizer_multiple_cases():
+    case_all_eligible = CaseFactory.create(
+        case_number="0000", balance="100.00", date_location=["1/1/1995", "Multnomah"]
+    )
+    case_all_eligible.charges = [
+        ChargeFactory.create(
+            case=case_all_eligible, name="Theft of dignity", disposition=["Convicted", Time.TEN_YEARS_AGO]
+        )
+    ]
+
+    case_partially_eligible = CaseFactory.create(
+        case_number="0001", balance="200.00", date_location=["1/1/1995", "Clackamas"]
+    )
+    case_partially_eligible.charges = [
+        ChargeFactory.create(case=case_partially_eligible, disposition=["Convicted", Time.TEN_YEARS_AGO]),
+        ChargeFactory.create(
+            case=case_partially_eligible, level="Felony Class A", disposition=["Convicted", Time.TEN_YEARS_AGO]
+        ),
+    ]
+
+    case_possibly_eligible = CaseFactory.create(
+        case_number="0002", balance="300.00", date_location=["1/1/1995", "Baker"]
+    )
+    case_possibly_eligible.charges = [
+        ChargeFactory.create(
+            case=case_possibly_eligible, level="Felony Class B", disposition=["Convicted", Time.TEN_YEARS_AGO]
+        )
+    ]
+
+    case_all_ineligible = CaseFactory.create(case_number="0003", balance="400.00", date_location=["1/1/1995", "Baker"])
+    case_all_ineligible.charges = [
+        ChargeFactory.create(
+            case=case_all_ineligible, level="Felony Class A", disposition=["Convicted", Time.TEN_YEARS_AGO]
+        )
+    ]
+
+    case_all_ineligible_2 = CaseFactory.create(case_number="0004", date_location=["1/1/1995", "Baker"])
+    case_all_ineligible_2.charges = [
+        ChargeFactory.create(
+            case=case_all_ineligible_2, level="Felony Class A", disposition=["Convicted", Time.TEN_YEARS_AGO]
+        )
+    ]
+    record = RecordFactory.create(
+        [case_all_eligible, case_partially_eligible, case_possibly_eligible, case_all_ineligible, case_all_ineligible_2]
+    )
+    expunger = Expunger(record)
+    expunger.run()
+    record_summary = RecordSummarizer.summarize(record)
+
+    assert record_summary.total_balance_due == 1000.00
+    assert record_summary.total_cases == 5
+    assert record_summary.total_charges == 6
+    assert record_summary.cases_sorted["fully_eligible"] == ["0000"]
+    assert record_summary.cases_sorted["fully_ineligible"] == ["0003", "0004"]
+    assert record_summary.cases_sorted["partially_eligible"] == ["0001"]
+    assert record_summary.cases_sorted["other"] == ["0002"]
+
+    assert record_summary.county_balances["Baker"] == 700.00
+    assert record_summary.county_balances["Multnomah"] == 100.00
+    assert record_summary.county_balances["Clackamas"] == 200.00
+    assert record_summary.eligible_charges == ["Theft of dignity", "Theft of services"]
+
+
+def test_record_summarizer_no_cases():
+    record = RecordFactory.create([])
+    record_summary = RecordSummarizer.summarize(record)
+
+    assert record_summary.total_balance_due == 0.00
+    assert record_summary.total_cases == 0
+    assert record_summary.total_charges == 0
+    assert record_summary.cases_sorted["fully_eligible"] == []
+    assert record_summary.cases_sorted["fully_ineligible"] == []
+    assert record_summary.cases_sorted["partially_eligible"] == []
+    assert record_summary.cases_sorted["other"] == []
+    assert record_summary.county_balances == {}
+    assert record_summary.eligible_charges == []


### PR DESCRIPTION
Provides a new data object for populating the Summary panel that will lead the search results #630.

This summarizer sorts case numbers into 4 disjoint sets: `fully_eligible`, `fully_ineligible`, `partially_eligible`, and `other` . It's probably not useful to include `other` in the summary panel, but this way the summary object includes the complete set of case numbers, in case that is useful. 

County balances are computed across cases as a sum of floats, which accumulates a floating point error, but the sums get rounded off again and that seems fine to me.