### PR TITLE
added a frontend based redirect for http -> https

### DIFF
--- a/src/frontend/src/components/HttpsApp/index.tsx
+++ b/src/frontend/src/components/HttpsApp/index.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import HttpsRedirect from '../../service/https-redirect';
+import App from '../App';
+
+class HttpsApp extends React.Component {
+  render() {
+    return (
+      <HttpsRedirect>
+        <App />
+      </HttpsRedirect>
+    );
+  }
+}
+
+export default HttpsApp;

--- a/src/frontend/src/index.tsx
+++ b/src/frontend/src/index.tsx
@@ -1,7 +1,7 @@
 // These imports are all defaults from create-react-app.
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App from './components/App';
+import HttpsApp from './components/HttpsApp';
 import * as serviceWorker from './serviceWorker';
 import './index.scss';
 
@@ -13,7 +13,7 @@ import store from './redux/store';
 const rootElement = document.getElementById('root');
 ReactDOM.render(
   <Provider store={store}>
-    <App />
+    <HttpsApp />
   </Provider>,
   rootElement
 );

--- a/src/frontend/src/service/https-redirect.ts
+++ b/src/frontend/src/service/https-redirect.ts
@@ -1,0 +1,30 @@
+import { ReactElement } from 'react';
+
+const isLocalHost = (hostname: string) =>
+  !!(
+    hostname === 'localhost' ||
+    hostname === '[::1]' ||
+    hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/)
+  );
+
+interface HttpsRedirectObject {
+  disabled?: ReactElement;
+  children: ReactElement;
+}
+
+const HttpsRedirect = ({ disabled, children }: HttpsRedirectObject) => {
+  if (
+    !disabled &&
+    typeof window !== 'undefined' &&
+    window.location &&
+    window.location.protocol === 'http:' &&
+    !isLocalHost(window.location.hostname)
+  ) {
+    window.location.href = window.location.href.replace(/^http(?!s)/, 'https');
+    return null;
+  }
+
+  return children;
+};
+
+export default HttpsRedirect;


### PR DESCRIPTION
Added a simple redirect that will push us into https from http to work around a bug we were experiencing in the OECI login.

Addresses: #711 

See these posts for information on the fix(I had to adjust the actual code of the package instead of installing the npm package to agree with typescript)

Article:  
https://medium.com/@ethanryan/making-your-custom-name-heroku-hosted-react-app-ssl-certified-f9c7fece699c

Fix:  
https://www.npmjs.com/package/react-https-redirect