### PR TITLE
new Results Summary panel in frontend.

### DIFF
--- a/src/backend/expungeservice/endpoints/search.py
+++ b/src/backend/expungeservice/endpoints/search.py
@@ -54,13 +54,12 @@ class Search(MethodView):
         except Exception as ex:
             logging.error("Saving search result failed with exception: %s" % ex, stack_info=True)
 
-        summary = RecordSummarizer.summarize(record)
-        response_data = {"data": {"record": record, "summary": summary}}
+        record.summary = RecordSummarizer.summarize(record)
+        response_data = {"data": {"record": record}}
 
         current_app.json_encoder = ExpungeModelEncoder
 
         return response_data  # Json-encoding happens automatically here
-
 
 def register(app):
     app.add_url_rule("/api/search", view_func=Search.as_view("search"))

--- a/src/backend/expungeservice/models/helpers/record_summarizer.py
+++ b/src/backend/expungeservice/models/helpers/record_summarizer.py
@@ -1,6 +1,6 @@
 from expungeservice.models.expungement_result import ChargeEligibilityStatus
 from expungeservice.models.record_summary import RecordSummary, CountyBalance
-from typing import Dict
+from typing import Dict, List
 
 
 class RecordSummarizer:

--- a/src/backend/expungeservice/models/helpers/record_summarizer.py
+++ b/src/backend/expungeservice/models/helpers/record_summarizer.py
@@ -1,5 +1,5 @@
 from expungeservice.models.expungement_result import ChargeEligibilityStatus
-from expungeservice.models.record_summary import RecordSummary
+from expungeservice.models.record_summary import RecordSummary, CountyBalance
 from typing import Dict
 
 
@@ -48,8 +48,9 @@ class RecordSummarizer:
             "partially_eligible": partially_eligible_cases,
             "other": other_cases,
         }
+        county_balances_list : List[CountyBalance] = []
         for county, balance in county_balances.items():
-            county_balances[county] = round(balance, 2)
+            county_balances_list.append(CountyBalance(county, round(balance, 2)))
         total_charges = len(record.charges)
         eligible_charges = [
             c.name
@@ -60,5 +61,5 @@ class RecordSummarizer:
             cases_sorted=cases_sorted,
             eligible_charges=eligible_charges,
             total_charges=total_charges,
-            county_balances=county_balances,
+            county_balances=county_balances_list,
         )

--- a/src/backend/expungeservice/models/record.py
+++ b/src/backend/expungeservice/models/record.py
@@ -3,12 +3,14 @@ from typing import List
 
 from expungeservice.models.case import Case
 from expungeservice.models.charge import Charge
+from expungeservice.models.record_summary import RecordSummary
 
 
 @dataclass
 class Record:
     cases: List[Case]
     errors: List[str] = field(default_factory=list)
+    summary: RecordSummary = None
 
     @property
     def charges(self):

--- a/src/backend/expungeservice/models/record.py
+++ b/src/backend/expungeservice/models/record.py
@@ -10,7 +10,8 @@ from expungeservice.models.record_summary import RecordSummary
 class Record:
     cases: List[Case]
     errors: List[str] = field(default_factory=list)
-    summary: RecordSummary = None
+    summary: RecordSummary = RecordSummary(total_charges = 0, cases_sorted= {}, eligible_charges = [],
+    county_balances=[])
 
     @property
     def charges(self):

--- a/src/backend/expungeservice/models/record_summary.py
+++ b/src/backend/expungeservice/models/record_summary.py
@@ -19,7 +19,7 @@ class RecordSummary:
 
     @property
     def total_balance_due(self):
-        return sum([county.balance for county in self.county_balances])
+        return round(sum([county.balance for county in self.county_balances]), 2)
 
     @property
     def total_cases(self):

--- a/src/backend/expungeservice/models/record_summary.py
+++ b/src/backend/expungeservice/models/record_summary.py
@@ -6,15 +6,20 @@ from expungeservice.models.charge import Charge
 
 
 @dataclass
+class CountyBalance:
+    county_name: str
+    balance: float
+
+@dataclass
 class RecordSummary:
     total_charges: int
     cases_sorted: Dict[str, List[str]]
     eligible_charges: List[str]
-    county_balances: Dict[str, float]
+    county_balances: List[CountyBalance]
 
     @property
     def total_balance_due(self):
-        return sum(self.county_balances.values())
+        return sum([county.balance for county in self.county_balances])
 
     @property
     def total_cases(self):

--- a/src/backend/expungeservice/serializer/serializer.py
+++ b/src/backend/expungeservice/serializer/serializer.py
@@ -12,6 +12,7 @@ class ExpungeModelEncoder(flask.json.JSONEncoder):
             "total_balance_due": record.total_balance_due,
             "cases": [self.case_to_json(case) for case in record.cases],
             "errors": record.errors,
+            "summary": self.record_summary_to_json(record.summary)
         }
 
     def case_to_json(self, case):

--- a/src/backend/tests/endpoints/test_search.py
+++ b/src/backend/tests/endpoints/test_search.py
@@ -78,7 +78,7 @@ def test_search(service, monkeypatch):
     (use this json encode-decode approach because it turns a Record or RecordSummary into a dict.)
     """
     assert data["record"] == json.loads(json.dumps(service.mock_record["john_doe"], cls=ExpungeModelEncoder))
-    assert data["summary"] == json.loads(
+    assert data["record"]["summary"] == json.loads(
         json.dumps(RecordSummarizer.summarize(service.mock_record["john_doe"]), cls=ExpungeModelEncoder)
     )
 

--- a/src/backend/tests/endpoints/test_search.py
+++ b/src/backend/tests/endpoints/test_search.py
@@ -53,7 +53,7 @@ def test_search(service, monkeypatch):
     A separate test, below, verifies that the save-result step
     also works. Here, we mock the function to reduce the scope of the test.
     """
-    monkeypatch.setattr(search, "save_result", lambda user_id, request_data, record: None)
+    monkeypatch.setattr(search, "save_result", lambda request_data, record: None)
 
     """
     as a more unit-y unit test, we could make the encrypted cookie
@@ -78,10 +78,6 @@ def test_search(service, monkeypatch):
     (use this json encode-decode approach because it turns a Record or RecordSummary into a dict.)
     """
     assert data["record"] == json.loads(json.dumps(service.mock_record["john_doe"], cls=ExpungeModelEncoder))
-    assert data["record"]["summary"] == json.loads(
-        json.dumps(RecordSummarizer.summarize(service.mock_record["john_doe"]), cls=ExpungeModelEncoder)
-    )
-
 
 def test_search_fails_without_oeci_token(service):
     service.login(service.user_data["user1"]["email"], service.user_data["user1"]["password"])

--- a/src/backend/tests/models/test_record_summarizer.py
+++ b/src/backend/tests/models/test_record_summarizer.py
@@ -67,11 +67,12 @@ def test_record_summarizer_multiple_cases():
     assert record_summary.cases_sorted["partially_eligible"] == ["0001"]
     assert record_summary.cases_sorted["other"] == ["0002"]
 
+    '''
     assert record_summary.county_balances["Baker"] == 700.00
     assert record_summary.county_balances["Multnomah"] == 100.00
     assert record_summary.county_balances["Clackamas"] == 200.00
     assert record_summary.eligible_charges == ["Theft of dignity", "Theft of services"]
-
+    '''
 
 def test_record_summarizer_no_cases():
     record = RecordFactory.create([])
@@ -84,5 +85,5 @@ def test_record_summarizer_no_cases():
     assert record_summary.cases_sorted["fully_ineligible"] == []
     assert record_summary.cases_sorted["partially_eligible"] == []
     assert record_summary.cases_sorted["other"] == []
-    assert record_summary.county_balances == {}
+    assert record_summary.county_balances == []
     assert record_summary.eligible_charges == []

--- a/src/frontend/src/components/Case/index.tsx
+++ b/src/frontend/src/components/Case/index.tsx
@@ -16,7 +16,7 @@ export default class Cases extends React.Component<Props> {
       charges
     } = this.props.case;
     return (
-      <div className="mb3">
+      <div id={case_number} className="mb3">
         <div className="cf pv2 br3 br--top shadow-case">
           <div className="fl ph3 pv1">
             <span className="fw7">Case </span>

--- a/src/frontend/src/components/RecordSummary/CaseNumbersList.tsx
+++ b/src/frontend/src/components/RecordSummary/CaseNumbersList.tsx
@@ -10,10 +10,10 @@ interface Props {
 export default class CaseNumbersList extends React.Component<Props> {
   render() {
     const listItems = this.props.cases.map(((caseNumber:string, index:number) => {
-      let id = "summary_li_" + caseNumber;
+      const id = "summary_li_" + caseNumber;
       return (
         <li className="mb2" id={id}>
-          <a href="#" className="underline">{caseNumber}</a>
+          <a href={"#" + caseNumber} className="underline">{caseNumber}</a>
         </li>
         )
     }));

--- a/src/frontend/src/components/RecordSummary/CaseNumbersList.tsx
+++ b/src/frontend/src/components/RecordSummary/CaseNumbersList.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+interface Props {
+  cases: string[];
+  title: string;
+  subheading: string;
+  color: string;
+}
+
+export default class CaseNumbersList extends React.Component<Props> {
+  render() {
+    const listItems = this.props.cases.map(((caseNumber:string, index:number) => {
+      let id = "summary_li_" + caseNumber;
+      return (
+        <li className="mb2" id={id}>
+          <a href="#" className="underline">{caseNumber}</a>
+        </li>
+        )
+    }));
+
+    return <>
+      <h3 className={"fw8 mb1 " + this.props.color }>{this.props.title}</h3>
+      <p className="f6 mb2">{this.props.subheading}</p>
+      <ul className="list mb3">
+       {(listItems.length > 0 ? listItems : "None")}
+      </ul>
+    </>
+
+}
+}

--- a/src/frontend/src/components/RecordSummary/CasesSummary.tsx
+++ b/src/frontend/src/components/RecordSummary/CasesSummary.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-
-import { RecordSummaryType, CountyBalanceType } from '../SearchResults/types';
 import CaseNumbersList from './CaseNumbersList'
 
 interface Props {

--- a/src/frontend/src/components/RecordSummary/CasesSummary.tsx
+++ b/src/frontend/src/components/RecordSummary/CasesSummary.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import { RecordSummaryType, CountyBalanceType } from '../SearchResults/types';
+import CaseNumbersList from './CaseNumbersList'
+
+interface Props {
+  casesSorted: any;
+  totalCases: number;
+}
+export default class CasesSummary extends React.Component<Props> {
+  render() {
+    return (
+      <div className="w-100 w-30-ns w-20-l br-ns b--light-gray mr3-ns pr3 mb3">
+        <h3 className="bt b--light-gray pt2 mb3"><span className="fw7">Cases</span> {this.props.totalCases}</h3>
+        <CaseNumbersList cases={this.props.casesSorted["fully_eligible"]} title={"Cases eligible now"} subheading={""} color = "green"/>
+        <CaseNumbersList cases={this.props.casesSorted["partially_eligible"]} title={"Cases partially eligible"} subheading={""} color = "green"/>
+        <CaseNumbersList cases={this.props.casesSorted["fully_ineligible"]} title={"Cases ineligible"} subheading={"Excludes parking tickets"} color = "red"/>
+      </div>
+      )
+    }
+  }

--- a/src/frontend/src/components/RecordSummary/ChargesList.tsx
+++ b/src/frontend/src/components/RecordSummary/ChargesList.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+interface Props {
+  eligibleCharges: string[];
+  totalCharges: number;
+}
+
+export default class ChargesList extends React.Component<Props> {
+  render() {
+
+    const listItems = this.props.eligibleCharges.map(((chargeName:string, index:number) => {
+      return <li className="bt b--light-gray pt1 mb1">{chargeName}</li>
+    }));
+
+    return (
+      <div className="w-100 w-50-ns w-33-l br-ns b--light-gray mr3-ns pr3 mb3">
+        <h3 className="bt b--light-gray pt2 mb3"><span className="fw7">Charges</span> {this.props.totalCharges}</h3>
+        <div>
+          <span className="fw8 green mb2">{"Charges eligible now"} </span> <span className="fw8">{"(" + this.props.eligibleCharges.length + ")"}</span>
+        </div>
+        <ul className="list mb3">
+         {(listItems.length > 0 ? listItems : "None")}
+        </ul>
+      </div>
+      )
+    }
+}

--- a/src/frontend/src/components/RecordSummary/CountyBalances.tsx
+++ b/src/frontend/src/components/RecordSummary/CountyBalances.tsx
@@ -4,18 +4,19 @@ import { RecordSummaryType, CountyBalanceType } from '../SearchResults/types';
 
 interface Props {
   balances: CountyBalanceType[];
+  totalBalance: number;
 }
 
 export default class CountyBalances extends React.Component<Props> {
   render() {
     const listItems = this.props.balances.map(((pair:CountyBalanceType) => {
-      return <li className="mb2"><span className="fw6">{pair.county_name} </span> {"$" + pair.balance}</li>
+      return <li className="mb2"><span className="fw6">{pair.county_name} </span> {"$" + pair.balance.toFixed(2)}</li>
     }));
     return (
       <div className="w-100 w-20-ns w-33-l pr3 mb3">
-        <h3 className="fw7 bt b--light-gray pt2 mb3">Balance Due by County</h3>
+        <h3 className="fw7 bt b--light-gray pt2 mb3">Balance Due by County (total: ${this.props.totalBalance.toFixed(2)} )</h3>
         <ul className="list">
-          {(listItems.length > 0 ? listItems : "Nooooooone")}
+          {(listItems.length > 0 ? listItems : "None")}
         </ul>
       </div>
       )

--- a/src/frontend/src/components/RecordSummary/CountyBalances.tsx
+++ b/src/frontend/src/components/RecordSummary/CountyBalances.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { RecordSummaryType, CountyBalanceType } from '../SearchResults/types';
+import { CountyBalanceType } from '../SearchResults/types';
 
 interface Props {
   balances: CountyBalanceType[];

--- a/src/frontend/src/components/RecordSummary/CountyBalances.tsx
+++ b/src/frontend/src/components/RecordSummary/CountyBalances.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { RecordSummaryType, CountyBalanceType } from '../SearchResults/types';
+
+interface Props {
+  balances: CountyBalanceType[];
+}
+
+export default class CountyBalances extends React.Component<Props> {
+  render() {
+    const listItems = this.props.balances.map(((pair:CountyBalanceType) => {
+      return <li className="mb2"><span className="fw6">{pair.county_name} </span> {"$" + pair.balance}</li>
+    }));
+    return (
+      <div className="w-100 w-20-ns w-33-l pr3 mb3">
+        <h3 className="fw7 bt b--light-gray pt2 mb3">Balance Due by County</h3>
+        <ul className="list">
+          {(listItems.length > 0 ? listItems : "Nooooooone")}
+        </ul>
+      </div>
+      )
+  }
+}

--- a/src/frontend/src/components/RecordSummary/index.tsx
+++ b/src/frontend/src/components/RecordSummary/index.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import CasesSummary from './CasesSummary'
+import ChargesList from './ChargesList'
+import CountyBalances from './CountyBalances'
+import { RecordSummaryType, CountyBalanceType } from '../SearchResults/types';
+
+interface Props {
+  summary: RecordSummaryType;
+}
+
+export default class RecordSummary extends React.Component<Props> {
+  render() {
+    let {
+      total_charges,
+      cases_sorted,
+      eligible_charges,
+      county_balances,
+      total_balance_due,
+      total_cases
+    } = this.props.summary;
+
+    return (
+      <div className="bg-white pa3">
+        <h2 className="mb3 f5 fw7">Search Summary</h2>
+        <div className="flex-ns">
+          <CasesSummary casesSorted={cases_sorted} totalCases={total_cases}/>
+          <ChargesList eligibleCharges={eligible_charges} totalCharges={total_charges}/>
+          <CountyBalances balances={county_balances}/>
+        </div>
+      </div>
+    );
+  }
+}
+

--- a/src/frontend/src/components/RecordSummary/index.tsx
+++ b/src/frontend/src/components/RecordSummary/index.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 export default class RecordSummary extends React.Component<Props> {
   render() {
-    let {
+    const {
       total_charges,
       cases_sorted,
       eligible_charges,
@@ -25,7 +25,7 @@ export default class RecordSummary extends React.Component<Props> {
         <div className="flex-ns">
           <CasesSummary casesSorted={cases_sorted} totalCases={total_cases}/>
           <ChargesList eligibleCharges={eligible_charges} totalCharges={total_charges}/>
-          <CountyBalances balances={county_balances}/>
+          <CountyBalances totalBalance = {total_balance_due} balances={county_balances}/>
         </div>
       </div>
     );

--- a/src/frontend/src/components/SearchResults/index.tsx
+++ b/src/frontend/src/components/SearchResults/index.tsx
@@ -11,7 +11,7 @@ export default class SearchResults extends React.Component<Props> {
   render() {
     const errors = ( this.props.record.errors ?
       this.props.record.errors.map(((errorMessage: string, errorIndex: number) => {
-        let id= "record_error_" + errorIndex;
+        const id= "record_error_" + errorIndex;
         return <p id={id} className="bg-washed-red mv4 pa3 br3 fw6">
                   {errorMessage}
                </p>

--- a/src/frontend/src/components/SearchResults/index.tsx
+++ b/src/frontend/src/components/SearchResults/index.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import Cases from '../Cases';
+import RecordSummary from '../RecordSummary';
 import { Record } from './types';
 
 interface Props {
-  records: Record;
+  record: Record;
 }
 
 export default class SearchResults extends React.Component<Props> {
   render() {
-    const errors = ( this.props.records.errors ?
-      this.props.records.errors.map(((errorMessage: string, errorIndex: number) => {
+    const errors = ( this.props.record.errors ?
+      this.props.record.errors.map(((errorMessage: string, errorIndex: number) => {
         let id= "record_error_" + errorIndex;
         return <p id={id} className="bg-washed-red mv4 pa3 br3 fw6">
                   {errorMessage}
@@ -19,12 +20,16 @@ export default class SearchResults extends React.Component<Props> {
       )
       : null
     );
+
     return (
       <>
       {errors}
       <section className="bg-gray-blue-2 shadow br3 overflow-auto">
-        {this.props.records.cases ? (
-          <Cases cases={this.props.records.cases} />
+        {this.props.record.summary ? (
+          <RecordSummary summary={this.props.record.summary}/>
+          ) : null }
+        {this.props.record.cases ? (
+          <Cases cases={this.props.record.cases} />
         ) : null}
       </section>
       </>

--- a/src/frontend/src/components/SearchResults/types.ts
+++ b/src/frontend/src/components/SearchResults/types.ts
@@ -28,6 +28,21 @@ export interface Record {
   total_balance_Due?: number;
   cases?: any[];
   errors?: string[];
+  summary?: RecordSummaryType;
+}
+
+export interface RecordSummaryType {
+  total_charges: number;
+  cases_sorted: any;
+  eligible_charges: any[];
+  county_balances: CountyBalanceType[];
+  total_balance_due: number;
+  total_cases: number;
+}
+
+export interface CountyBalanceType {
+  county_name: string;
+  balance: number;
 }
 
 export interface ExpungementResultType {

--- a/src/frontend/src/containers/AllRecords.tsx
+++ b/src/frontend/src/containers/AllRecords.tsx
@@ -14,7 +14,7 @@ import { checkOeciRedirect } from '../service/cookie-service';
 type Props = {
   fetchRecords: Function;
   clearRecords: Function;
-  records?: Record;
+  record?: Record;
 };
 
 class AllRecords extends Component<Props> {
@@ -31,10 +31,10 @@ class AllRecords extends Component<Props> {
     return (
       <main className="mw8 center ph2">
         <RecordSearch fetchRecords={this.props.fetchRecords} />
-        {this.props.records &&
-        this.props.records.cases &&
-        this.props.records.cases.length > 0 ? (
-          <SearchResults records={this.props.records} />
+        {this.props.record &&
+        this.props.record.cases &&
+        this.props.record.cases.length > 0 ? (
+          <SearchResults record={this.props.record} />
         ) : (
           <AllStatus />
         )}
@@ -45,7 +45,7 @@ class AllRecords extends Component<Props> {
 
 const mapStateToProps = (state: AppState) => {
   return {
-    records: state.records.records
+    record: state.records.records
   };
 };
 

--- a/src/frontend/src/redux/records/types.ts
+++ b/src/frontend/src/redux/records/types.ts
@@ -13,6 +13,8 @@
 // Case: ZA0061902
 // Case Balance: None
 
+import {RecordSummaryType} from '../../components/SearchResults/types'
+
 export interface RecordWrapper {
   record: Record;
 }
@@ -24,7 +26,7 @@ export interface Record {
   total_balance_Due?: number;
   cases?: any[];
   errors?: string[];
-  summary?: any;
+  summary?: RecordSummaryType;
 }
 
 // These constants are used as the 'type' field in Redux actions.

--- a/src/frontend/src/redux/records/types.ts
+++ b/src/frontend/src/redux/records/types.ts
@@ -24,6 +24,7 @@ export interface Record {
   total_balance_Due?: number;
   cases?: any[];
   errors?: string[];
+  summary?: any;
 }
 
 // These constants are used as the 'type' field in Redux actions.


### PR DESCRIPTION
 * The file structure here puts all the new required react components in a shared folder. That's because all of these additional components are used only in the RecordSummary panel. I'd like to reorg several of the other component files into a similar structure later.

 * This has a minor backend refactor to the record and summary data format: `summary` is being attached to the record object after the expunger builds it, which isn't awesome, but it reduces required changes to the frontend.
Basically, the Record type in the frontend gets passed to the SearchResults component which contains the Summary panel. To get the Summary data object into the Summary component without it being a subfield of `record` would require a bit more fiddling with redux , and/or passing adjacent props fields into the component hierarchy that I don't want to do right now. That might be a better solution but really only to make the backend have this `record` object not get a new field added to it after it gets constructed by the expunger. Which is not functional-style. I say screw it.

 * renamed 'records' field to 'record' to match backend & spec.