### PR TITLE
Amended Disposition gets parsed as a disposition

### DIFF
--- a/src/backend/expungeservice/crawler/crawler.py
+++ b/src/backend/expungeservice/crawler/crawler.py
@@ -83,5 +83,5 @@ class Crawler:
                 datetime.strptime(disposition_data.get("date"), "%m/%d/%Y")
             )  # TODO: Log error if format is not correct
             ruling = disposition_data.get("ruling")
-            charge["disposition"] = Disposition(date, ruling)
+            charge["disposition"] = Disposition(date, ruling, "amended" in disposition_data["event"].lower())
         return ChargeCreator.create(**charge)

--- a/src/backend/expungeservice/crawler/parsers/case_parser.py
+++ b/src/backend/expungeservice/crawler/parsers/case_parser.py
@@ -108,13 +108,13 @@ class CaseParser:
             else:
                 raise ValueError("len(event_table_contents) should always be 4 or 5.")
 
-            if CaseParser.__normalize_text(event_type.text) == "disposition":
+            if CaseParser.__normalize_text(event_type.text) in ["disposition", "amendeddisposition"]:
                 disposition_data = {}
                 for row, next_row in zip(event_inner_table_parse, event_inner_table_parse[1:]):
                     if CaseParser._valid_data(row.split(".\xa0")):
                         charge_id_string, charge = row.split(".\xa0")
                         charge_id = int(charge_id_string)
-                        disposition_data[charge_id] = {"date": date.text, "charge": charge, "ruling": next_row}
+                        disposition_data[charge_id] = {"date": date.text, "charge": charge, "ruling": next_row, "event": event_type.text}
                 return disposition_data
             else:
                 return None

--- a/src/backend/expungeservice/models/disposition.py
+++ b/src/backend/expungeservice/models/disposition.py
@@ -16,6 +16,7 @@ class DispositionStatus(str, Enum):
 class Disposition:
     date: date
     ruling: str
+    amended: bool = False
     status: DispositionStatus = field(init=False)
 
     def __post_init__(self):

--- a/src/backend/expungeservice/serializer/serializer.py
+++ b/src/backend/expungeservice/serializer/serializer.py
@@ -43,7 +43,7 @@ class ExpungeModelEncoder(flask.json.JSONEncoder):
         }
 
     def disposition_to_json(self, disposition):
-        return {"date": disposition.date, "ruling": disposition.ruling, "status": disposition.status}
+        return {"date": disposition.date, "ruling": disposition.ruling, "status": disposition.status, "amended": disposition.amended}
 
     def expungement_result_to_json(self, expungement_result):
         return {

--- a/src/frontend/src/components/Charge/index.tsx
+++ b/src/frontend/src/components/Charge/index.tsx
@@ -27,6 +27,9 @@ export default class Charge extends React.Component<Props> {
       } else if (disposition.status === "Unrecognized") {
         dispositionEvent += " (\"" + disposition.ruling + "\")";
       }
+      if (disposition.amended) {
+        dispositionEvent += " (Amended)"
+      }
       return <>
         <li className="mb2">
           <span className="fw7">Disposition:</span> {dispositionEvent}


### PR DESCRIPTION
This fixes the common bug that 'conditional discharge', et al., are not readable as a final disposition

If both "disposition" and "amended disposition" events are on a record for a single charge, the last one in order is the only one returned by the crawler. Amended dispos come later in the OECI page of events, so they take precedence.

The frontend now shows "Amended" if it's showing the disposition result of an amended event