### PR TITLE
Fix expunger test relating to friendly rule

### DIFF
--- a/src/backend/tests/test_crawler_expunger.py
+++ b/src/backend/tests/test_crawler_expunger.py
@@ -169,21 +169,20 @@ def record_with_specific_dates(crawler):
     )
 
 
-@pytest.mark.skip(reason="Line 178 should be ELIGIBLE. TODO: Confirm this is the case")
 def test_expunger_runs_time_analyzer(record_with_specific_dates):
     record = record_with_specific_dates
     expunger = Expunger(record)
     assert expunger.run()
 
     print(record.cases[0].charges[0])
-    assert record.cases[0].charges[0].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert record.cases[0].charges[0].expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
     assert record.cases[0].charges[1].expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert record.cases[0].charges[2].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert record.cases[0].charges[2].expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
 
     assert record.cases[1].charges[0].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
     assert record.cases[1].charges[1].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
     assert record.cases[1].charges[2].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
 
-    assert record.cases[2].charges[0].expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert record.cases[2].charges[1].expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert record.cases[2].charges[2].expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert record.cases[2].charges[0].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert record.cases[2].charges[1].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert record.cases[2].charges[2].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE

--- a/src/backend/tests/test_time_analyzer.py
+++ b/src/backend/tests/test_time_analyzer.py
@@ -34,7 +34,7 @@ class TestSingleChargeAcquittals(unittest.TestCase):
         assert three_yr_mrc.expungement_result.time_eligibility.reason == ""
         assert three_yr_mrc.expungement_result.time_eligibility.date_will_be_eligible is None
 
-    @pytest.mark.skip(reason="Line 66 should be ineligible. TODO: Confirm this is the case")
+    @pytest.mark.skip(reason="We still need to implement the friendly rule extension.")
     def test_eligible_mrc_with_violation(self):
         case = CaseFactory.create()
 


### PR DESCRIPTION
Also recognize the fact that no complaints do also get blocked by recent dismissals.

The logic was fixed with https://github.com/codeforpdx/recordexpungPDX/pull/742 but I was waiting for confirmation until I also adjusted this test.