### PR TITLE
Make time eligibility depend on type eligiblity

### DIFF
--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -7,6 +7,7 @@ from more_itertools import flatten, padnone, take
 from expungeservice.models.charge import Charge
 from expungeservice.models.charge_types.felony_class_b import FelonyClassB
 from expungeservice.models.disposition import DispositionStatus
+from expungeservice.models.expungement_result import EligibilityStatus
 from expungeservice.models.record import Record
 
 
@@ -46,6 +47,13 @@ class Expunger:
                 eligibility_dates.append(
                     (charge.disposition.date + relativedelta(years=3), "Time-ineligible under 137.225(1)(a)")
                 )
+            elif charge.acquitted():
+                eligibility_dates.append((charge.disposition.date, "Time eligible under 137.225(1)(b)"))
+            else:
+                raise ValueError("Charge should always convicted or acquitted at this point.")
+
+            if charge.expungement_result.type_eligibility.status == EligibilityStatus.INELIGIBLE:
+                eligibility_dates.append((date.max, "Never. Type ineligible charges are always time ineligible."))
 
             if charge.disposition.status == DispositionStatus.NO_COMPLAINT:
                 eligibility_dates.append(
@@ -76,14 +84,7 @@ class Expunger:
                 else:
                     eligibility_dates.append((charge.disposition.date + relativedelta(years=20), "137.225(5)(a)(A)(i) - Twenty years from class B felony conviction"))  # type: ignore
 
-            if eligibility_dates:
-                eligibility_date, reason = max(eligibility_dates)
-                if date.today() >= eligibility_date:
-                    charge.set_time_eligible()
-                else:
-                    charge.set_time_ineligible(reason, eligibility_date)
-            else:
-                charge.set_time_eligible()
+            charge.set_time_eligibility(eligibility_dates)
         for case in self.record.cases:
             convictions_in_case = [charge for charge in case.charges if charge.convicted()]
             if len(convictions_in_case) == 1:

--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -72,17 +72,12 @@ class Charge:
     def skip_analysis(self):
         return False
 
-    def set_time_ineligible(self, reason, date_of_eligibility):
-        status = self.expungement_result.type_eligibility.status
-        if status == EligibilityStatus.ELIGIBLE or status == EligibilityStatus.NEEDS_MORE_ANALYSIS and date_of_eligibility != date_class.max:
-            date_will_be_eligible = date_of_eligibility
+    def set_time_eligibility(self, eligibility_dates):
+        date_will_be_eligible, reason = max(eligibility_dates)
+        if date_will_be_eligible and date_class.today() >= date_will_be_eligible:
+            time_eligibility = TimeEligibility(status=EligibilityStatus.ELIGIBLE, reason="", date_will_be_eligible=None)
         else:
-            date_will_be_eligible = None
-        time_eligibility = TimeEligibility(
-            status=EligibilityStatus.INELIGIBLE, reason=reason, date_will_be_eligible=date_will_be_eligible
-        )
-        self.expungement_result.time_eligibility = time_eligibility
-
-    def set_time_eligible(self, reason=""):
-        time_eligibility = TimeEligibility(status=EligibilityStatus.ELIGIBLE, reason=reason, date_will_be_eligible=None)
+            time_eligibility = TimeEligibility(
+                status=EligibilityStatus.INELIGIBLE, reason=reason, date_will_be_eligible=date_will_be_eligible
+            )
         self.expungement_result.time_eligibility = time_eligibility

--- a/src/backend/expungeservice/models/expungement_result.py
+++ b/src/backend/expungeservice/models/expungement_result.py
@@ -54,16 +54,18 @@ class ExpungementResult:
                 return ChargeEligibility(ChargeEligibilityStatus.ELIGIBLE_NOW, "Eligible", None)
 
             elif self.time_eligibility and self.time_eligibility.status == EligibilityStatus.INELIGIBLE:
-                if self.time_eligibility.date_will_be_eligible:
+                if self.time_eligibility.date_will_be_eligible == date.max:
+                    # Currently, no charge types that are type-eligible can be disqualified due to a time-ineligibility date of max, meaning "never"
+                    # So this else block has no applicable cases and never runs. But it will apply if a new charge type that qualifies gets added.
+                    return ChargeEligibility(ChargeEligibilityStatus.INELIGIBLE, "Ineligible", None)
+                elif self.time_eligibility.date_will_be_eligible:
                     return ChargeEligibility(
                         ChargeEligibilityStatus.WILL_BE_ELIGIBLE,
                         f"Eligible {self.time_eligibility.date_will_be_eligible.strftime('%b %-d, %Y')}",
                         self.time_eligibility.date_will_be_eligible,
                     )
                 else:
-                    # Currently, no charge types that are type-eligible can be disqualified due to a time-ineligibility date of None, meaning "never"
-                    # So this else block has no applicable cases and never runs. But it will apply if a new charge type that qualifies gets added.
-                    return ChargeEligibility(ChargeEligibilityStatus.INELIGIBLE, "Ineligible", None)
+                    raise ValueError("There was no date_will_be_eligible.")
             else:
                 return ChargeEligibility(
                     ChargeEligibilityStatus.UNKNOWN, "Type-eligible but time analysis is missing", None
@@ -74,15 +76,17 @@ class ExpungementResult:
                 return ChargeEligibility(ChargeEligibilityStatus.POSSIBLY_ELIGIBILE, "Possibly Eligible (review)", None)
 
             elif self.time_eligibility and self.time_eligibility.status == EligibilityStatus.INELIGIBLE:
-                if self.time_eligibility.date_will_be_eligible:
+                if self.time_eligibility.date_will_be_eligible == date.max:
+                    # Currently, this occurs with Class B Felonies only, which can be time ineligible with a date of max, meaning "never"
+                    return ChargeEligibility(ChargeEligibilityStatus.INELIGIBLE, "Ineligible", None)
+                elif self.time_eligibility.date_will_be_eligible:
                     return ChargeEligibility(
                         ChargeEligibilityStatus.POSSIBLY_WILL_BE_ELIGIBLE,
                         f"Possibly Eligible {self.time_eligibility.date_will_be_eligible.strftime('%b %-d, %Y')} (review)",
                         self.time_eligibility.date_will_be_eligible,
                     )
                 else:
-                    # Currently, this occurs with Class B Felonies only, which can be time ineligible with a date of None, meaning "never"
-                    return ChargeEligibility(ChargeEligibilityStatus.INELIGIBLE, "Ineligible", None)
+                    raise ValueError("There was no date_will_be_eligible.")
             else:
                 return ChargeEligibility(
                     ChargeEligibilityStatus.UNKNOWN, "Possibly eligible but time analysis is missing", None

--- a/src/backend/tests/models/test_expungement_result.py
+++ b/src/backend/tests/models/test_expungement_result.py
@@ -54,7 +54,7 @@ def test_ineligible():
 
 def test_type_eligible_never_becomes_eligible():
     type_eligibility = TypeEligibility(EligibilityStatus.ELIGIBLE, "Eligible under some statute")
-    time_eligibility = TimeEligibility(EligibilityStatus.INELIGIBLE, "Never eligible under some statute", None)
+    time_eligibility = TimeEligibility(EligibilityStatus.INELIGIBLE, "Never eligible under some statute", date.max)
     expungement_result = ExpungementResult(type_eligibility, time_eligibility)
 
     assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.INELIGIBLE
@@ -63,7 +63,7 @@ def test_type_eligible_never_becomes_eligible():
 
 def test_type_possibly_eligible_never_becomes_eligible():
     type_eligibility = TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, "Unrecognized charge")
-    time_eligibility = TimeEligibility(EligibilityStatus.INELIGIBLE, "Never eligible under some statute", None)
+    time_eligibility = TimeEligibility(EligibilityStatus.INELIGIBLE, "Never eligible under some statute", date.max)
     expungement_result = ExpungementResult(type_eligibility, time_eligibility)
 
     assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.INELIGIBLE

--- a/src/backend/tests/test_crawler_expunger.py
+++ b/src/backend/tests/test_crawler_expunger.py
@@ -169,21 +169,19 @@ def record_with_specific_dates(crawler):
     )
 
 
-@pytest.mark.skip(reason="Line 178 should be ELIGIBLE. TODO: Confirm this is the case")
 def test_expunger_runs_time_analyzer(record_with_specific_dates):
     record = record_with_specific_dates
     expunger = Expunger(record)
     assert expunger.run()
 
-    print(record.cases[0].charges[0])
     assert record.cases[0].charges[0].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert record.cases[0].charges[1].expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert record.cases[0].charges[1].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
     assert record.cases[0].charges[2].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
 
     assert record.cases[1].charges[0].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
     assert record.cases[1].charges[1].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
     assert record.cases[1].charges[2].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
 
-    assert record.cases[2].charges[0].expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert record.cases[2].charges[1].expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert record.cases[2].charges[2].expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert record.cases[2].charges[0].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert record.cases[2].charges[1].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert record.cases[2].charges[2].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE

--- a/src/backend/tests/test_time_analyzer.py
+++ b/src/backend/tests/test_time_analyzer.py
@@ -208,8 +208,11 @@ class TestSingleChargeAcquittals(unittest.TestCase):
         expunger.run()
 
         assert charge.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
-        assert charge.expungement_result.time_eligibility.reason == "Time-ineligible under 137.225(1)(a)"
-        assert charge.expungement_result.time_eligibility.date_will_be_eligible is None
+        assert (
+            charge.expungement_result.time_eligibility.reason
+            == "Never. Type ineligible charges are always time ineligible."
+        )
+        assert charge.expungement_result.time_eligibility.date_will_be_eligible is date.max
 
 
 class TestDismissalBlock(unittest.TestCase):
@@ -389,7 +392,7 @@ def test_felony_class_b_with_subsequent_conviction():
         b_felony_charge.expungement_result.time_eligibility.reason
         == "Never. Class B felony can have no subsequent arrests or convictions (137.225(5)(a)(A)(ii))"
     )
-    assert b_felony_charge.expungement_result.time_eligibility.date_will_be_eligible == None
+    assert b_felony_charge.expungement_result.time_eligibility.date_will_be_eligible == date.max
 
     # The Class B felony does not affect eligibility of another charge that is otherwise eligible
     assert subsequent_charge.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE


### PR DESCRIPTION
Resolves https://github.com/codeforpdx/recordexpungPDX/issues/768

Note my comment from https://github.com/codeforpdx/recordexpungPDX/pull/742#issuecomment-576988867 now no longer applies as time eligibility is depends on type eligibility.

Both Class B Felonies with subsequent arrests and type ineligible charges now have a time eligibility of date.max. We now push an eligibility date for acquitted charges so that we are guaranteed to have a non-empty eligibility_dates, making the downstream processing cleaner.

Line 185-187 in test_crawler_expunger.py was fixed in https://github.com/codeforpdx/recordexpungPDX/pull/742 but wasn't changed then as I was waiting for some confirmation.