### PR TITLE
Add extension to friendly rule

### DIFF
--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -96,7 +96,7 @@ class Expunger:
                     else:
                         non_violation_convictions_in_case.append(charge)
             violations_in_case.sort(key=lambda charge: charge.disposition.date, reverse=True)
-            if len(non_violation_convictions_in_case) == 1:
+            if len(non_violation_convictions_in_case) == 1 and len(violations_in_case) <= 1:
                 attractor = non_violation_convictions_in_case[0]
             elif len(violations_in_case) == 1:
                 attractor = violations_in_case[0]

--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -111,15 +111,32 @@ class Expunger:
                         charge.expungement_result.type_eligibility.status != EligibilityStatus.INELIGIBLE
                         and charge.acquitted()
                         and (
-                            not attractor.expungement_result.time_eligibility.date_will_be_eligible
-                            or charge.expungement_result.time_eligibility.date_will_be_eligible
-                            >= attractor.expungement_result.time_eligibility.date_will_be_eligible
+                            Expunger._is_newer(
+                                charge.expungement_result.time_eligibility.date_will_be_eligible,
+                                attractor.expungement_result.time_eligibility.date_will_be_eligible,
+                            )
                         )
                     ):
-                        charge.expungement_result.time_eligibility = (
-                            attractor.expungement_result.time_eligibility
-                        )  # TODO: Feels dangerous; clean up
+                        charge.expungement_result.time_eligibility.status = (
+                            attractor.expungement_result.time_eligibility.status
+                        )
+                        charge.expungement_result.time_eligibility.date_will_be_eligible = (
+                            attractor.expungement_result.time_eligibility.date_will_be_eligible
+                        )
+                        charge.expungement_result.time_eligibility.reason = "The friendly rule: time eligibility of the arrest matches time eligibility of the conviction."
+                        # TODO: Feels dangerous; clean up
         return len(open_cases) == 0
+
+    @staticmethod
+    def _is_newer(date, other_date):
+        if date and other_date:
+            return date >= other_date
+        elif date:
+            return True
+        elif other_date:
+            return False
+        else:
+            return False
 
     @staticmethod
     def _categorize_charges(charges):

--- a/src/backend/tests/test_friendly_rule.py
+++ b/src/backend/tests/test_friendly_rule.py
@@ -1,0 +1,84 @@
+from expungeservice.expunger import Expunger
+from expungeservice.models.expungement_result import EligibilityStatus
+from expungeservice.models.record import Record
+from tests.factories.case_factory import CaseFactory
+from tests.factories.charge_factory import ChargeFactory
+from tests.factories.expunger_factory import ExpungerFactory
+from tests.time import Time
+
+
+def test_arrest_is_unaffected_if_conviction_is_older():
+    # A single violation doesn't block other records, but it is still subject to the 3 year rule.
+    violation_charge = ChargeFactory.create(
+        level="Class A Violation", date=Time.TEN_YEARS_AGO, disposition=["Convicted", Time.LESS_THAN_THREE_YEARS_AGO]
+    )
+    arrest = ChargeFactory.create(disposition=["Dismissed", Time.ONE_YEAR_AGO])
+
+    case = CaseFactory.create()
+    case.charges = [violation_charge, arrest]
+    expunger = Expunger(Record([case]))
+    expunger.run()
+
+    assert arrest.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert arrest.expungement_result.time_eligibility.date_will_be_eligible == None
+    assert arrest.expungement_result.time_eligibility.reason == ""
+
+
+def test_arrest_time_eligibility_is_set_to_older_violation():
+    older_violation = ChargeFactory.create(
+        level="Class A Violation",
+        date=Time.LESS_THAN_THREE_YEARS_AGO,
+        disposition=["Convicted", Time.LESS_THAN_THREE_YEARS_AGO],
+    )
+    newer_violation = ChargeFactory.create(
+        level="Class A Violation", date=Time.TWO_YEARS_AGO, disposition=["Convicted", Time.TWO_YEARS_AGO]
+    )
+    arrest = ChargeFactory.create(disposition=["Dismissed", Time.ONE_YEAR_AGO])
+
+    case = CaseFactory.create()
+    case.charges = [older_violation, newer_violation, arrest]
+    expunger = Expunger(Record([case]))
+    expunger.run()
+
+    assert arrest.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert (
+        arrest.expungement_result.time_eligibility.reason
+        == "The friendly rule: time eligibility of the arrest matches time eligibility of the conviction."
+    )
+    assert (
+        arrest.expungement_result.time_eligibility.date_will_be_eligible
+        == older_violation.disposition.date + Time.THREE_YEARS
+    )
+
+
+def test_3_violations_are_time_restricted():
+    violation_charge_1 = ChargeFactory.create(
+        level="Class A Violation",
+        date=Time.LESS_THAN_THREE_YEARS_AGO,
+        disposition=["Convicted", Time.LESS_THAN_THREE_YEARS_AGO],
+    )
+    violation_charge_2 = ChargeFactory.create(
+        level="Class A Violation", date=Time.TWO_YEARS_AGO, disposition=["Convicted", Time.TWO_YEARS_AGO]
+    )
+    violation_charge_3 = ChargeFactory.create(
+        level="Class A Violation", date=Time.ONE_YEAR_AGO, disposition=["Convicted", Time.ONE_YEAR_AGO]
+    )
+    arrest = ChargeFactory.create(disposition=["Dismissed", Time.ONE_YEAR_AGO])
+
+    case = CaseFactory.create()
+    case.charges = [violation_charge_3, violation_charge_2, violation_charge_1, arrest]
+    expunger = Expunger(Record([case]))
+    expunger.run()
+
+    earliest_date_eligible = min(
+        violation_charge_1.expungement_result.time_eligibility.date_will_be_eligible,
+        violation_charge_2.expungement_result.time_eligibility.date_will_be_eligible,
+        violation_charge_3.expungement_result.time_eligibility.date_will_be_eligible,
+    )
+
+    assert arrest.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert (
+        arrest.expungement_result.time_eligibility.reason
+        == "The friendly rule: time eligibility of the arrest matches time eligibility of the conviction."
+    )
+    assert arrest.expungement_result.time_eligibility.date_will_be_eligible == earliest_date_eligible

--- a/src/backend/tests/test_time_analyzer.py
+++ b/src/backend/tests/test_time_analyzer.py
@@ -86,9 +86,7 @@ class TestSingleChargeAcquittals(unittest.TestCase):
         )
 
         assert arrest.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
-        assert arrest.expungement_result.time_eligibility.date_will_be_eligible == date.today() + relativedelta(
-            years=7, days=1
-        )
+        assert arrest.expungement_result.time_eligibility.date_will_be_eligible == date.today() + relativedelta(years=7)
 
     def test_ineligible_mrc_with_arrest_on_single_case(self):
         case = CaseFactory.create()


### PR DESCRIPTION
When there are 2 violations, we want to set the arrests to have the time eligibility of the older violation because that will always become eligible first. Similarly when there are 3 violations, we want to set the arrests to have the time eligibility of the second oldest violation. Note we only set the time eligibility to the attractor if the attractor has a earlier time eligibility than the arrests.