### PR TITLE
Add logic for 137.225(1)(c) to expunger

### DIFF
--- a/src/backend/expungeservice/crawler/parsers/case_parser.py
+++ b/src/backend/expungeservice/crawler/parsers/case_parser.py
@@ -1,5 +1,6 @@
 import re
 from dataclasses import dataclass
+from datetime import datetime, date
 from typing import List, Dict, Optional, Tuple
 
 from bs4 import BeautifulSoup
@@ -18,7 +19,7 @@ class CaseParserData:
     hashed_charge_data: Dict[int, Dict[str, str]]
     hashed_dispo_data: Dict[int, Dict[str, str]]
     balance_due: str
-    probation_revoked: bool
+    probation_revoked: Optional[date]
 
 
 class CaseParser:
@@ -28,10 +29,13 @@ class CaseParser:
         hashed_charge_data = CaseParser.__build_charge_table_data(soup)
         (
             hashed_dispo_data,
-            latest_probation_revoked_date_string,
+            probation_revoked_date_string,
         ) = CaseParser.__build_hashed_dispo_data_and_probation_revoked(soup)
         balance_due = CaseParser.__build_balance_due(soup)
-        probation_revoked = True if latest_probation_revoked_date_string else False  # TODO: Pass through date
+        if probation_revoked_date_string:
+            probation_revoked = datetime.date(datetime.strptime(probation_revoked_date_string, "%m/%d/%Y"))
+        else:
+            probation_revoked = None  # type: ignore
         return CaseParserData(hashed_charge_data, hashed_dispo_data, balance_due, probation_revoked)
 
     @staticmethod

--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -20,13 +20,6 @@ class Expunger:
         """
         Evaluates the expungement eligibility of a record.
 
-        Assuming that convictions within the same case are processed around the same time,
-        if we just assume that the probation revoked applies to all convictions,
-        then the eligibility date of all charges are roughly the same as when
-        the probation revoked only applied to a single conviction:
-        because of the 10 year blocking rule for multiple convictions,
-        the eligibility date of some charges will only be off by the difference in processing times.
-
         :return: True if there are no open cases; otherwise False
         """
         open_cases = [case for case in self.record.cases if not case.closed()]

--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -60,13 +60,15 @@ class Expunger:
                     (charge.disposition.date + relativedelta(years=1), "Time-ineligible under 137.225(1)(b)")
                 )
 
-            if charge.convicted() and charge.case()().get_probation_revoked():
-                eligibility_dates.append(
-                    (
-                        charge.disposition.date + relativedelta(years=10),
-                        "Time-ineligible under 137.225(1)(c). See comments for when there are multiple convictions in a case.",
+            if charge.convicted():
+                probation_revoked_date = charge.case()().get_probation_revoked()
+                if probation_revoked_date:
+                    eligibility_dates.append(
+                        (
+                            probation_revoked_date + relativedelta(years=10),
+                            "Time-ineligible under 137.225(1)(c). Inspect further if the case has multiple convictions on the case.",
+                        )
                     )
-                )
 
             if most_recent_blocking_conviction:
                 eligibility_dates.append(

--- a/src/backend/expungeservice/models/case.py
+++ b/src/backend/expungeservice/models/case.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import datetime, date
+from datetime import datetime, date as date_class
 from typing import List, Optional
 
 from expungeservice.models.charge import Charge
@@ -12,13 +12,13 @@ class Case:
     case_number: str
     citation_number: str
     location: str
-    date: date
+    date: date_class
     violation_type: str
     current_status: str
     charges: List[Charge]
     case_detail_link: str
     __balance_due_in_cents: int = 0
-    __probation_revoked: bool = False
+    __probation_revoked: Optional[date_class] = None
 
     @staticmethod
     def create(info, case_number, citation_number, date_location, type_status, charges, case_detail_link, balance="0"):
@@ -43,10 +43,10 @@ class Case:
         case.set_balance_due(balance)
         return case
 
-    def get_probation_revoked(self) -> bool:
+    def get_probation_revoked(self) -> Optional[date_class]:
         return self.__probation_revoked
 
-    def set_probation_revoked(self, probation_revoked: bool):
+    def set_probation_revoked(self, probation_revoked: Optional[date_class]):
         self.__probation_revoked = probation_revoked
 
     def set_balance_due(self, balance_due_dollar_amount: str):

--- a/src/backend/tests/test_crawler_expunger.py
+++ b/src/backend/tests/test_crawler_expunger.py
@@ -195,7 +195,6 @@ def record_with_revoked_probation(crawler):
 def test_probation_revoked_affects_time_eligibility(record_with_revoked_probation):
     record = record_with_revoked_probation
     expunger = Expunger(record)
-    assert expunger.run()
-    print(record.cases[0].charges[0].expungement_result.time_eligibility.date_will_be_eligible)
 
+    assert expunger.run()
     assert record.cases[0].charges[0].expungement_result.time_eligibility.date_will_be_eligible == date_class(2020,11,9)


### PR DESCRIPTION
~~Assuming that convictions within the same case are processed around the same time, if we just assume that the probation revoked applies to all convictions, then the eligibility date of all charges are roughly the same as if the probation revoked only applied to a single conviction: because of the 10 year blocking rule for multiple convictions, the eligibility date of some charges will only be off by the difference in processing times.~~