### PR TITLE
Refactor RecordSummary to "has-a" Record

### DIFF
--- a/src/backend/expungeservice/crawler/crawler.py
+++ b/src/backend/expungeservice/crawler/crawler.py
@@ -19,7 +19,7 @@ class Crawler:
         self.response = requests.Response()
         self.result = RecordParser()
 
-    def login(self, username, password, close_session=False):
+    def login(self, username, password, close_session=False) -> bool:
         url = URL.login_url()
         payload = Payload.login_payload(username, password)
 
@@ -30,7 +30,7 @@ class Crawler:
 
         return Crawler.__login_validation(self.response, url)
 
-    def search(self, first_name, last_name, middle_name="", birth_date=""):
+    def search(self, first_name, last_name, middle_name="", birth_date="") -> Record:
         url = "https://publicaccess.courts.oregon.gov/PublicAccessLogin/Search.aspx?ID=100"
         node_response = self.__parse_nodes(url)
         payload = Crawler.__extract_payload(node_response, last_name, first_name, middle_name, birth_date)

--- a/src/backend/expungeservice/endpoints/search.py
+++ b/src/backend/expungeservice/endpoints/search.py
@@ -54,8 +54,8 @@ class Search(MethodView):
         except Exception as ex:
             logging.error("Saving search result failed with exception: %s" % ex, stack_info=True)
 
-        record.summary = RecordSummarizer.summarize(record)
-        response_data = {"data": {"record": record}}
+        record_summary = RecordSummarizer.summarize(record)
+        response_data = {"data": {"record": record_summary}}
 
         current_app.json_encoder = ExpungeModelEncoder
 

--- a/src/backend/expungeservice/models/helpers/record_summarizer.py
+++ b/src/backend/expungeservice/models/helpers/record_summarizer.py
@@ -48,7 +48,7 @@ class RecordSummarizer:
             "partially_eligible": partially_eligible_cases,
             "other": other_cases,
         }
-        county_balances_list : List[CountyBalance] = []
+        county_balances_list: List[CountyBalance] = []
         for county, balance in county_balances.items():
             county_balances_list.append(CountyBalance(county, round(balance, 2)))
         total_charges = len(record.charges)
@@ -58,6 +58,7 @@ class RecordSummarizer:
             if c.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.ELIGIBLE_NOW
         ]
         return RecordSummary(
+            record=record,
             cases_sorted=cases_sorted,
             eligible_charges=eligible_charges,
             total_charges=total_charges,

--- a/src/backend/expungeservice/models/record.py
+++ b/src/backend/expungeservice/models/record.py
@@ -3,15 +3,12 @@ from typing import List
 
 from expungeservice.models.case import Case
 from expungeservice.models.charge import Charge
-from expungeservice.models.record_summary import RecordSummary
 
 
 @dataclass
 class Record:
     cases: List[Case]
     errors: List[str] = field(default_factory=list)
-    summary: RecordSummary = RecordSummary(total_charges = 0, cases_sorted= {}, eligible_charges = [],
-    county_balances=[])
 
     @property
     def charges(self):

--- a/src/backend/expungeservice/models/record_summary.py
+++ b/src/backend/expungeservice/models/record_summary.py
@@ -3,6 +3,7 @@ from typing import List, Dict
 
 from expungeservice.models.case import Case
 from expungeservice.models.charge import Charge
+from expungeservice.models.record import Record
 
 
 @dataclass
@@ -10,8 +11,10 @@ class CountyBalance:
     county_name: str
     balance: float
 
+
 @dataclass
 class RecordSummary:
+    record: Record
     total_charges: int
     cases_sorted: Dict[str, List[str]]
     eligible_charges: List[str]


### PR DESCRIPTION
Similar to how Expunger.run works, the RecordSummary result previously mutated the Record object that was being built up. Up until now, we were trying to ignore this dangerous mutation but unfortunately it came to bite us back when we tried to add the alias feature: the test_search.py tests started failing mysteriously and it took a while to discover that we we're relying on `service.mock_record` to be mutated. What I mean here might be more clear with the alias feature PR that is upcoming. To prevent a similar surprise in the future, the RecordSummary now has a Record and Expunger.run is the only non-local mutation in the codebase again (`set_probation_revoked`/`set_balance_due` are also non-local mutations but are relatively benign).

`record_summary_to_json` now looks a bit ugly but that is to preserve current API exposed to the front-end: eventually we can refactor this to be a more natural representation and sync up the front-end.