### PR TITLE
Allow for aliases in search backend

### DIFF
--- a/src/backend/expungeservice/stats.py
+++ b/src/backend/expungeservice/stats.py
@@ -1,3 +1,5 @@
+import json
+
 from flask import g
 import uuid
 import hashlib
@@ -8,31 +10,18 @@ from flask_login import current_user
 
 
 def save_result(request_data, record):
-
     user_id = current_user.user_id
-
-    search_param_string = (
-        user_id
-        + request_data["first_name"]
-        + request_data["last_name"]
-        + request_data["middle_name"]
-        + request_data["birth_date"]
-    )
-
+    search_param_string = user_id + json.dumps(request_data["names"], sort_keys=True)
     hashed_search_params = hashlib.sha256(search_param_string.encode()).hexdigest()
-
     num_charges = len(record.charges)
-
     num_eligible_charges = len(
         [c for c in record.charges if c.expungement_result.type_eligibility.status == EligibilityStatus.ELIGIBLE]
     )
-
     _db_insert_result(g.database, user_id, hashed_search_params, num_charges, num_eligible_charges)
 
 
 @rollback_errors
 def _db_insert_result(database, user_id, hashed_search_params, num_charges, num_eligible_charges):
-
     database.cursor.execute(
         """
         INSERT INTO  SEARCH_RESULTS(search_result_id, user_id, hashed_search_params, num_charges, num_eligible_charges )

--- a/src/backend/tests/endpoints/test_search.py
+++ b/src/backend/tests/endpoints/test_search.py
@@ -20,10 +20,7 @@ def setup_and_teardown(service):
     service.crawler.logged_in = True
     service.mock_record = {"john_doe": CrawlerFactory.create(service.crawler)}
     service.search_request_data = {
-        "first_name": "John",
-        "last_name": "Doe",
-        "middle_name": "",
-        "birth_date": "02/02/1990",
+        "names": [{"first_name": "John", "last_name": "Doe", "middle_name": "", "birth_date": "02/02/1990"}]
     }
     yield
     service.teardown()

--- a/src/backend/tests/test_stats_save_result.py
+++ b/src/backend/tests/test_stats_save_result.py
@@ -22,10 +22,7 @@ def setup_and_teardown(service):
 def test_save_result(service):
     with service.client:
         request_data = {
-            "first_name": "John",
-            "last_name": "Doe",
-            "middle_name": "Test",
-            "birth_date": "01/01/1980",
+            "names": [{"first_name": "John", "last_name": "Doe", "middle_name": "Test", "birth_date": "01/01/1980",}]
         }
 
         record = CrawlerFactory.create(CrawlerFactory.setup())

--- a/src/frontend/src/redux/records/actions.ts
+++ b/src/frontend/src/redux/records/actions.ts
@@ -24,10 +24,9 @@ export function loadSearchRecords(
     return apiService<SearchResponse>(dispatch, {
       url: '/api/search',
       data: {
-        first_name: firstName,
-        middle_name: '',
-        last_name: lastName,
-        birth_date: birthday
+        names: [
+          {first_name: firstName, middle_name: '', last_name: lastName, birth_date: birthday}
+        ]
       },
       method: 'post',
       withCredentials: true


### PR DESCRIPTION
Resolves https://github.com/codeforpdx/recordexpungPDX/issues/724
Relative to #777 

Now by default, the search POST endpoint takes in a list of name objects, each of which contains a first/last/middle name and birth date. The stats module now uses the request_data["names"] as part of the search parameter string.