### PR TITLE
Add the middle name field for record search

### DIFF
--- a/src/frontend/src/components/RecordSearch/index.tsx
+++ b/src/frontend/src/components/RecordSearch/index.tsx
@@ -82,7 +82,7 @@ class RecordSearch extends React.Component<Props, State> {
         <h1 className="mb4 f4 fw6">Record Search</h1>
         <form onSubmit={this.handleSubmit} noValidate>
           <div className="flex flex-wrap items-end">
-            <div className="w-100 w-25-ns mb3 pr2-ns">
+            <div className="w-100 w-50-m w-25-ns mb3 pr2-ns">
               <label htmlFor="firstName" className="db mb1 fw6">
                 First Name
               </label>
@@ -98,7 +98,7 @@ class RecordSearch extends React.Component<Props, State> {
                 onChange={this.handleChange}
               />
             </div>
-            <div className="w-100 w-25-ns mb3 pr2-ns">
+            <div className="w-100 w-50-m w-25-ns mb3 pr2-ns">
               <label htmlFor="middleName" className="db mb1 ">
                 <span className= "fw6"> Middle Name </span> <span className= "fw1">(Optional) </span>
               </label>
@@ -110,7 +110,7 @@ class RecordSearch extends React.Component<Props, State> {
                 onChange={this.handleChange}
               />
             </div>
-            <div className="w-100 w-25-ns mb3 pr2-ns">
+            <div className="w-100 w-50-m w-25-ns mb3 pr2-ns">
               <label htmlFor="lastName" className="db mb1 fw6">
                 Last Name
               </label>
@@ -126,7 +126,7 @@ class RecordSearch extends React.Component<Props, State> {
                 onChange={this.handleChange}
               />
             </div>
-            <div className="w-100 w-25-ns mb3 pr2-ns">
+            <div className="w-100 w-50-m w-25-ns mb3 pr2-ns">
               <label htmlFor="dateOfBirth" className="db mb1 fw6">
                 Date of Birth <span className="fw2 f6">MM/DD/YYYY</span>
               </label>

--- a/src/frontend/src/components/RecordSearch/index.tsx
+++ b/src/frontend/src/components/RecordSearch/index.tsx
@@ -78,99 +78,109 @@ class RecordSearch extends React.Component<Props, State> {
 
   public render() {
     return (
+      // TODO: verify Tachyon differences btwn this section tag and <main> in prototype
       <section className="cf mt4 mb3 pa3 pa4-l bg-white shadow br3">
-        <h1 className="mb4 f4 fw6">Record Search</h1>
-        <form onSubmit={this.handleSubmit} noValidate>
-          <div className="flex flex-wrap items-end">
-            <div className="w-100 w-50-m w-25-ns mb3 pr2-ns">
-              <label htmlFor="firstName" className="db mb1 fw6">
-                First Name
-              </label>
-              <input
-                id="firstName"
-                type="text"
-                className="w-100 pa3 br2 b--black-20"
-                required
-                aria-describedby={
-                  this.state.firstNameHasInput ? 'name_msg' : undefined
-                }
-                aria-invalid={this.state.firstNameHasInput}
-                onChange={this.handleChange}
-              />
-            </div>
-            <div className="w-100 w-50-m w-25-ns mb3 pr2-ns">
-              <label htmlFor="middleName" className="db mb1 ">
-                <span className= "fw6"> Middle Name </span> <span className= "fw1">(Optional) </span>
-              </label>
-              <input
-                id="middleName"
-                type="text"
-                className="w-100 pa3 br2 b--black-20"
-                required
-                onChange={this.handleChange}
-              />
-            </div>
-            <div className="w-100 w-50-m w-25-ns mb3 pr2-ns">
-              <label htmlFor="lastName" className="db mb1 fw6">
-                Last Name
-              </label>
-              <input
-                id="lastName"
-                type="text"
-                className="w-100 pa3 br2 b--black-20"
-                required
-                aria-describedby={
-                  this.state.lastNameHasInput ? 'name_msg' : undefined
-                }
-                aria-invalid={this.state.lastNameHasInput}
-                onChange={this.handleChange}
-              />
-            </div>
-            <div className="w-100 w-50-m w-25-ns mb3 pr2-ns">
-              <label htmlFor="dateOfBirth" className="db mb1 fw6">
-                Date of Birth <span className="fw2 f6">MM/DD/YYYY</span>
-              </label>
-              <input
-                id="dateOfBirth"
-                type="text"
-                className="w-100 pa3 br2 b--black-20"
-                required
-                aria-describedby={
-                  this.state.invalidDate ? 'dob_msg' : undefined
-                }
-                aria-invalid={this.state.invalidDate}
-                onChange={this.handleChange}
-              />
-            </div>
+        <h1 className="f4 fw6 tc mv4">Record Search</h1>
+        <section className="cf mt4 mb3 pa4 bg-white shadow br3">
+          <form className="mw7 center" onSubmit={this.handleSubmit} noValidate>
+            <div className="flex flex-wrap items-end">
 
-            <div className="visually-hidden justify-between w-100 w-20-ns v-top">
-                <div className="mb3 mt2-ns">
-                  <button className="br2 bg-gray-blue-2 link hover-dark-blue mid-gray fw5 pv2 ph3 mt2">
-                    <i aria-hidden="true" className="fas fa-times-circle" />
-                    &nbsp;Remove
-                  </button>
-                </div>
+              <div className="w-100 w-third-ns w-25-l mb3">
+              { // TODO: abstract this div to a "Field" react component,
+                // to instance as First, middle, last name, and bday
+              }
+                <label htmlFor="firstName" className="db mb1 fw6">
+                  First Name
+                </label>
+                <input
+                  id="firstName"
+                  type="text"
+                  className="w-100 pa3 br2 b--black-20"
+                  required
+                  aria-describedby={
+                    this.state.firstNameHasInput ? 'name_msg' : undefined
+                  }
+                  aria-invalid={this.state.firstNameHasInput}
+                  onChange={this.handleChange}
+                />
+              </div>
+              <div className="w-100 w-third-ns w-25-l mb3">
+                <label htmlFor="middleName" className="db mb1 fw6">
+                  Middle Name<span className= "fw2 f6">(Optional) </span>
+                </label>
+                <input
+                  id="middleName"
+                  type="text"
+                  className="w-100 pa3 br2 b--black-20"
+                  required
+                  onChange={this.handleChange}
+                />
+              </div>
+              <div className="w-100 w-third-ns w-25-l mb3">
+                <label htmlFor="lastName" className="db mb1 fw6">
+                  Last Name
+                </label>
+                <input
+                  id="lastName"
+                  type="text"
+                  className="w-100 pa3 br2 b--black-20"
+                  required
+                  aria-describedby={
+                    this.state.lastNameHasInput ? 'name_msg' : undefined
+                  }
+                  aria-invalid={this.state.lastNameHasInput}
+                  onChange={this.handleChange}
+                />
+              </div>
+              <div className="w-100 w-third-ns w-25-l pl2-l mb3">
+                <label htmlFor="dateOfBirth" className="db mb1 fw6">
+                  Date of Birth <span className="fw2 f6">mm/dd/yyyy</span>
+                </label>
+                <input
+                  id="dateOfBirth"
+                  type="text"
+                  className="w-100 pa3 br2 b--black-20"
+                  required
+                  aria-describedby={
+                    this.state.invalidDate ? 'dob_msg' : undefined
+                  }
+                  aria-invalid={this.state.invalidDate}
+                  onChange={this.handleChange}
+                />
               </div>
 
-             <div className="visually-hidden justify-between w-100 w-two-thirds-ns">
-                <div className="mb3 mt2-ns">
-                  <button className="br2 bg-gray-blue-2 link hover-dark-blue mid-gray fw5 pv2 ph3 mt2 ml2">
-                    <i aria-hidden="true" className="fas fa-plus-circle" />
-                    &nbsp;Add alias
-                  </button>
-                </div>
+
+              <div className="flex items-center pb1 mb3 ml3-ns ml0-l">
+              { // TODO: keep the #-Results label and Remove buttons as "visually-hidden"
+                // until Aliases feature is complete.
+              }
+                <span className="fw5 bl bw2 b--blue bg-gray-blue-2 pa2 pr3 mr2 mb2">1 Result</span>
+                <button className="br2 bg-gray-blue-2 link hover-dark-blue mid-gray fw5 pa2 mb2">
+                  <i aria-hidden={"true"} className="fas fa-times-circle pr1"></i>Remove
+                </button>
+              </div>
               </div>
 
-            <div className="w-100 mb3">
-              <button
-                className="br2 bg-blue white bg-animate hover-bg-dark-blue db w-100 tc pv3 btn--search"
-                type="submit"
-              >
-                <span className="visually-hidden">Search Records</span>
+              {
+                // TODO: insert this when rendering additional Alias components.
+                //<hr className="ba b--white mt0 mb3" />
+              }
 
-                <i aria-hidden="true" className="fas fa-search" />
-              </button>
-            </div>
+              <div className="flex">
+              {  // Row containing The +Alias and search buttons.
+              }
+                <button className="w4 tc br2 bg-gray-blue-2 link hover-dark-blue mid-gray fw5 pv3 ph3 mr2">
+                {  // TODO: keep Alias button as "visually-hidden" until Aliases feature is complete.
+                }
+                  <i aria-hidden={"true"} className="fas fa-plus-circle pr1"></i>Alias
+
+                </button>
+                <button className="br2 bg-blue white bg-animate hover-bg-dark-blue db w-100 tc pv3 btn--search"  type="submit">
+                  <i aria-hidden="true" className="fas fa-search pr2"></i>
+                  <span className="fw7">Search</span>
+                </button>
+              </div>
+
             <div role="alert" className="w-100">
               {this.state.missingInputs === true ? (
                 <p id="name_msg" className="bg-washed-red mv4 pa3 br3 fw6">
@@ -183,8 +193,8 @@ class RecordSearch extends React.Component<Props, State> {
                 </p>
               ) : null}
             </div>
-          </div>
-        </form>
+          </form>
+        </section>
       </section>
     );
   }

--- a/src/frontend/src/components/RecordSearch/index.tsx
+++ b/src/frontend/src/components/RecordSearch/index.tsx
@@ -78,7 +78,6 @@ class RecordSearch extends React.Component<Props, State> {
 
   public render() {
     return (
-      // TODO: verify Tachyon differences btwn this section tag and <main> in prototype
       <div>
         <h1 className="f4 fw6 tc mv4">Record Search</h1>
         <section className="cf mt4 mb3 pa4 bg-white shadow br3">
@@ -148,8 +147,8 @@ class RecordSearch extends React.Component<Props, State> {
               </div>
 
 
-              <div className="flex items-center pb1 mb3 ml3-ns ml0-l">
-              { // TODO: keep the #-Results label and Remove buttons as "visually-hidden"
+              <div className="visually-hidden flex items-center pb1 mb3 ml3-ns ml0-l">
+              { // TODO: The #-Results label and Remove buttons are "visually-hidden"
                 // until Aliases feature is complete.
               }
                 <span className="fw5 bl bw2 b--blue bg-gray-blue-2 pa2 pr3 mr2 mb2">1 Result</span>
@@ -167,7 +166,7 @@ class RecordSearch extends React.Component<Props, State> {
               <div className="flex">
               {  // Row containing The +Alias and search buttons.
               }
-                <button className="w4 tc br2 bg-gray-blue-2 link hover-dark-blue mid-gray fw5 pv3 ph3 mr2">
+                <button className="visually-hidden w4 tc br2 bg-gray-blue-2 link hover-dark-blue mid-gray fw5 pv3 ph3 mr2">
                 {  // TODO: keep Alias button as "visually-hidden" until Aliases feature is complete.
                 }
                   <i aria-hidden={"true"} className="fas fa-plus-circle pr1"></i>Alias

--- a/src/frontend/src/components/RecordSearch/index.tsx
+++ b/src/frontend/src/components/RecordSearch/index.tsx
@@ -11,6 +11,7 @@ interface Props {
 
 interface State {
   firstName: string;
+  middleName: string;
   lastName: string;
   dateOfBirth: string;
   firstNameHasInput: boolean;
@@ -22,6 +23,7 @@ interface State {
 class RecordSearch extends React.Component<Props, State> {
   state: State = {
     firstName: '',
+    middleName: '',
     lastName: '', // Validation check relies on string length.
     dateOfBirth: '', // Moment expects a string to be passed in as a paramenter in the validateForm function.
     firstNameHasInput: false, // Initially set to false to ensure aria-invalid attribute is rendered.
@@ -48,9 +50,10 @@ class RecordSearch extends React.Component<Props, State> {
         // Dispatch an action.
         let state = this.state;
         let firstName = state.firstName;
+        let middleName = state.middleName;
         let lastName = state.lastName;
         let dateOfBirth = state.dateOfBirth.length > 0 ? state.dateOfBirth : '';
-        this.props.fetchRecords(firstName, lastName, dateOfBirth);
+        this.props.fetchRecords(firstName, middleName, lastName, dateOfBirth);
       }
     });
   };
@@ -79,7 +82,7 @@ class RecordSearch extends React.Component<Props, State> {
         <h1 className="mb4 f4 fw6">Record Search</h1>
         <form onSubmit={this.handleSubmit} noValidate>
           <div className="flex flex-wrap items-end">
-            <div className="w-100 w-30-ns mb3 pr2-ns">
+            <div className="w-100 w-25-ns mb3 pr2-ns">
               <label htmlFor="firstName" className="db mb1 fw6">
                 First Name
               </label>
@@ -95,7 +98,19 @@ class RecordSearch extends React.Component<Props, State> {
                 onChange={this.handleChange}
               />
             </div>
-            <div className="w-100 w-30-ns mb3 pr2-ns">
+            <div className="w-100 w-25-ns mb3 pr2-ns">
+              <label htmlFor="middleName" className="db mb1 ">
+                <span className= "fw6"> Middle Name </span> <span className= "fw1">(Optional) </span>
+              </label>
+              <input
+                id="middleName"
+                type="text"
+                className="w-100 pa3 br2 b--black-20"
+                required
+                onChange={this.handleChange}
+              />
+            </div>
+            <div className="w-100 w-25-ns mb3 pr2-ns">
               <label htmlFor="lastName" className="db mb1 fw6">
                 Last Name
               </label>
@@ -111,7 +126,7 @@ class RecordSearch extends React.Component<Props, State> {
                 onChange={this.handleChange}
               />
             </div>
-            <div className="w-100 w-30-ns mb3 pr2-ns">
+            <div className="w-100 w-25-ns mb3 pr2-ns">
               <label htmlFor="dateOfBirth" className="db mb1 fw6">
                 Date of Birth <span className="fw2 f6">MM/DD/YYYY</span>
               </label>
@@ -127,19 +142,39 @@ class RecordSearch extends React.Component<Props, State> {
                 onChange={this.handleChange}
               />
             </div>
-            <div className="w-100 w-10-ns mb3">
+
+            <div className="visually-hidden justify-between w-100 w-20-ns v-top">
+                <div className="mb3 mt2-ns">
+                  <button className="br2 bg-gray-blue-2 link hover-dark-blue mid-gray fw5 pv2 ph3 mt2">
+                    <i aria-hidden="true" className="fas fa-times-circle" />
+                    &nbsp;Remove
+                  </button>
+                </div>
+              </div>
+
+             <div className="visually-hidden justify-between w-100 w-two-thirds-ns">
+                <div className="mb3 mt2-ns">
+                  <button className="br2 bg-gray-blue-2 link hover-dark-blue mid-gray fw5 pv2 ph3 mt2 ml2">
+                    <i aria-hidden="true" className="fas fa-plus-circle" />
+                    &nbsp;Add alias
+                  </button>
+                </div>
+              </div>
+
+            <div className="w-100 mb3">
               <button
                 className="br2 bg-blue white bg-animate hover-bg-dark-blue db w-100 tc pv3 btn--search"
                 type="submit"
               >
                 <span className="visually-hidden">Search Records</span>
+
                 <i aria-hidden="true" className="fas fa-search" />
               </button>
             </div>
             <div role="alert" className="w-100">
               {this.state.missingInputs === true ? (
                 <p id="name_msg" className="bg-washed-red mv4 pa3 br3 fw6">
-                  All search fields are required.
+                  First and last name are required.
                 </p>
               ) : null}
               {this.state.invalidDate === true ? (

--- a/src/frontend/src/components/RecordSearch/index.tsx
+++ b/src/frontend/src/components/RecordSearch/index.tsx
@@ -79,7 +79,7 @@ class RecordSearch extends React.Component<Props, State> {
   public render() {
     return (
       // TODO: verify Tachyon differences btwn this section tag and <main> in prototype
-      <section className="cf mt4 mb3 pa3 pa4-l bg-white shadow br3">
+      <div>
         <h1 className="f4 fw6 tc mv4">Record Search</h1>
         <section className="cf mt4 mb3 pa4 bg-white shadow br3">
           <form className="mw7 center" onSubmit={this.handleSubmit}>
@@ -95,7 +95,7 @@ class RecordSearch extends React.Component<Props, State> {
                 <input
                   id="firstName"
                   type="text"
-                  className="w-100 pa3 br2 b--black-20"
+                  className="w-100 b--black-20 br2 br-0-ns br--left-ns pa3"
                   aria-describedby={
                     this.state.firstNameHasInput ? 'name_msg' : undefined
                   }
@@ -105,12 +105,12 @@ class RecordSearch extends React.Component<Props, State> {
               </div>
               <div className="w-100 w-third-ns w-25-l mb3">
                 <label htmlFor="middleName" className="db mb1 fw6">
-                  Middle Name<span className= "fw2 f6">(Optional) </span>
+                  Middle Name <span className= "fw2 f6">Optional</span>
                 </label>
                 <input
                   id="middleName"
                   type="text"
-                  className="w-100 pa3 br2 b--black-20"
+                  className="w-100 br2 br0-ns b--black-20 pa3"
                   onChange={this.handleChange}
                 />
               </div>
@@ -121,7 +121,7 @@ class RecordSearch extends React.Component<Props, State> {
                 <input
                   id="lastName"
                   type="text"
-                  className="w-100 pa3 br2 b--black-20"
+                  className="w-100 b--black-20 br2 bl-0-ns br--right-ns pa3"
                   aria-describedby={
                     this.state.lastNameHasInput ? 'name_msg' : undefined
                   }
@@ -191,7 +191,7 @@ class RecordSearch extends React.Component<Props, State> {
             </div>
           </form>
         </section>
-      </section>
+      </div>
     );
   }
 }

--- a/src/frontend/src/components/RecordSearch/index.tsx
+++ b/src/frontend/src/components/RecordSearch/index.tsx
@@ -82,7 +82,7 @@ class RecordSearch extends React.Component<Props, State> {
       <section className="cf mt4 mb3 pa3 pa4-l bg-white shadow br3">
         <h1 className="f4 fw6 tc mv4">Record Search</h1>
         <section className="cf mt4 mb3 pa4 bg-white shadow br3">
-          <form className="mw7 center" onSubmit={this.handleSubmit} noValidate>
+          <form className="mw7 center" onSubmit={this.handleSubmit}>
             <div className="flex flex-wrap items-end">
 
               <div className="w-100 w-third-ns w-25-l mb3">
@@ -96,7 +96,6 @@ class RecordSearch extends React.Component<Props, State> {
                   id="firstName"
                   type="text"
                   className="w-100 pa3 br2 b--black-20"
-                  required
                   aria-describedby={
                     this.state.firstNameHasInput ? 'name_msg' : undefined
                   }
@@ -112,7 +111,6 @@ class RecordSearch extends React.Component<Props, State> {
                   id="middleName"
                   type="text"
                   className="w-100 pa3 br2 b--black-20"
-                  required
                   onChange={this.handleChange}
                 />
               </div>
@@ -124,7 +122,6 @@ class RecordSearch extends React.Component<Props, State> {
                   id="lastName"
                   type="text"
                   className="w-100 pa3 br2 b--black-20"
-                  required
                   aria-describedby={
                     this.state.lastNameHasInput ? 'name_msg' : undefined
                   }
@@ -140,7 +137,6 @@ class RecordSearch extends React.Component<Props, State> {
                   id="dateOfBirth"
                   type="text"
                   className="w-100 pa3 br2 b--black-20"
-                  required
                   aria-describedby={
                     this.state.invalidDate ? 'dob_msg' : undefined
                   }

--- a/src/frontend/src/components/RecordSearch/index.tsx
+++ b/src/frontend/src/components/RecordSearch/index.tsx
@@ -82,7 +82,7 @@ class RecordSearch extends React.Component<Props, State> {
       <div>
         <h1 className="f4 fw6 tc mv4">Record Search</h1>
         <section className="cf mt4 mb3 pa4 bg-white shadow br3">
-          <form className="mw7 center" onSubmit={this.handleSubmit}>
+          <form className="mw7 center" onSubmit={this.handleSubmit} noValidate>
             <div className="flex flex-wrap items-end">
 
               <div className="w-100 w-third-ns w-25-l mb3">
@@ -96,6 +96,7 @@ class RecordSearch extends React.Component<Props, State> {
                   id="firstName"
                   type="text"
                   className="w-100 b--black-20 br2 br-0-ns br--left-ns pa3"
+                  required
                   aria-describedby={
                     this.state.firstNameHasInput ? 'name_msg' : undefined
                   }
@@ -122,6 +123,7 @@ class RecordSearch extends React.Component<Props, State> {
                   id="lastName"
                   type="text"
                   className="w-100 b--black-20 br2 bl-0-ns br--right-ns pa3"
+                  required
                   aria-describedby={
                     this.state.lastNameHasInput ? 'name_msg' : undefined
                   }

--- a/src/frontend/src/redux/records/actions.ts
+++ b/src/frontend/src/redux/records/actions.ts
@@ -14,6 +14,7 @@ function validateResponseData(data: SearchResponse): boolean {
 
 export function loadSearchRecords(
   firstName: string,
+  middleName: string,
   lastName: string,
   birthday: string
 ): any {
@@ -25,7 +26,7 @@ export function loadSearchRecords(
       url: '/api/search',
       data: {
         names: [
-          {first_name: firstName, middle_name: '', last_name: lastName, birth_date: birthday}
+          {first_name: firstName, middle_name: middleName, last_name: lastName, birth_date: birthday}
         ]
       },
       method: 'post',


### PR DESCRIPTION
I chose to keep all the search fields on one line despite the mockup change, since the fields are still plenty large enough when set to 25% width.

The button elements for add/remove extra aliases are included but hidden, since the formatting I used here is meant to account for the aliases feature.

A refactor to abstract out a `Field` component for the four fields is forthcoming.

Closes #726. Is a dependency for #722 