### PR TITLE
Provide multiple aliases in search

### DIFF
--- a/src/backend/expungeservice/endpoints/search.py
+++ b/src/backend/expungeservice/endpoints/search.py
@@ -23,10 +23,10 @@ class Search(MethodView):
     def post(self):
         request_data = request.get_json()
 
-        if request_data is None or not request_data.get("names"):
+        if request_data is None or not request_data.get("aliases"):
             error(400, "No json data in request body")
-
-        for alias in request_data["names"]:
+        check_data_fields(request_data, ["aliases"])
+        for alias in request_data["aliases"]:
             check_data_fields(alias, ["first_name", "last_name", "middle_name", "birth_date"])
 
         cipher = DataCipher(key=current_app.config.get("SECRET_KEY"))
@@ -46,7 +46,7 @@ class Search(MethodView):
             error(401, "Attempted login to OECI failed")
 
         cases: List[Case] = []
-        for alias in request_data["names"]:
+        for alias in request_data["aliases"]:
             cases += crawler.search(
                 alias["first_name"], alias["last_name"], alias["middle_name"], alias["birth_date"],
             ).cases

--- a/src/backend/expungeservice/endpoints/search.py
+++ b/src/backend/expungeservice/endpoints/search.py
@@ -36,17 +36,17 @@ class Search(MethodView):
 
         decrypted_credentials = cipher.decrypt(request.cookies["oeci_token"])
 
-        crawler = Crawler()
-
-        login_result = crawler.login(
-            decrypted_credentials["oeci_username"], decrypted_credentials["oeci_password"], close_session=False
-        )
-
-        if login_result is False:
-            error(401, "Attempted login to OECI failed")
-
         cases: List[Case] = []
         for alias in request_data["aliases"]:
+            crawler = Crawler()
+
+            login_result = crawler.login(
+                decrypted_credentials["oeci_username"], decrypted_credentials["oeci_password"], close_session=False
+            )
+
+            if login_result is False:
+                error(401, "Attempted login to OECI failed")
+
             cases += crawler.search(
                 alias["first_name"], alias["last_name"], alias["middle_name"], alias["birth_date"],
             ).cases

--- a/src/backend/expungeservice/stats.py
+++ b/src/backend/expungeservice/stats.py
@@ -11,7 +11,7 @@ from flask_login import current_user
 
 def save_result(request_data, record):
     user_id = current_user.user_id
-    search_param_string = user_id + json.dumps(request_data["names"], sort_keys=True)
+    search_param_string = user_id + json.dumps(request_data["aliases"], sort_keys=True)
     hashed_search_params = hashlib.sha256(search_param_string.encode()).hexdigest()
     num_charges = len(record.charges)
     num_eligible_charges = len(

--- a/src/backend/tests/endpoints/endpoint_util.py
+++ b/src/backend/tests/endpoints/endpoint_util.py
@@ -114,7 +114,7 @@ class EndpointShared:
     """
 
     def __hash_search_params(self, user_id, request_data):
-        search_param_string = user_id + json.dumps(request_data["names"], sort_keys=True)
+        search_param_string = user_id + json.dumps(request_data["aliases"], sort_keys=True)
         hashed_search_params = hashlib.sha256(search_param_string.encode()).hexdigest()
         return hashed_search_params
 

--- a/src/backend/tests/endpoints/test_search.py
+++ b/src/backend/tests/endpoints/test_search.py
@@ -20,7 +20,7 @@ def setup_and_teardown(service):
     service.crawler.logged_in = True
     service.mock_record = {"john_doe": CrawlerFactory.create(service.crawler)}
     service.search_request_data = {
-        "names": [{"first_name": "John", "last_name": "Doe", "middle_name": "", "birth_date": "02/02/1990"}]
+        "aliases": [{"first_name": "John", "last_name": "Doe", "middle_name": "", "birth_date": "02/02/1990"}]
     }
     yield
     service.teardown()

--- a/src/backend/tests/test_stats_save_result.py
+++ b/src/backend/tests/test_stats_save_result.py
@@ -22,7 +22,7 @@ def setup_and_teardown(service):
 def test_save_result(service):
     with service.client:
         request_data = {
-            "names": [{"first_name": "John", "last_name": "Doe", "middle_name": "Test", "birth_date": "01/01/1980",}]
+            "aliases": [{"first_name": "John", "last_name": "Doe", "middle_name": "Test", "birth_date": "01/01/1980",}]
         }
 
         record = CrawlerFactory.create(CrawlerFactory.setup())

--- a/src/frontend/src/components/RecordSearch/Alias.tsx
+++ b/src/frontend/src/components/RecordSearch/Alias.tsx
@@ -33,7 +33,7 @@ export default class Alias extends React.Component<Props, State> {
           name="firstName"
           label="First Name"
           content={this.props.aliasData.first_name}
-          coda=""
+          inputMarkup="br-0-ns br--left-ns"
           onChange = {(fieldValue: string) => {this.handleFieldChange("first_name", fieldValue)}}
           required={true}
           errorMessage="name_msg"
@@ -51,12 +51,13 @@ export default class Alias extends React.Component<Props, State> {
           name="lastName"
           label="Last Name"
           content={this.props.aliasData.last_name}
-          coda=""
+          inputMarkup="bl-0-ns br--right-ns "
           onChange = {(fieldValue: string) => {this.handleFieldChange("last_name", fieldValue)}}
           required={true}
           errorMessage="name_msg"
           />
         <Field
+          divMarkup="pl2-l"
           name="birthDate"
           label="Date of Birth"
           content={this.props.aliasData.birth_date}

--- a/src/frontend/src/components/RecordSearch/Alias.tsx
+++ b/src/frontend/src/components/RecordSearch/Alias.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { AliasType, AliasFieldNames } from './types';
+import Field from './Field';
+
+
+interface Props {
+  ind: number;
+  aliasData: AliasType;
+  onChange: Function; // requires 2 arguments: the fieldName and fieldValue
+  onRemoveClick: Function;
+  hideRemoveButton: boolean;
+}
+
+interface State {
+  firstNameHasInput: boolean;
+  lastNameHasInput: boolean;
+}
+
+export default class Alias extends React.Component<Props, State> {
+  state: State = {
+    firstNameHasInput: false, // Initially set to false to ensure aria-invalid attribute is rendered.
+    lastNameHasInput: false
+  }
+
+  handleFieldChange = (fieldName: AliasFieldNames, value: string) => {
+    this.props.onChange(fieldName, value);
+  };
+
+  render() {
+    return (
+      <div className="flex flex-wrap items-end">
+        <Field
+          name="firstName"
+          label="First Name"
+          content={this.props.aliasData.first_name}
+          coda=""
+          onChange = {(fieldValue: string) => {this.handleFieldChange("first_name", fieldValue)}}
+          required={true}
+          errorMessage="name_msg"
+          />
+        <Field
+          name="middleName"
+          label="Middle Name"
+          content={this.props.aliasData.middle_name}
+          coda="(Optional)"
+          onChange = {(fieldValue: string) => {this.handleFieldChange("middle_name", fieldValue)}}
+          required={false}
+          errorMessage="name_msg"
+          />
+        <Field
+          name="lastName"
+          label="Last Name"
+          content={this.props.aliasData.last_name}
+          coda=""
+          onChange = {(fieldValue: string) => {this.handleFieldChange("last_name", fieldValue)}}
+          required={true}
+          errorMessage="name_msg"
+          />
+        <Field
+          name="birthDate"
+          label="Date of Birth"
+          content={this.props.aliasData.birth_date}
+          coda="mm/dd/yyyy"
+          onChange = {(fieldValue: string) => {this.handleFieldChange("birth_date", fieldValue)}}
+          required={true}
+          errorMessage="dob_msg"
+          />
+        <div className={(this.props.hideRemoveButton ? "visually-hidden " : "" ) +
+        "flex items-center pb1 mb3 ml3-ns ml0-l"}>
+        { // TODO: The #-Results label and Remove buttons are "visually-hidden"
+          // until Aliases feature is complete.
+        }
+          <span className=" visually-hidden fw5 bl bw2 b--blue bg-gray-blue-2 pa2 pr3 mr2 mb2">1 Result</span>
+          <button
+            className="br2 bg-gray-blue-2 link hover-dark-blue mid-gray fw5 pa2 mb2"
+            onClick={() => {this.props.onRemoveClick()}}
+            type="button"
+          >
+
+            <i className="fas fa-times-circle pr1"></i>Remove
+            {// aria-hidden={"true"} this as a prop on the <i>?
+            }
+          </button>
+        </div>
+      </div>
+      )
+        // TODO: insert this when rendering additional Alias components.
+        //<hr className="ba b--white mt0 mb3" />
+        // wrapping the <div> and <hr> may require <></>
+  }
+}

--- a/src/frontend/src/components/RecordSearch/Alias.tsx
+++ b/src/frontend/src/components/RecordSearch/Alias.tsx
@@ -63,13 +63,13 @@ export default class Alias extends React.Component<Props, State> {
           content={this.props.aliasData.birth_date}
           coda="mm/dd/yyyy"
           onChange = {(fieldValue: string) => {this.handleFieldChange("birth_date", fieldValue)}}
-          required={true}
+          required={false}
           errorMessage="dob_msg"
           />
         <div className={(this.props.hideRemoveButton ? "visually-hidden " : "" ) +
         "flex items-center pb1 mb3 ml3-ns ml0-l"}>
-        { // TODO: The #-Results label and Remove buttons are "visually-hidden"
-          // until Aliases feature is complete.
+        { // TODO: The #-Results label is "visually-hidden" until we update the endpoint
+          // to support this feature.
         }
           <span className=" visually-hidden fw5 bl bw2 b--blue bg-gray-blue-2 pa2 pr3 mr2 mb2">1 Result</span>
           <button
@@ -85,8 +85,5 @@ export default class Alias extends React.Component<Props, State> {
         </div>
       </div>
       )
-        // TODO: insert this when rendering additional Alias components.
-        //<hr className="ba b--white mt0 mb3" />
-        // wrapping the <div> and <hr> may require <></>
   }
 }

--- a/src/frontend/src/components/RecordSearch/Field.tsx
+++ b/src/frontend/src/components/RecordSearch/Field.tsx
@@ -5,6 +5,8 @@ interface Props {
   label: string;
   content: string;
   coda: string;
+  divMarkup: string;
+  inputMarkup: string;
   onChange: Function; // arg: value
   errorMessage: string;
   required: boolean;
@@ -18,6 +20,11 @@ export default class Field extends React.Component<Props, State> {
   state: State = {
     hasInput: false
   }
+  public static defaultProps = {
+    coda: "",
+    divMarkup: "",
+    inputMarkup: ""
+    };
 
   handleInputChange = (e: React.BaseSyntheticEvent) => {
     let fieldContent : string = e.target.value
@@ -32,7 +39,7 @@ export default class Field extends React.Component<Props, State> {
 
   render() {
     return(
-      <div className="w-100 w-third-ns w-25-l mb3">
+      <div className={"w-100 w-third-ns w-25-l mb3 " + this.props.divMarkup}>
         <label htmlFor={this.props.name} className="db mb1 fw6">
           {this.props.label} <span className= "fw2 f6">{this.props.coda}</span>
         </label>
@@ -40,7 +47,7 @@ export default class Field extends React.Component<Props, State> {
           value={this.props.content}
           id={this.props.name}
           type="text"
-          className="w-100 b--black-20 br2 br-0-ns br--left-ns pa3"
+          className={"w-100 br2 b--black-20 pa3 " + this.props.inputMarkup}
           required
           aria-invalid={false} // this.state.firstNameHasInput}
           aria-describedby={

--- a/src/frontend/src/components/RecordSearch/Field.tsx
+++ b/src/frontend/src/components/RecordSearch/Field.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+interface Props {
+  name: string;
+  label: string;
+  content: string;
+  coda: string;
+  onChange: Function; // arg: value
+  errorMessage: string;
+  required: boolean;
+}
+
+interface State {
+  hasInput: boolean;
+}
+
+export default class Field extends React.Component<Props, State> {
+  state: State = {
+    hasInput: false
+  }
+
+  handleInputChange = (e: React.BaseSyntheticEvent) => {
+    let fieldContent : string = e.target.value
+    this.setState(
+      {
+        hasInput: fieldContent.length > 0
+      }
+      )
+
+    this.props.onChange(e.target.value);
+  };
+
+  render() {
+    return(
+      <div className="w-100 w-third-ns w-25-l mb3">
+        <label htmlFor={this.props.name} className="db mb1 fw6">
+          {this.props.label} <span className= "fw2 f6">{this.props.coda}</span>
+        </label>
+        <input
+          value={this.props.content}
+          id={this.props.name}
+          type="text"
+          className="w-100 b--black-20 br2 br-0-ns br--left-ns pa3"
+          required
+          aria-invalid={false} // this.state.firstNameHasInput}
+          aria-describedby={
+            this.props.required && this.state.hasInput ? this.props.errorMessage : undefined
+          }
+          onChange={this.handleInputChange}
+        />
+      </div>
+      )
+  }
+}

--- a/src/frontend/src/components/RecordSearch/Field.tsx
+++ b/src/frontend/src/components/RecordSearch/Field.tsx
@@ -38,8 +38,10 @@ export default class Field extends React.Component<Props, State> {
   };
 
   render() {
+    const sharedDivMarkup = "w-100 w-third-ns w-25-l mb3 ";
+    const sharedInputMarkup = "w-100 br2 b--black-20 pa3 ";
     return(
-      <div className={"w-100 w-third-ns w-25-l mb3 " + this.props.divMarkup}>
+      <div className={sharedDivMarkup + this.props.divMarkup}>
         <label htmlFor={this.props.name} className="db mb1 fw6">
           {this.props.label} <span className= "fw2 f6">{this.props.coda}</span>
         </label>
@@ -47,9 +49,9 @@ export default class Field extends React.Component<Props, State> {
           value={this.props.content}
           id={this.props.name}
           type="text"
-          className={"w-100 br2 b--black-20 pa3 " + this.props.inputMarkup}
-          required
-          aria-invalid={false} // this.state.firstNameHasInput}
+          className={sharedInputMarkup + this.props.inputMarkup}
+          required={this.props.required}
+          aria-invalid={this.state.hasInput}
           aria-describedby={
             this.props.required && this.state.hasInput ? this.props.errorMessage : undefined
           }

--- a/src/frontend/src/components/RecordSearch/index.tsx
+++ b/src/frontend/src/components/RecordSearch/index.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { AppState } from '../../redux/store';
 import { SystemState } from '../../redux/system/types';
+import { AliasType, AliasFieldNames } from './types';
 import moment from 'moment';
+import Alias from './Alias';
 
 interface Props {
   system: SystemState;
@@ -10,174 +12,124 @@ interface Props {
 }
 
 interface State {
-  firstName: string;
-  middleName: string;
-  lastName: string;
-  dateOfBirth: string;
-  firstNameHasInput: boolean;
-  lastNameHasInput: boolean;
+  aliases: AliasType[];
   missingInputs: null | boolean;
   invalidDate: boolean;
 }
 
 class RecordSearch extends React.Component<Props, State> {
   state: State = {
-    firstName: '',
-    middleName: '',
-    lastName: '', // Validation check relies on string length.
-    dateOfBirth: '', // Moment expects a string to be passed in as a paramenter in the validateForm function.
-    firstNameHasInput: false, // Initially set to false to ensure aria-invalid attribute is rendered.
-    lastNameHasInput: false,
+    aliases: [
+      {
+        first_name: '',
+        middle_name: '',
+        last_name: '',
+        birth_date: '',
+      },
+    ],
     missingInputs: null,
     invalidDate: false
-  };
-
-  handleChange = (e: React.BaseSyntheticEvent) => {
-    // See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/26635 for why we're
-    // using the "any" type.
-    this.setState<any>({
-      [e.target.id]: e.target.value
-    });
   };
 
   handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     this.validateForm().then(() => {
       if (
-        this.state.missingInputs === false &&
-        this.state.invalidDate === false
+        !this.state.missingInputs &&
+        !this.state.invalidDate
       ) {
-        // Dispatch an action.
-        let state = this.state;
-        let firstName = state.firstName;
-        let middleName = state.middleName;
-        let lastName = state.lastName;
-        let dateOfBirth = state.dateOfBirth.length > 0 ? state.dateOfBirth : '';
-        this.props.fetchRecords(
-          [{
-            first_name: firstName,
-            middle_name: middleName,
-            last_name: lastName,
-            birth_date: dateOfBirth
-          }]
-            );
+        this.props.fetchRecords( this.state.aliases);
       }
     });
   };
 
   validateForm = () => {
     return new Promise(resolve => {
+      let missingInputs : boolean = false;
+        for (let i : number = 0; i < this.state.aliases.length; i++) {
+          if (this.state.aliases[i].first_name.trim().length === 0 ||
+              this.state.aliases[i].last_name.trim().length === 0 ) {
+            missingInputs = true;
+            break;
+          }
+        }
       this.setState(
         {
-          firstNameHasInput: this.state.firstName.trim().length === 0,
-          lastNameHasInput: this.state.lastName.trim().length === 0,
-          missingInputs:
-            this.state.firstName.trim().length === 0 ||
-            this.state.lastName.trim().length === 0,
+          missingInputs: missingInputs,
           invalidDate:
-            moment(this.state.dateOfBirth, 'M/D/YYYY', true).isValid() ===
-              false && this.state.dateOfBirth.length !== 0
+            moment(this.state.aliases[0].birth_date, 'M/D/YYYY', true).isValid() ===
+              false && this.state.aliases[0].birth_date.length !== 0
         },
         resolve
       );
     });
   };
 
+  handleAliasContentChange = (ind: number, fieldName: AliasFieldNames, fieldValue: string) => {
+    let updated_aliases: AliasType[] = this.state.aliases;
+    updated_aliases[ind][fieldName] = fieldValue;
+
+    this.setState<any>({
+      aliases: updated_aliases
+    });
+
+  }
+
+  addAlias = () => {
+    let updatedAliases = this.state.aliases;
+    updatedAliases.push({
+        first_name: '',
+        middle_name: '',
+        last_name: '',
+        birth_date: ''
+      })
+    this.setState({aliases: updatedAliases})
+  }
+
+  handleAliasRemoveClick = (aliasIndex : number) => {
+    let updated_aliases: AliasType[] = this.state.aliases;
+    updated_aliases.splice(aliasIndex, 1);
+
+    this.setState<any>({
+      aliases: updated_aliases
+    });
+  }
+
   public render() {
+    const aliasComponents = this.state.aliases.map((alias: AliasType, i) => {
+      return (
+        <Alias
+          ind={i}
+          aliasData={alias}
+          onChange={
+            (fieldName: AliasFieldNames, fieldValue: string) => {
+              this.handleAliasContentChange(i, fieldName, fieldValue)
+            }
+          }
+          onRemoveClick={
+            () => {
+              this.handleAliasRemoveClick(i)
+            }
+          }
+          hideRemoveButton={this.state.aliases.length === 1}
+          key={"alias" + i}
+        />
+      );
+    });
     return (
       <div>
         <h1 className="f4 fw6 tc mv4">Record Search</h1>
         <section className="cf mt4 mb3 pa4 bg-white shadow br3">
           <form className="mw7 center" onSubmit={this.handleSubmit} noValidate>
-            <div className="flex flex-wrap items-end">
-
-              <div className="w-100 w-third-ns w-25-l mb3">
-              { // TODO: abstract this div to a "Field" react component,
-                // to instance as First, middle, last name, and bday
-              }
-                <label htmlFor="firstName" className="db mb1 fw6">
-                  First Name
-                </label>
-                <input
-                  id="firstName"
-                  type="text"
-                  className="w-100 b--black-20 br2 br-0-ns br--left-ns pa3"
-                  required
-                  aria-describedby={
-                    this.state.firstNameHasInput ? 'name_msg' : undefined
-                  }
-                  aria-invalid={this.state.firstNameHasInput}
-                  onChange={this.handleChange}
-                />
-              </div>
-              <div className="w-100 w-third-ns w-25-l mb3">
-                <label htmlFor="middleName" className="db mb1 fw6">
-                  Middle Name <span className= "fw2 f6">Optional</span>
-                </label>
-                <input
-                  id="middleName"
-                  type="text"
-                  className="w-100 br2 br0-ns b--black-20 pa3"
-                  onChange={this.handleChange}
-                />
-              </div>
-              <div className="w-100 w-third-ns w-25-l mb3">
-                <label htmlFor="lastName" className="db mb1 fw6">
-                  Last Name
-                </label>
-                <input
-                  id="lastName"
-                  type="text"
-                  className="w-100 b--black-20 br2 bl-0-ns br--right-ns pa3"
-                  required
-                  aria-describedby={
-                    this.state.lastNameHasInput ? 'name_msg' : undefined
-                  }
-                  aria-invalid={this.state.lastNameHasInput}
-                  onChange={this.handleChange}
-                />
-              </div>
-              <div className="w-100 w-third-ns w-25-l pl2-l mb3">
-                <label htmlFor="dateOfBirth" className="db mb1 fw6">
-                  Date of Birth <span className="fw2 f6">mm/dd/yyyy</span>
-                </label>
-                <input
-                  id="dateOfBirth"
-                  type="text"
-                  className="w-100 pa3 br2 b--black-20"
-                  aria-describedby={
-                    this.state.invalidDate ? 'dob_msg' : undefined
-                  }
-                  aria-invalid={this.state.invalidDate}
-                  onChange={this.handleChange}
-                />
-              </div>
-
-
-              <div className="visually-hidden flex items-center pb1 mb3 ml3-ns ml0-l">
-              { // TODO: The #-Results label and Remove buttons are "visually-hidden"
-                // until Aliases feature is complete.
-              }
-                <span className="fw5 bl bw2 b--blue bg-gray-blue-2 pa2 pr3 mr2 mb2">1 Result</span>
-                <button className="br2 bg-gray-blue-2 link hover-dark-blue mid-gray fw5 pa2 mb2">
-                  <i aria-hidden={"true"} className="fas fa-times-circle pr1"></i>Remove
-                </button>
-              </div>
-              </div>
-
-              {
-                // TODO: insert this when rendering additional Alias components.
-                //<hr className="ba b--white mt0 mb3" />
-              }
-
+              {aliasComponents}
               <div className="flex">
-              {  // Row containing The +Alias and search buttons.
+              {  // Row containing The +Alias and Search buttons.
               }
-                <button className="visually-hidden w4 tc br2 bg-gray-blue-2 link hover-dark-blue mid-gray fw5 pv3 ph3 mr2">
-                {  // TODO: keep Alias button as "visually-hidden" until Aliases feature is complete.
-                }
+                <button
+                  className="w4 tc br2 bg-gray-blue-2 link hover-dark-blue mid-gray fw5 pv3 ph3 mr2"
+                  onClick={() => {this.addAlias()}}
+                  type="button">
                   <i aria-hidden={"true"} className="fas fa-plus-circle pr1"></i>Alias
-
                 </button>
                 <button className="br2 bg-blue white bg-animate hover-bg-dark-blue db w-100 tc pv3 btn--search"  type="submit">
                   <i aria-hidden="true" className="fas fa-search pr2"></i>

--- a/src/frontend/src/components/RecordSearch/index.tsx
+++ b/src/frontend/src/components/RecordSearch/index.tsx
@@ -53,7 +53,14 @@ class RecordSearch extends React.Component<Props, State> {
         let middleName = state.middleName;
         let lastName = state.lastName;
         let dateOfBirth = state.dateOfBirth.length > 0 ? state.dateOfBirth : '';
-        this.props.fetchRecords(firstName, middleName, lastName, dateOfBirth);
+        this.props.fetchRecords(
+          [{
+            first_name: firstName,
+            middle_name: middleName,
+            last_name: lastName,
+            birth_date: dateOfBirth
+          }]
+            );
       }
     });
   };

--- a/src/frontend/src/components/RecordSearch/index.tsx
+++ b/src/frontend/src/components/RecordSearch/index.tsx
@@ -97,7 +97,10 @@ class RecordSearch extends React.Component<Props, State> {
 
   public render() {
     const aliasComponents = this.state.aliases.map((alias: AliasType, i) => {
+      const separator = ( i > 0 ? <hr className="bb b--black-05 mt2 mt3-ns mb3 mb4-ns" /> : null );
       return (
+        <>
+        {separator}
         <Alias
           ind={i}
           aliasData={alias}
@@ -114,6 +117,7 @@ class RecordSearch extends React.Component<Props, State> {
           hideRemoveButton={this.state.aliases.length === 1}
           key={"alias" + i}
         />
+        </>
       );
     });
     return (

--- a/src/frontend/src/components/RecordSearch/types.ts
+++ b/src/frontend/src/components/RecordSearch/types.ts
@@ -1,7 +1,8 @@
 export interface AliasType {
-  statute: string;
+  // this data structure is sent in the endpoint request, so it uses python's snake_case
   first_name: string;
   middle_name: string;
   last_name: string;
   birth_date: string;
 }
+export type AliasFieldNames = "first_name" | "middle_name" | "last_name" | "birth_date";

--- a/src/frontend/src/components/RecordSearch/types.ts
+++ b/src/frontend/src/components/RecordSearch/types.ts
@@ -1,0 +1,7 @@
+export interface AliasType {
+  statute: string;
+  first_name: string;
+  middle_name: string;
+  last_name: string;
+  birth_date: string;
+}

--- a/src/frontend/src/redux/records/actions.ts
+++ b/src/frontend/src/redux/records/actions.ts
@@ -7,16 +7,14 @@ import {
   SearchResponse,
   CLEAR_SEARCH_RECORDS
 } from './types';
+import {AliasType} from '../../components/RecordSearch/types'
 
 function validateResponseData(data: SearchResponse): boolean {
   return data.hasOwnProperty('data') && data.data.hasOwnProperty('record');
 }
 
 export function loadSearchRecords(
-  firstName: string,
-  middleName: string,
-  lastName: string,
-  birthday: string
+  aliases: AliasType[]
 ): any {
   return (dispatch: Dispatch) => {
     dispatch({
@@ -25,9 +23,7 @@ export function loadSearchRecords(
     return apiService<SearchResponse>(dispatch, {
       url: '/api/search',
       data: {
-        names: [
-          {first_name: firstName, middle_name: middleName, last_name: lastName, birth_date: birthday}
-        ]
+        aliases: aliases
       },
       method: 'post',
       withCredentials: true


### PR DESCRIPTION
(edited for latest commit)
This abstracts the main component in RecordSearch into the Field and Alias subcomponents .

The Object array of aliases data is still held in RecordSearch state, and it is synced with the input fields via nested react Props and chained clickHandler calls.

The +Alias and -Remove buttons are fully functional. Multiple alias search works end-to-end.

The backend Crawler().search() has interior side effects that make a second search() call break with a single crawler instance. Rather than fix this issue, I instance a new crawler for each alias search. The crawler needs a general overhaul for multiple alias but this works as is.

for testing: Good names to search for screwing around with the UI are 'a a' (firstname a, lastname a) and 'e e' (firstname e, lastname e) . They have short nonempty records. Convenient.

Todo: insert the `<hr>` element between Aliases when more than one is rendered.

Progress for #722 