### PR TITLE
Ensure that date will be eligible is always set

### DIFF
--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -49,7 +49,7 @@ class Expunger:
                     (charge.disposition.date + relativedelta(years=3), "Time-ineligible under 137.225(1)(a)")
                 )
             elif charge.acquitted():
-                eligibility_dates.append((charge.disposition.date, "Time eligible under 137.225(1)(b)"))
+                eligibility_dates.append((charge.date, "Time eligible under 137.225(1)(b)"))
             else:
                 raise ValueError("Charge should always convicted or acquitted at this point.")
 
@@ -110,12 +110,8 @@ class Expunger:
                     if (
                         charge.expungement_result.type_eligibility.status != EligibilityStatus.INELIGIBLE
                         and charge.acquitted()
-                        and (
-                            Expunger._is_newer(
-                                charge.expungement_result.time_eligibility.date_will_be_eligible,
-                                attractor.expungement_result.time_eligibility.date_will_be_eligible,
-                            )
-                        )
+                        and charge.expungement_result.time_eligibility.date_will_be_eligible
+                        >= attractor.expungement_result.time_eligibility.date_will_be_eligible
                     ):
                         charge.expungement_result.time_eligibility.status = (
                             attractor.expungement_result.time_eligibility.status
@@ -126,17 +122,6 @@ class Expunger:
                         charge.expungement_result.time_eligibility.reason = "The friendly rule: time eligibility of the arrest matches time eligibility of the conviction."
                         # TODO: Feels dangerous; clean up
         return len(open_cases) == 0
-
-    @staticmethod
-    def _is_newer(date, other_date):
-        if date and other_date:
-            return date >= other_date
-        elif date:
-            return True
-        elif other_date:
-            return False
-        else:
-            return False
 
     @staticmethod
     def _categorize_charges(charges):

--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -76,7 +76,9 @@ class Charge:
     def set_time_eligibility(self, eligibility_dates):
         date_will_be_eligible, reason = max(eligibility_dates)
         if date_will_be_eligible and date_class.today() >= date_will_be_eligible:
-            time_eligibility = TimeEligibility(status=EligibilityStatus.ELIGIBLE, reason="", date_will_be_eligible=None)
+            time_eligibility = TimeEligibility(
+                status=EligibilityStatus.ELIGIBLE, reason="", date_will_be_eligible=date_will_be_eligible
+            )
         else:
             time_eligibility = TimeEligibility(
                 status=EligibilityStatus.INELIGIBLE, reason=reason, date_will_be_eligible=date_will_be_eligible

--- a/src/backend/tests/test_friendly_rule.py
+++ b/src/backend/tests/test_friendly_rule.py
@@ -1,14 +1,38 @@
+from dateutil.relativedelta import relativedelta
+
 from expungeservice.expunger import Expunger
 from expungeservice.models.expungement_result import EligibilityStatus
 from expungeservice.models.record import Record
 from tests.factories.case_factory import CaseFactory
 from tests.factories.charge_factory import ChargeFactory
-from tests.factories.expunger_factory import ExpungerFactory
 from tests.time import Time
+from datetime import date
+
+
+def test_eligible_mrc_with_single_arrest():
+    three_yr_mrc = ChargeFactory.create(disposition=["Convicted", Time.THREE_YEARS_AGO])
+
+    arrest = ChargeFactory.create(disposition=["Dismissed", Time.THREE_YEARS_AGO])
+
+    case = CaseFactory.create()
+    case.charges = [three_yr_mrc, arrest]
+    record = Record([case])
+    expunger = Expunger(record)
+
+    expunger.run()
+    assert arrest.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert (
+        arrest.expungement_result.time_eligibility.reason
+        == "The friendly rule: time eligibility of the arrest matches time eligibility of the conviction."
+    )
+    assert arrest.expungement_result.time_eligibility.date_will_be_eligible == date.today()
+
+    assert three_yr_mrc.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert three_yr_mrc.expungement_result.time_eligibility.reason == ""
+    assert three_yr_mrc.expungement_result.time_eligibility.date_will_be_eligible == date.today()
 
 
 def test_arrest_is_unaffected_if_conviction_is_older():
-    # A single violation doesn't block other records, but it is still subject to the 3 year rule.
     violation_charge = ChargeFactory.create(
         level="Class A Violation", date=Time.TEN_YEARS_AGO, disposition=["Convicted", Time.LESS_THAN_THREE_YEARS_AGO]
     )
@@ -20,8 +44,38 @@ def test_arrest_is_unaffected_if_conviction_is_older():
     expunger.run()
 
     assert arrest.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert arrest.expungement_result.time_eligibility.date_will_be_eligible == None
+    assert arrest.expungement_result.time_eligibility.date_will_be_eligible == arrest.disposition.date
     assert arrest.expungement_result.time_eligibility.reason == ""
+
+
+def test_eligible_mrc_with_violation():
+    case = CaseFactory.create()
+
+    three_yr_mrc = ChargeFactory.create(case=case, disposition=["Convicted", Time.THREE_YEARS_AGO])
+
+    arrest = ChargeFactory.create(case=case, disposition=["Dismissed", Time.THREE_YEARS_AGO])
+
+    violation = ChargeFactory.create(level="Violation", case=case, disposition=["Convicted", Time.THREE_YEARS_AGO])
+
+    case.charges = [three_yr_mrc, arrest, violation]
+    record = Record([case])
+    expunger = Expunger(record)
+
+    expunger.run()
+    assert three_yr_mrc.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert three_yr_mrc.expungement_result.time_eligibility.reason == ""
+    assert three_yr_mrc.expungement_result.time_eligibility.date_will_be_eligible == date.today()
+
+    assert arrest.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert (
+        arrest.expungement_result.time_eligibility.reason
+        == "The friendly rule: time eligibility of the arrest matches time eligibility of the conviction."
+    )
+    assert arrest.expungement_result.time_eligibility.date_will_be_eligible == date.today()
+
+    assert violation.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert violation.expungement_result.time_eligibility.date_will_be_eligible == date.today() + relativedelta(years=7)
+    assert violation.expungement_result.time_eligibility.reason == "Time-ineligible under 137.225(7)(b)"
 
 
 def test_arrest_time_eligibility_is_set_to_older_violation():

--- a/src/backend/tests/test_friendly_rule.py
+++ b/src/backend/tests/test_friendly_rule.py
@@ -32,7 +32,7 @@ def test_eligible_mrc_with_single_arrest():
     assert three_yr_mrc.expungement_result.time_eligibility.date_will_be_eligible == date.today()
 
 
-def test_arrest_is_unaffected_if_conviction_is_older():
+def test_arrest_is_unaffected_if_conviction_eligibility_is_older():
     violation_charge = ChargeFactory.create(
         level="Class A Violation", date=Time.TEN_YEARS_AGO, disposition=["Convicted", Time.LESS_THAN_THREE_YEARS_AGO]
     )
@@ -44,7 +44,7 @@ def test_arrest_is_unaffected_if_conviction_is_older():
     expunger.run()
 
     assert arrest.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert arrest.expungement_result.time_eligibility.date_will_be_eligible == arrest.disposition.date
+    assert arrest.expungement_result.time_eligibility.date_will_be_eligible == arrest.date
     assert arrest.expungement_result.time_eligibility.reason == ""
 
 


### PR DESCRIPTION
Resolves https://github.com/codeforpdx/recordexpungPDX/issues/819

Previously if the date will be eligible was before today, we would just set it to None. While this is ok, it is more elegant to just set it to the appropriate past date as then we can analyze what would have happened if we tried to expunge it in the past. A bunch of tests that had set the date_will_be_eligible to None were then fixed. While fixing those tests, I noticed that we didn't use the arrest date but instead the disposition date as the starting point for calculating eligibility dates for the dismissals, and so that was taken care of. A previously skipped test related to the friendly rule was fixed and moved to the new test_friendly_rule.py. Since we don't have to worry about date_will_be_eligible being None, we can now use >= comparisons in the Expunger.