### PR TITLE
Windows setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 .env.test.local
 .env.production.local
 scrap.txt
+.editorconfig
 
 npm-debug.log*
 yarn-debug.log*

--- a/Makefile
+++ b/Makefile
@@ -38,62 +38,35 @@ dev_logs:
 	docker-compose -f docker-compose.dev.yml logs -f
 
 dev_psql:
-ifeq ($(OSFLAG), WIN32)
 	docker exec -ti $(shell docker ps -qf name=$(DB_CONTAINER_NAME)) psql -U postgres -d $(PGDATABASE)
-else
-	docker exec -ti $$(docker ps -qf name=$(DB_CONTAINER_NAME)) psql -U postgres -d $(PGDATABASE)
-endif
 
 bash_backend:
-ifeq ($(OSFLAG), WIN32)
 	docker exec -it $(shell docker ps -qf name=$(BACKEND_CONTAINER_NAME)) /bin/bash
-else
-	docker exec -it $$(docker ps -qf name=$(BACKEND_CONTAINER_NAME)) /bin/bash
-endif
 
 bash_frontend:
-ifeq ($(OSFLAG), WIN32)
 	docker exec -it $(shell docker ps -qf name=$(FRONTEND_CONTAINER_NAME)) /bin/bash
-else
-	docker exec -it $$(docker ps -qf name=$(FRONTEND_CONTAINER_NAME)) /bin/bash
-endif
+
+database_image:
+	docker build --no-cache -t $(STACK_NAME):database config/postgres -f config/postgres/Dockerfile.dev
+
+expungeservice_image:
+	docker build --no-cache -t $(STACK_NAME):expungeservice src/backend/ -f src/backend/Dockerfile.dev
 
 dblogs:
-ifeq ($(OSFLAG), WIN32)
 	docker logs --details -ft $(shell docker ps -qf name=$(DB_CONTAINER_NAME))
-else
-	docker logs --details -ft $$(docker ps -qf name=$(DB_CONTAINER_NAME))
-endif
 
 applogs:
-ifeq ($(OSFLAG), WIN32)
 	docker logs --details -ft $(shell docker ps -qf name=$(BACKEND_CONTAINER_NAME))
-else
-	docker logs --details -ft $$(docker ps -qf name=$(BACKEND_CONTAINER_NAME))
-endif
 
 weblogs:
-ifeq ($(OSFLAG), WIN32)
 	docker logs --details -ft $(shell docker ps -qf name=$(FRONTEND_CONTAINER_NAME))
-else
-	docker logs --details -ft $$(docker ps -qf name=$(FRONTEND_CONTAINER_NAME))
-endif
 
 dev_test:
-ifeq ($(OSFLAG), WIN32)
 	docker exec -t $(shell docker ps -qf name=$(BACKEND_CONTAINER_NAME)) mypy
 	docker exec -t $(shell docker ps -qf name=$(BACKEND_CONTAINER_NAME)) pytest
-else
-	docker exec -t $$(docker ps -qf name=$(BACKEND_CONTAINER_NAME)) mypy
-	docker exec -t $$(docker ps -qf name=$(BACKEND_CONTAINER_NAME)) pytest
-endif
 
 dev_drop_database:
-ifeq ($(OSFLAG), WIN32)
 	docker volume rm $(shell docker volume ls -qf name=$(STACK_NAME))
-else
-	docker volume rm $$(docker volume ls -qf name=$(STACK_NAME))
-endif
 
 dev_mock_oeci_up:
 	docker-compose -f docker-compose.dev.yml -f src/frontend/developerUtils/docker-compose.mock-oeci.yml up -d

--- a/Makefile
+++ b/Makefile
@@ -58,27 +58,6 @@ else
 	docker exec -it $$(docker ps -qf name=$(FRONTEND_CONTAINER_NAME)) /bin/bash
 endif
 
-database_image:
-	docker build --no-cache -t $(STACK_NAME):database config/postgres -f config/postgres/Dockerfile.dev
-
-expungeservice_image:
-	docker build --no-cache -t $(STACK_NAME):expungeservice src/backend/ -f src/backend/Dockerfile.dev
-
-
-# TODO - this doesn't work on Windows, and doesn't look like it works on Mac/Linux either
-# 	as the Dockerfile.dev is not present in the config/nginx folder
-webserver_image:
-ifeq ($(OSFLAG), WIN32)
-	if not exist .\config\nginx\frontend mkdir .\config\nginx\frontend
-	xcopy .\src\frontend\* .\config\nginx\frontend /s /e /h
-	docker build --no-cache -t $(STACK_NAME):webserver .\config\nginx -f .\config\nginx\Dockerfile.dev
-	del /s /q /f .\config\nginx\frontend
-else
-	cp -r src/frontend/ config/nginx/frontend
-	docker build --no-cache -t $(STACK_NAME):webserver config/nginx -f config/nginx/Dockerfile.dev
-	rm -rf config/nginx/frontend
-endif
-
 dblogs:
 ifeq ($(OSFLAG), WIN32)
 	docker logs --details -ft $(shell docker ps -qf name=$(DB_CONTAINER_NAME))

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 .PHONY: clean
 
-clean:
-	rm -rf src/backend/*.egg-info &
-	find . -type f -name \*~ | xargs rm &
-	find . -type f -name \*pyc | xargs rm
+OSFLAG 				:=
+ifeq ($(OS),Windows_NT)
+	OSFLAG = WIN32
+endif
 
 STACK_NAME := recordexpungpdx
 PGDATABASE := record_expunge
@@ -11,6 +11,16 @@ DB_CONTAINER_NAME := db
 BACKEND_CONTAINER_NAME := expungeservice
 FRONTEND_CONTAINER_NAME := webserver
 REQUIREMENTS_TXT := src/backend/requirements.txt
+
+
+clean:
+    ifeq ($(OSFLAG), WIN32)
+		Get-ChildItem ./src/backend/* -Include *.egg-info -Recurse | Remove-Item
+    else
+		rm -rf src/backend/*.egg-info &
+		find . -type f -name \*~ | xargs rm &
+		find . -type f -name \*pyc | xargs rm
+    endif
 
 dev: dev_up
 

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,27 @@
 .PHONY: clean
 
-OSFLAG 				:=
-ifeq ($(OS),Windows_NT)
-	OSFLAG = WIN32
-endif
-
 STACK_NAME := recordexpungpdx
 PGDATABASE := record_expunge
 DB_CONTAINER_NAME := db
 BACKEND_CONTAINER_NAME := expungeservice
 FRONTEND_CONTAINER_NAME := webserver
 REQUIREMENTS_TXT := src/backend/requirements.txt
+OSFLAG 	:=
+ifeq ($(OS),Windows_NT)
+	OSFLAG = WIN32
+endif
 
 
 clean:
-    ifeq ($(OSFLAG), WIN32)
-		Get-ChildItem ./src/backend/* -Include *.egg-info -Recurse | Remove-Item
-    else
-		rm -rf src/backend/*.egg-info &
-		find . -type f -name \*~ | xargs rm &
-		find . -type f -name \*pyc | xargs rm
-    endif
+ifeq ($(OSFLAG), WIN32)
+	del /s /q /f .\src\backend\*.egg-info -and \
+	del /s /q /f .\*pyc -and \
+	del /s /q /f .\*~
+else
+	rm -rf src/backend/*.egg-info &
+	find . -type f -name \*~ | xargs rm &
+	find . -type f -name \*pyc | xargs rm
+endif
 
 dev: dev_up
 
@@ -37,13 +38,25 @@ dev_logs:
 	docker-compose -f docker-compose.dev.yml logs -f
 
 dev_psql:
+ifeq ($(OSFLAG), WIN32)
+	docker exec -ti $(shell docker ps -qf name=$(DB_CONTAINER_NAME)) psql -U postgres -d $(PGDATABASE)
+else
 	docker exec -ti $$(docker ps -qf name=$(DB_CONTAINER_NAME)) psql -U postgres -d $(PGDATABASE)
+endif
 
 bash_backend:
+ifeq ($(OSFLAG), WIN32)
+	docker exec -it $(shell docker ps -qf name=$(BACKEND_CONTAINER_NAME)) /bin/bash
+else
 	docker exec -it $$(docker ps -qf name=$(BACKEND_CONTAINER_NAME)) /bin/bash
+endif
 
 bash_frontend:
+ifeq ($(OSFLAG), WIN32)
+	docker exec -it $(shell docker ps -qf name=$(FRONTEND_CONTAINER_NAME)) /bin/bash
+else
 	docker exec -it $$(docker ps -qf name=$(FRONTEND_CONTAINER_NAME)) /bin/bash
+endif
 
 database_image:
 	docker build --no-cache -t $(STACK_NAME):database config/postgres -f config/postgres/Dockerfile.dev
@@ -51,26 +64,57 @@ database_image:
 expungeservice_image:
 	docker build --no-cache -t $(STACK_NAME):expungeservice src/backend/ -f src/backend/Dockerfile.dev
 
+
+# TODO - this doesn't work on Windows, and doesn't look like it works on Mac/Linux either
+# 	as the Dockerfile.dev is not present in the config/nginx folder
 webserver_image:
+ifeq ($(OSFLAG), WIN32)
+	if not exist .\config\nginx\frontend mkdir .\config\nginx\frontend
+	xcopy .\src\frontend\* .\config\nginx\frontend /s /e /h
+	docker build --no-cache -t $(STACK_NAME):webserver .\config\nginx -f .\config\nginx\Dockerfile.dev
+	del /s /q /f .\config\nginx\frontend
+else
 	cp -r src/frontend/ config/nginx/frontend
 	docker build --no-cache -t $(STACK_NAME):webserver config/nginx -f config/nginx/Dockerfile.dev
 	rm -rf config/nginx/frontend
+endif
 
 dblogs:
+ifeq ($(OSFLAG), WIN32)
+	docker logs --details -ft $(shell docker ps -qf name=$(DB_CONTAINER_NAME))
+else
 	docker logs --details -ft $$(docker ps -qf name=$(DB_CONTAINER_NAME))
+endif
 
 applogs:
+ifeq ($(OSFLAG), WIN32)
+	docker logs --details -ft $(shell docker ps -qf name=$(BACKEND_CONTAINER_NAME))
+else
 	docker logs --details -ft $$(docker ps -qf name=$(BACKEND_CONTAINER_NAME))
+endif
 
 weblogs:
+ifeq ($(OSFLAG), WIN32)
+	docker logs --details -ft $(shell docker ps -qf name=$(FRONTEND_CONTAINER_NAME))
+else
 	docker logs --details -ft $$(docker ps -qf name=$(FRONTEND_CONTAINER_NAME))
+endif
 
 dev_test:
+ifeq ($(OSFLAG), WIN32)
+	docker exec -t $(shell docker ps -qf name=$(BACKEND_CONTAINER_NAME)) mypy
+	docker exec -t $(shell docker ps -qf name=$(BACKEND_CONTAINER_NAME)) pytest
+else
 	docker exec -t $$(docker ps -qf name=$(BACKEND_CONTAINER_NAME)) mypy
 	docker exec -t $$(docker ps -qf name=$(BACKEND_CONTAINER_NAME)) pytest
+endif
 
 dev_drop_database:
+ifeq ($(OSFLAG), WIN32)
+	docker volume rm $(shell docker volume ls -qf name=$(STACK_NAME))
+else
 	docker volume rm $$(docker volume ls -qf name=$(STACK_NAME))
+endif
 
 dev_mock_oeci_up:
 	docker-compose -f docker-compose.dev.yml -f src/frontend/developerUtils/docker-compose.mock-oeci.yml up -d

--- a/README.md
+++ b/README.md
@@ -49,7 +49,19 @@ You can get your dev environment up and running with installing only Docker and 
         - Configure your user to run docker without sudo: https://docs.docker.com/install/linux/linux-postinstall/
 
    * **Windows**
-        - Unfortunately, we don't have documentation to support development in Windows. If you use Windows, we'd love your contribution here!
+        - Windows (as always) is a bit more challenging. Docker CE on Windows requires Hyper-V support, which is only available on Windows 10 Pro, Enterprise, or Education.
+        If you have one of those versions, follow [Docker's documentation to install Docker Engine](https://docs.docker.com/docker-for-windows/install/).
+        - **If you have Hyper-V**:
+            - Install GNU Make for Windows using either [Chocolatey](https://chocolatey.org/) or by downloading the executable
+        [from sourceforge](http://gnuwin32.sourceforge.net/packages/make.htm), running the installer, and then putting the 
+        binary on your [Path Environment variable](https://helpdeskgeek.com/windows-10/add-windows-path-environment-variable/).
+        - **If you have Windows 10 Community, Home, or other versions**, [create a Linux VM using VirtualBox and run Docker Engine](https://www.sitepoint.com/docker-windows-10-home/) 
+        through there.  Alternately, you could partition your hard drive [and dual-boot Linux to use for development](https://opensource.com/article/18/5/dual-boot-linux).
+        ##### Important Note 
+        if your git config changes [Linux-style line endings into windows-style line endings](http://www.cs.toronto.edu/~krueger/csc209h/tut/line-endings.html)
+        using the `core.autocrlf` config flag, you'll need to disable that in order for the docker builds to work 
+        correctly.  You can disable this setting for just the `recordexpungPDX` repo by running `git config --local core.autocrlf false`
+        from the root directory of this repo.
 
 3. Install [docker-compose](https://docs.docker.com/compose/install/)
 


### PR DESCRIPTION
Added a setup for docker and expung dev on Windows.  

Question: There are many things within the makefile which won't run on windows because they are specific to *nix-style commands.  example:

```
clean:
	rm -rf src/backend/*.egg-info &
	find . -type f -name \*~ | xargs rm &
	find . -type f -name \*pyc | xargs rm
```

Windows doesn't know about `xargs`, and Powershell aliases `rm` is to `Remove-Item`, which has different parameters/options to Unix's `rm`.  So many of these will have to be either rewritten to be cross-platform or conditionally checked for OS using something like: 

```
OSFLAG :=
ifeq ($(OS),Windows_NT)
	OSFLAG = WIN32
endif
```

Is this something worth focusing on?