### PR TITLE
Parking tickets and traffic violation cases hidden from Summary display

### DIFF
--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -73,6 +73,9 @@ class Charge:
     def blocks_other_charges(self):
         return True
 
+    def hidden_in_record_summary(self):
+        return False
+
     def set_time_eligibility(self, eligibility_dates):
         date_will_be_eligible, reason = max(eligibility_dates)
         if date_will_be_eligible and date_class.today() >= date_will_be_eligible:

--- a/src/backend/expungeservice/models/charge_types/parking_ticket.py
+++ b/src/backend/expungeservice/models/charge_types/parking_ticket.py
@@ -22,3 +22,6 @@ class ParkingTicket(Charge):
 
     def blocks_other_charges(self):
         return False
+
+    def hidden_in_record_summary(self):
+        return True

--- a/src/backend/expungeservice/models/charge_types/traffic_violation.py
+++ b/src/backend/expungeservice/models/charge_types/traffic_violation.py
@@ -16,3 +16,6 @@ class TrafficViolation(Charge):
 
     def blocks_other_charges(self):
         return False
+
+    def hidden_in_record_summary(self):
+        return True

--- a/src/backend/expungeservice/models/helpers/record_summarizer.py
+++ b/src/backend/expungeservice/models/helpers/record_summarizer.py
@@ -35,6 +35,7 @@ class RecordSummarizer:
             elif all(
                 [
                     c.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.INELIGIBLE
+                    and not c.hidden_in_record_summary()
                     for c in case.charges
                 ]
             ):

--- a/src/frontend/src/components/RecordSummary/CasesSummary.tsx
+++ b/src/frontend/src/components/RecordSummary/CasesSummary.tsx
@@ -12,7 +12,7 @@ export default class CasesSummary extends React.Component<Props> {
         <h3 className="bt b--light-gray pt2 mb3"><span className="fw7">Cases</span> {this.props.totalCases}</h3>
         <CaseNumbersList cases={this.props.casesSorted["fully_eligible"]} title={"Cases eligible now"} subheading={""} color = "green"/>
         <CaseNumbersList cases={this.props.casesSorted["partially_eligible"]} title={"Cases partially eligible"} subheading={""} color = "green"/>
-        <CaseNumbersList cases={this.props.casesSorted["fully_ineligible"]} title={"Cases ineligible"} subheading={"Excludes parking tickets"} color = "red"/>
+        <CaseNumbersList cases={this.props.casesSorted["fully_ineligible"]} title={"Cases ineligible"} subheading={"Excludes traffic violations, which are always ineligible"} color = "red"/>
       </div>
       )
     }


### PR DESCRIPTION
These types are excluded because they're always ineligible, uninteresting, and they clutter the summary list.

This uses a new method on Charge type `hidden_from_record_summary()`, which defaults to `False` for most charge types, so the main work is done in the backend summarizer code.

Updates the subheader on the list of ineligible cases to clarify the new behavior. Parking violations are a subset of traffic violations, so the subheader names only traffic violations.

closes #810 