### PR TITLE
Remove acquittal language

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ You can get your dev environment up and running with installing only Docker and 
         binary on your [Path Environment variable](https://helpdeskgeek.com/windows-10/add-windows-path-environment-variable/).
         - **If you have Windows 10 Community, Home, or other versions**, [create a Linux VM using VirtualBox and run Docker Engine](https://www.sitepoint.com/docker-windows-10-home/) 
         through there.  Alternately, you could partition your hard drive [and dual-boot Linux to use for development](https://opensource.com/article/18/5/dual-boot-linux).
-        ##### Important Note 
-        if your git config changes [Linux-style line endings into windows-style line endings](http://www.cs.toronto.edu/~krueger/csc209h/tut/line-endings.html)
-        using the `core.autocrlf` config flag, you'll need to disable that in order for the docker builds to work 
-        correctly.  You can disable this setting for just the `recordexpungPDX` repo by running `git config --local core.autocrlf false`
-        from the root directory of this repo.
+        -   ##### Important Windows Note 
+            if your git config changes [Linux-style line endings into windows-style line endings](http://www.cs.toronto.edu/~krueger/csc209h/tut/line-endings.html)
+            using the `core.autocrlf` config flag, you'll need to disable that in order for the docker builds to work 
+            correctly.  You can disable this setting for just the `recordexpungPDX` repo by running `git config --local core.autocrlf false`
+            from the root directory of this repo.
 
 ## Running the docker stack
 

--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -48,10 +48,10 @@ class Expunger:
                 eligibility_dates.append(
                     (charge.disposition.date + relativedelta(years=3), "Time-ineligible under 137.225(1)(a)")
                 )
-            elif charge.acquitted():
+            elif charge.dismissed():
                 eligibility_dates.append((charge.disposition.date, "Time eligible under 137.225(1)(b)"))
             else:
-                raise ValueError("Charge should always convicted or acquitted at this point.")
+                raise ValueError("Charge should always convicted or dismissed at this point.")
 
             if charge.expungement_result.type_eligibility.status == EligibilityStatus.INELIGIBLE:
                 eligibility_dates.append((date.max, "Never. Type ineligible charges are always time ineligible."))
@@ -69,7 +69,7 @@ class Expunger:
                     )
                 )
 
-            if charge.acquitted() and most_recent_blocking_dismissal:
+            if charge.dismissed() and most_recent_blocking_dismissal:
                 eligibility_dates.append(
                     (most_recent_blocking_dismissal.date + relativedelta(years=3), "Recommend sequential expungement")
                 )
@@ -109,7 +109,7 @@ class Expunger:
                 for charge in case.charges:
                     if (
                         charge.expungement_result.type_eligibility.status != EligibilityStatus.INELIGIBLE
-                        and charge.acquitted()
+                        and charge.dismissed()
                         and (
                             Expunger._is_newer(
                                 charge.expungement_result.time_eligibility.date_will_be_eligible,
@@ -140,22 +140,22 @@ class Expunger:
 
     @staticmethod
     def _categorize_charges(charges):
-        acquittals, convictions = [], []
+        dismissals, convictions = [], []
         for charge in charges:
-            if charge.acquitted():
-                acquittals.append(charge)
+            if charge.dismissed():
+                dismissals.append(charge)
             elif charge.convicted():
                 convictions.append(charge)
             else:
-                raise ValueError("Charge should always convicted or acquitted at this point.")
-        return acquittals, convictions
+                raise ValueError("Charge should always convicted or dismissed at this point.")
+        return dismissals, convictions
 
     @staticmethod
-    def _most_recent_different_case_dismissal(charge, acquittals):
-        different_case_acquittals = [c for c in acquittals if c.case()() != charge.case()()]
-        different_case_acquittals.sort(key=lambda charge: charge.date)
-        if different_case_acquittals and different_case_acquittals[-1].recent_acquittal():
-            return different_case_acquittals[-1]
+    def _most_recent_different_case_dismissal(charge, dismissals):
+        different_case_dismissals = [c for c in dismissals if c.case()() != charge.case()()]
+        different_case_dismissals.sort(key=lambda charge: charge.date)
+        if different_case_dismissals and different_case_dismissals[-1].recent_dismissal():
+            return different_case_dismissals[-1]
         else:
             return None
 
@@ -171,7 +171,7 @@ class Expunger:
     @staticmethod
     def _calculate_has_subsequent_charge(class_b_felony: Charge, other_charges: List[Charge]) -> bool:
         for other_charge in other_charges:
-            if other_charge.acquitted():
+            if other_charge.dismissed():
                 date_of_other_charge = other_charge.date
             else:
                 date_of_other_charge = other_charge.disposition.date  # type: ignore
@@ -182,7 +182,7 @@ class Expunger:
 
     @staticmethod
     def _without_skippable_charges(charges: Iterator[Charge]):
-        return [charge for charge in charges if charge.disposition and (charge.convicted() or charge.acquitted())]
+        return [charge for charge in charges if charge.disposition and (charge.convicted() or charge.dismissed())]
 
     @staticmethod
     def _build_disposition_errors(charges: List[Charge]):

--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -51,10 +51,9 @@ class Charge:
     def case(self):
         return self._case
 
-    def acquitted(self):
-        # TODO: rename this method and related variables to "dismissed" or similar
-        acquittal_statuses = [DispositionStatus.NO_COMPLAINT, DispositionStatus.DISMISSED, DispositionStatus.DIVERTED]
-        return self.disposition and self.disposition.status in acquittal_statuses
+    def dismissed(self):
+        dismissal_status = [DispositionStatus.NO_COMPLAINT, DispositionStatus.DISMISSED, DispositionStatus.DIVERTED]
+        return self.disposition and self.disposition.status in dismissal_status
 
     def convicted(self):
         return self.disposition and self.disposition.status == DispositionStatus.CONVICTED
@@ -66,9 +65,9 @@ class Charge:
         else:
             return False
 
-    def recent_acquittal(self):
+    def recent_dismissal(self):
         three_years_ago = date_class.today() + relativedelta(years=-3)
-        return self.acquitted() and self.date > three_years_ago
+        return self.dismissed() and self.date > three_years_ago
 
     def blocks_other_charges(self):
         return True

--- a/src/backend/expungeservice/models/charge_types/felony_class_a.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_a.py
@@ -9,7 +9,7 @@ class FelonyClassA(Charge):
     type_name: str = "Felony Class A"
 
     def _default_type_eligibility(self):
-        if self.acquitted():
+        if self.dismissed():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.225(1)(b)")
         else:
             return TypeEligibility(EligibilityStatus.INELIGIBLE, reason="Ineligible under 137.225(5)")

--- a/src/backend/expungeservice/models/charge_types/felony_class_b.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_b.py
@@ -21,7 +21,7 @@ Applicable subsections: 137.225(5)(a) for convictions; 137.225(5)(a) for dismiss
     )
 
     def _default_type_eligibility(self):
-        if self.acquitted():
+        if self.dismissed():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.225(1)(b)")
         else:
             return TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, reason="Further Analysis Needed")

--- a/src/backend/expungeservice/models/charge_types/felony_class_c.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_c.py
@@ -9,7 +9,7 @@ class FelonyClassC(Charge):
     type_name: str = "Felony Class C"
 
     def _default_type_eligibility(self):
-        if self.acquitted():
+        if self.dismissed():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.225(1)(b)")
         else:
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.225(5)(b)")

--- a/src/backend/expungeservice/models/charge_types/marijuana_ineligible.py
+++ b/src/backend/expungeservice/models/charge_types/marijuana_ineligible.py
@@ -9,7 +9,7 @@ class MarijuanaIneligible(Charge):
     type_name: str = "Marijuana Ineligible"
 
     def _default_type_eligibility(self):
-        if self.acquitted():
+        if self.dismissed():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.225(1)(b)")
         else:
             return TypeEligibility(EligibilityStatus.INELIGIBLE, reason="Ineligible under 137.226")

--- a/src/backend/expungeservice/models/charge_types/misdemeanor.py
+++ b/src/backend/expungeservice/models/charge_types/misdemeanor.py
@@ -9,7 +9,7 @@ class Misdemeanor(Charge):
     type_name: str = "Misdemeanor"
 
     def _default_type_eligibility(self):
-        if self.acquitted():
+        if self.dismissed():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.225(1)(b)")
         else:
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.225(5)(b)")

--- a/src/backend/expungeservice/models/charge_types/non_traffic_violation.py
+++ b/src/backend/expungeservice/models/charge_types/non_traffic_violation.py
@@ -9,7 +9,7 @@ class NonTrafficViolation(Charge):
     type_name: str = "Non-traffic Violation"
 
     def _default_type_eligibility(self):
-        if self.acquitted():
+        if self.dismissed():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.225(1)(b)")
         else:
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.225(5)(d)")

--- a/src/backend/expungeservice/models/charge_types/parking_ticket.py
+++ b/src/backend/expungeservice/models/charge_types/parking_ticket.py
@@ -17,7 +17,7 @@ class ParkingTicket(Charge):
     def _default_type_eligibility(self):
         if self.convicted():
             return TypeEligibility(EligibilityStatus.INELIGIBLE, reason="Ineligible under 137.225(7)(a)")
-        elif self.acquitted():
+        elif self.dismissed():
             return TypeEligibility(EligibilityStatus.INELIGIBLE, reason="Ineligible by omission from statute")
 
     def blocks_other_charges(self):

--- a/src/backend/expungeservice/models/charge_types/person_crime.py
+++ b/src/backend/expungeservice/models/charge_types/person_crime.py
@@ -9,7 +9,7 @@ class PersonCrime(Charge):
     type_name: str = "Person Crime"
 
     def _default_type_eligibility(self):
-        if self.acquitted():
+        if self.dismissed():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.225(1)(b)")
         else:
             return TypeEligibility(EligibilityStatus.INELIGIBLE, reason="Ineligible under 137.225(5)")

--- a/src/backend/expungeservice/models/charge_types/schedule_1_p_c_s.py
+++ b/src/backend/expungeservice/models/charge_types/schedule_1_p_c_s.py
@@ -9,7 +9,7 @@ class Schedule1PCS(Charge):
     type_name: str = "Schedule 1 PCS"
 
     def _default_type_eligibility(self):
-        if self.acquitted():
+        if self.dismissed():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.225(1)(b)")
         else:
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.225(5)(C)")

--- a/src/backend/expungeservice/models/charge_types/subsection_12.py
+++ b/src/backend/expungeservice/models/charge_types/subsection_12.py
@@ -15,7 +15,7 @@ Applicable subsections: 137.225(12) for convictions; 137.225(1)(b) for dismissal
     )
 
     def _default_type_eligibility(self):
-        if self.acquitted():
+        if self.dismissed():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Dismissal eligible under 137.225(1)(b)")
         else:
             if self.statute == "163525":

--- a/src/backend/expungeservice/models/charge_types/subsection_6.py
+++ b/src/backend/expungeservice/models/charge_types/subsection_6.py
@@ -20,7 +20,7 @@ Applicable subsections: 137.225(6) for convictions; 137.225(1)(b) for dismissals
     )
 
     def _default_type_eligibility(self):
-        if self.acquitted():
+        if self.dismissed():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Dismissal eligible under 137.225(1)(b)")
         else:
             return TypeEligibility(

--- a/src/backend/expungeservice/models/charge_types/traffic_non_violation.py
+++ b/src/backend/expungeservice/models/charge_types/traffic_non_violation.py
@@ -9,7 +9,7 @@ class TrafficNonViolation(Charge):
     type_name: str = "Traffic Non-Violation"
 
     def _default_type_eligibility(self):
-        if self.acquitted():
+        if self.dismissed():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Dismissal eligible under 137.225(1)(b)")
         else:
             return TypeEligibility(EligibilityStatus.INELIGIBLE, reason="Ineligible under 137.225(7)(a)")

--- a/src/backend/expungeservice/models/charge_types/traffic_violation.py
+++ b/src/backend/expungeservice/models/charge_types/traffic_violation.py
@@ -9,7 +9,7 @@ class TrafficViolation(Charge):
     type_name: str = "Traffic Violation"
 
     def _default_type_eligibility(self):
-        if self.acquitted():
+        if self.dismissed():
             return TypeEligibility(EligibilityStatus.INELIGIBLE, reason="Ineligible by omission from statute")
         else:
             return TypeEligibility(EligibilityStatus.INELIGIBLE, reason="Ineligible under 137.225(7)(a)")

--- a/src/backend/tests/models/charge_types/test_subsection_12.py
+++ b/src/backend/tests/models/charge_types/test_subsection_12.py
@@ -19,7 +19,7 @@ class TestSubsection12(unittest.TestCase):
     def create_recent_charge(self):
         return ChargeFactory.save(self.charge_dict)
 
-    def test_subsection_12_acquitted(self):
+    def test_subsection_12_dismissed(self):
         self.charge_dict["name"] = "Abandonment of a child"
         self.charge_dict["statute"] = "163.535"
         self.charge_dict["level"] = "Felony Class C"

--- a/src/backend/tests/models/charge_types/test_type_analyzer_dismissed_charges.py
+++ b/src/backend/tests/models/charge_types/test_type_analyzer_dismissed_charges.py
@@ -22,11 +22,11 @@ class TestSingleChargeAcquittals(unittest.TestCase):
         self.single_charge["name"] = "Assault in the first degree"
         self.single_charge["statute"] = "163.185"
         self.single_charge["level"] = "Felony Class A"
-        felony_class_a_acquitted = self.create_recent_charge()
-        self.charges.append(felony_class_a_acquitted)
+        felony_class_a_dismissed = self.create_recent_charge()
+        self.charges.append(felony_class_a_dismissed)
 
-        assert felony_class_a_acquitted.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
-        assert felony_class_a_acquitted.expungement_result.type_eligibility.reason == "Eligible under 137.225(1)(b)"
+        assert felony_class_a_dismissed.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+        assert felony_class_a_dismissed.expungement_result.type_eligibility.reason == "Eligible under 137.225(1)(b)"
 
 
 class TestSingleChargeDismissals(unittest.TestCase):

--- a/src/backend/tests/models/charge_types/test_type_analyzer_duii.py
+++ b/src/backend/tests/models/charge_types/test_type_analyzer_duii.py
@@ -14,12 +14,12 @@ def build_charge(statute, disposition_ruling):
     return ChargeFactory.save(charge)
 
 
-def test_duii_acquitted():
-    duii_acquitted = build_charge(statute="813.010", disposition_ruling="Acquitted")
+def test_duii_dismissed():
+    duii_dismissed = build_charge(statute="813.010", disposition_ruling="Acquitted")
 
-    assert duii_acquitted.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert duii_dismissed.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert (
-        duii_acquitted.expungement_result.type_eligibility.reason
+        duii_dismissed.expungement_result.type_eligibility.reason
         == "Further Analysis Needed - Dismissed charge may have been Diverted"
     )
 

--- a/src/backend/tests/models/test_charge.py
+++ b/src/backend/tests/models/test_charge.py
@@ -59,23 +59,23 @@ class TestChargeClass(unittest.TestCase):
 
         assert charge.recent_conviction() is False
 
-    def test_most_recent_acquittal_happy_path(self):
+    def test_most_recent_dismissal_happy_path(self):
         charge = ChargeFactory.create(date=self.LESS_THAN_THREE_YEARS_AGO)
         charge.disposition = Disposition(date=self.LESS_THAN_THREE_YEARS_AGO, ruling="Dismissed")
 
-        assert charge.recent_acquittal() is True
+        assert charge.recent_dismissal() is True
 
-    def test_most_recent_acquittal_sad_path(self):
+    def test_most_recent_dismissal_sad_path(self):
         charge = ChargeFactory.create(date=self.THREE_YEARS_AGO)
         charge.disposition = Disposition(date=self.THREE_YEARS_AGO, ruling="Dismissed")
 
-        assert charge.recent_acquittal() is False
+        assert charge.recent_dismissal() is False
 
-    def test_convicted_charge_is_not_a_recent_acquittal(self):
+    def test_convicted_charge_is_not_a_recent_dismissal(self):
         charge = ChargeFactory.create(date=self.LESS_THAN_THREE_YEARS_AGO)
         charge.disposition = Disposition(date=self.LESS_THAN_THREE_YEARS_AGO, ruling="Convicted")
 
-        assert charge.recent_acquittal() is False
+        assert charge.recent_dismissal() is False
 
     def test_same_charge_is_not_equal(self):
         case = CaseFactory.create(case_number="C0000")

--- a/src/backend/tests/models/test_disposition_status.py
+++ b/src/backend/tests/models/test_disposition_status.py
@@ -25,7 +25,7 @@ def test_disposition_status_values():
     assert Disposition(today, "What is this?").status == DispositionStatus.UNRECOGNIZED
 
 
-def test_all_disposition_statuses_are_either_convicted_or_acquitted():
+def test_all_disposition_statuses_are_either_convicted_or_dismissed():
 
     charge = ChargeFactory.create()
     today = date.today()
@@ -37,18 +37,18 @@ def test_all_disposition_statuses_are_either_convicted_or_acquitted():
 
         if status == DispositionStatus.UNRECOGNIZED:
             assert not charge.convicted()
-            assert not charge.acquitted()
+            assert not charge.dismissed()
 
         else:
             # Make sure that every DispositionStatus value is covered by this approach.
             assert charge.disposition.status == status
-            assert charge.convicted() or charge.acquitted()
+            assert charge.convicted() or charge.dismissed()
 
 
-def test_dispositionless_charge_is_not_convicted_nor_acquitted():
+def test_dispositionless_charge_is_not_convicted_nor_dismissed():
     charge = ChargeFactory.create()
     assert not charge.convicted()
-    assert not charge.acquitted()
+    assert not charge.dismissed()
     assert charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert charge.expungement_result.type_eligibility.reason == "Disposition not found. Needs further analysis"
 
@@ -56,6 +56,6 @@ def test_dispositionless_charge_is_not_convicted_nor_acquitted():
 def test_charge_with_unrecognized_disposition_eligibility():
     charge = ChargeFactory.create(disposition=["What am I", date(2001, 1, 1)])
     assert not charge.convicted()
-    assert not charge.acquitted()
+    assert not charge.dismissed()
     assert charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert charge.expungement_result.type_eligibility.reason == "Disposition not recognized. Needs further analysis"

--- a/src/backend/tests/test_crawler_expunger.py
+++ b/src/backend/tests/test_crawler_expunger.py
@@ -135,9 +135,9 @@ def record_with_various_categories(crawler):
 
 
 def test_expunger_categorizes_charges(record_with_various_categories):
-    acquittals, convictions = Expunger._categorize_charges(record_with_various_categories.charges)
+    dismissals, convictions = Expunger._categorize_charges(record_with_various_categories.charges)
 
-    assert len(acquittals) == 5
+    assert len(dismissals) == 5
     assert len(convictions) == 4
 
 

--- a/src/backend/tests/test_time_analyzer.py
+++ b/src/backend/tests/test_time_analyzer.py
@@ -13,7 +13,7 @@ from tests.factories.expunger_factory import ExpungerFactory
 from tests.time import Time
 
 
-class TestSingleChargeAcquittals(unittest.TestCase):
+class TestSingleChargeDismissals(unittest.TestCase):
     def setUp(self):
         self.expunger = ExpungerFactory.create()
 
@@ -414,7 +414,7 @@ def test_felony_class_b_with_prior_conviction():
     assert b_felony_charge.expungement_result.time_eligibility.reason == ""
 
 
-def test_acquitted_felony_class_b_with_subsequent_conviction():
+def test_dismissed_felony_class_b_with_subsequent_conviction():
     b_felony_charge = create_class_b_felony_charge(Time.LESS_THAN_TWENTY_YEARS_AGO, "Dismissed")
     case_1 = CaseFactory.create()
     case_1.charges = [b_felony_charge]


### PR DESCRIPTION
changing internal language to dismissed from acquitted.  Left a few instances of "acquit" in there, such as in `src/backend/tests/models/charge_types/test_type_analyzer_dismissed_charges.py`, where it is specifically checking for "acquitted" language being returned from search.