### PR TITLE
Refactor ChargeFactory.create to always take date and Disposition

### DIFF
--- a/src/backend/tests/factories/charge_factory.py
+++ b/src/backend/tests/factories/charge_factory.py
@@ -12,13 +12,9 @@ class ChargeFactory:
             "name": "Theft of services",
             "statute": "164.125",
             "level": "Misdemeanor Class A",
-            "date": "1/1/0001",
+            "date": date_class(1901, 1, 1),
             "disposition": disposition,
         }
-
-    @staticmethod
-    def save(charge):
-        return ChargeCreator.create(**charge)
 
     @staticmethod
     def create(
@@ -26,18 +22,22 @@ class ChargeFactory:
         name="Theft of services",
         statute="164.125",
         level="Misdemeanor Class A",
-        date=date_class(1901, 1, 1),
-        disposition=None,
+        date: date_class = None,
+        disposition: Disposition = None,
     ):
-        if disposition:
-            ruling, date = disposition
-            disposition = Disposition(date=date, ruling=ruling)
+        if disposition and not date:
+            date_string = disposition.date.strftime("%m/%d/%Y")
+        elif date:
+            date_string = date.strftime("%m/%d/%Y")
+        else:
+            date_string = "1/1/1901"
+
         kwargs = {
             "case": case,
             "name": name,
             "statute": statute,
             "level": level,
-            "date": date.strftime("%m/%d/%Y"),
+            "date": date_string,
             "disposition": disposition,
         }
 

--- a/src/backend/tests/factories/charge_factory.py
+++ b/src/backend/tests/factories/charge_factory.py
@@ -6,7 +6,7 @@ from tests.factories.case_factory import CaseFactory
 
 class ChargeFactory:
     @staticmethod
-    def build(disposition=None):
+    def default_dict(disposition=None):
         return {
             "case": CaseFactory.create(),
             "name": "Theft of services",

--- a/src/backend/tests/models/charge_types/test_civil_offense.py
+++ b/src/backend/tests/models/charge_types/test_civil_offense.py
@@ -1,6 +1,7 @@
 import unittest
 from datetime import date, datetime, timedelta
 
+from expungeservice.models.disposition import Disposition
 from expungeservice.models.expungement_result import EligibilityStatus
 from expungeservice.models.charge_types.civil_offense import CivilOffense
 
@@ -10,8 +11,8 @@ from tests.factories.charge_factory import ChargeFactory
 class TestCivilOffense(unittest.TestCase):
     def setUp(self):
         last_week = datetime.today() - timedelta(days=7)
-        self.convicted = ["Convicted", last_week]
-        self.dismissed = ["Dismissed", last_week]
+        self.convicted = Disposition(ruling="Convicted", date=last_week)
+        self.dismissed = Disposition(ruling="Dismissed", date=last_week)
 
     def test_00_is_not_a_civil_offense(self):
         charge = ChargeFactory.create(statute="00", level="N/A", disposition=self.convicted)

--- a/src/backend/tests/models/charge_types/test_juvenile_charge.py
+++ b/src/backend/tests/models/charge_types/test_juvenile_charge.py
@@ -12,7 +12,9 @@ from tests.factories.charge_factory import ChargeFactory
 class TestJuvenileCharge(unittest.TestCase):
     def test_juvenile_charge(self):
         case = CaseFactory.create(type_status=["Juvenile Delinquency: Misdemeanor", "Closed"])
-        juvenile_charge = ChargeFactory.create(case=case, disposition=("Acquitted", date(2001, 1, 1)))
+        juvenile_charge = ChargeFactory.create(
+            case=case, disposition=Disposition(ruling="Acquitted", date=date(2001, 1, 1))
+        )
 
         assert juvenile_charge.__class__.__name__ == "JuvenileCharge"
         assert juvenile_charge.type_name == "Juvenile"

--- a/src/backend/tests/models/charge_types/test_parking_ticket.py
+++ b/src/backend/tests/models/charge_types/test_parking_ticket.py
@@ -11,7 +11,7 @@ from tests.factories.case_factory import CaseFactory
 
 class TestParkingTicket(unittest.TestCase):
     def setUp(self):
-        self.charge_dict = ChargeFactory.build()
+        self.charge_dict = ChargeFactory.default_dict()
         case = CaseFactory.create(type_status=["Municipal Parking", "Closed"])
         self.charge_dict["statute"] = "109"
         self.charge_dict["case"] = case

--- a/src/backend/tests/models/charge_types/test_parking_ticket.py
+++ b/src/backend/tests/models/charge_types/test_parking_ticket.py
@@ -1,6 +1,7 @@
 import unittest
 from datetime import datetime, timedelta
 
+from expungeservice.models.disposition import Disposition
 from expungeservice.models.expungement_result import EligibilityStatus
 from expungeservice.models.charge_types.parking_ticket import ParkingTicket
 
@@ -16,8 +17,8 @@ class TestParkingTicket(unittest.TestCase):
         self.charge_dict["case"] = case
         self.charge_dict["level"] = "Violation Unclassified"
         last_week = datetime.today() - timedelta(days=7)
-        self.convicted = ["Convicted", last_week]
-        self.dismissed = ["Dismissed", last_week]
+        self.convicted = Disposition(ruling="Convicted", date=last_week)
+        self.dismissed = Disposition(ruling="Dismissed", date=last_week)
 
     def test_parking_ticket_conviction(self):
         self.charge_dict["disposition"] = self.convicted

--- a/src/backend/tests/models/charge_types/test_subsection_12.py
+++ b/src/backend/tests/models/charge_types/test_subsection_12.py
@@ -17,7 +17,7 @@ class TestSubsection12(unittest.TestCase):
         self.charge_dict["disposition"] = Disposition(ruling="Convicted", date=last_week)
 
     def create_recent_charge(self):
-        return ChargeFactory.save(self.charge_dict)
+        return ChargeFactory.create(**self.charge_dict)
 
     def test_subsection_12_dismissed(self):
         self.charge_dict["name"] = "Abandonment of a child"

--- a/src/backend/tests/models/charge_types/test_subsection_12.py
+++ b/src/backend/tests/models/charge_types/test_subsection_12.py
@@ -13,7 +13,7 @@ class TestSubsection12(unittest.TestCase):
     def setUp(self):
         last_week = datetime.today() - timedelta(days=7)
         self.dismissal = Disposition(ruling="Dismissed", date=last_week)
-        self.charge_dict = ChargeFactory.build()
+        self.charge_dict = ChargeFactory.default_dict()
         self.charge_dict["disposition"] = Disposition(ruling="Convicted", date=last_week)
 
     def create_recent_charge(self):

--- a/src/backend/tests/models/charge_types/test_subsection_6.py
+++ b/src/backend/tests/models/charge_types/test_subsection_6.py
@@ -17,7 +17,7 @@ class TestSubsection6(unittest.TestCase):
         self.charge_dict["disposition"] = Disposition(ruling="Convicted", date=last_week)
 
     def create_recent_charge(self):
-        return ChargeFactory.save(self.charge_dict)
+        return ChargeFactory.create(**self.charge_dict)
 
     def test_subsection_6_dismissed(self):
         self.charge_dict["name"] = "Criminal mistreatment in the second degree"

--- a/src/backend/tests/models/charge_types/test_subsection_6.py
+++ b/src/backend/tests/models/charge_types/test_subsection_6.py
@@ -13,7 +13,7 @@ class TestSubsection6(unittest.TestCase):
     def setUp(self):
         last_week = datetime.today() - timedelta(days=7)
         self.dismissal = Disposition(ruling="Dismissed", date=last_week)
-        self.charge_dict = ChargeFactory.build()
+        self.charge_dict = ChargeFactory.default_dict()
         self.charge_dict["disposition"] = Disposition(ruling="Convicted", date=last_week)
 
     def create_recent_charge(self):

--- a/src/backend/tests/models/charge_types/test_traffic_offenses.py
+++ b/src/backend/tests/models/charge_types/test_traffic_offenses.py
@@ -24,11 +24,11 @@ class TestTrafficViolation(unittest.TestCase):
         self.single_charge = ChargeFactory.build()
         self.charges = []
         last_week = datetime.today() - timedelta(days=7)
-        self.convicted = ["Convicted", last_week]
-        self.dismissed = ["Dismissed", last_week]
+        self.convicted = Disposition(ruling="Convicted", date=last_week)
+        self.dismissed = Disposition(ruling="Dismissed", date=last_week)
 
     def create_recent_charge(self):
-        charge = ChargeFactory.save(self.single_charge)
+        charge = ChargeFactory.create(**self.single_charge)
         last_week = datetime.today() - timedelta(days=7)
         charge.disposition = Disposition(ruling="Convicted", date=last_week)
         return charge
@@ -94,8 +94,8 @@ class TestTrafficNonViolation(unittest.TestCase):
 
     def setUp(self):
         last_week = datetime.today() - timedelta(days=7)
-        self.convicted = ["Convicted", last_week]
-        self.dismissed = ["Dismissed", last_week]
+        self.convicted = Disposition(ruling="Convicted", date=last_week)
+        self.dismissed = Disposition(ruling="Dismissed", date=last_week)
 
     def test_misdemeanor_conviction_is_not_eligible(self):
         charge = ChargeFactory.create(statute="814.010(4)", level="Misdemeanor Class A", disposition=self.convicted)

--- a/src/backend/tests/models/charge_types/test_traffic_offenses.py
+++ b/src/backend/tests/models/charge_types/test_traffic_offenses.py
@@ -21,7 +21,7 @@ from expungeservice.models.disposition import Disposition
 
 class TestTrafficViolation(unittest.TestCase):
     def setUp(self):
-        self.single_charge = ChargeFactory.build()
+        self.single_charge = ChargeFactory.default_dict()
         self.charges = []
         last_week = datetime.today() - timedelta(days=7)
         self.convicted = Disposition(ruling="Convicted", date=last_week)

--- a/src/backend/tests/models/charge_types/test_type_analyzer_convicted_charges.py
+++ b/src/backend/tests/models/charge_types/test_type_analyzer_convicted_charges.py
@@ -11,7 +11,7 @@ from expungeservice.models.disposition import Disposition
 class TestSingleChargeConvictions(unittest.TestCase):
     def setUp(self):
         last_week = datetime.today() - timedelta(days=7)
-        self.single_charge = ChargeFactory.build(disposition=Disposition(ruling="Convicted", date=last_week))
+        self.single_charge = ChargeFactory.default_dict(disposition=Disposition(ruling="Convicted", date=last_week))
         self.charges = []
 
     def create_recent_charge(self):
@@ -351,7 +351,7 @@ class TestMultipleCharges(unittest.TestCase):
     def setUp(self):
         last_week = datetime.today() - timedelta(days=7)
         disposition = Disposition(ruling="Convicted", date=last_week)
-        self.charge = ChargeFactory.build(disposition=disposition)
+        self.charge = ChargeFactory.default_dict(disposition=disposition)
         self.charges = []
 
     def create_charge(self):

--- a/src/backend/tests/models/charge_types/test_type_analyzer_convicted_charges.py
+++ b/src/backend/tests/models/charge_types/test_type_analyzer_convicted_charges.py
@@ -15,7 +15,7 @@ class TestSingleChargeConvictions(unittest.TestCase):
         self.charges = []
 
     def create_recent_charge(self):
-        charge = ChargeFactory.save(self.single_charge)
+        charge = ChargeFactory.create(**self.single_charge)
         return charge
 
     def test_felony_class_a_charge(self):
@@ -355,7 +355,7 @@ class TestMultipleCharges(unittest.TestCase):
         self.charges = []
 
     def create_charge(self):
-        charge = ChargeFactory.save(self.charge)
+        charge = ChargeFactory.create(**self.charge)
         return charge
 
     def test_two_charges(self):

--- a/src/backend/tests/models/charge_types/test_type_analyzer_dismissed_charges.py
+++ b/src/backend/tests/models/charge_types/test_type_analyzer_dismissed_charges.py
@@ -16,7 +16,7 @@ class TestSingleChargeAcquittals(unittest.TestCase):
         self.charges = []
 
     def create_recent_charge(self):
-        return ChargeFactory.save(self.single_charge)
+        return ChargeFactory.create(**self.single_charge)
 
     def test_felony_class_a_charge(self):
         self.single_charge["name"] = "Assault in the first degree"
@@ -37,7 +37,7 @@ class TestSingleChargeDismissals(unittest.TestCase):
         self.charges = []
 
     def create_recent_charge(self):
-        return ChargeFactory.save(self.single_charge)
+        return ChargeFactory.create(**self.single_charge)
 
     def test_felony_class_a_charge(self):
         self.single_charge["name"] = "Assault in the first degree"
@@ -73,7 +73,7 @@ class TestSingleChargeNoComplaint(unittest.TestCase):
         self.charges = []
 
     def create_recent_charge(self):
-        return ChargeFactory.save(self.single_charge)
+        return ChargeFactory.create(**self.single_charge)
 
     def test_felony_class_a_charge(self):
         self.single_charge["name"] = "Assault in the first degree"

--- a/src/backend/tests/models/charge_types/test_type_analyzer_dismissed_charges.py
+++ b/src/backend/tests/models/charge_types/test_type_analyzer_dismissed_charges.py
@@ -11,7 +11,7 @@ from expungeservice.models.disposition import Disposition
 class TestSingleChargeAcquittals(unittest.TestCase):
     def setUp(self):
         last_week = datetime.today() - timedelta(days=7)
-        self.single_charge = ChargeFactory.build()
+        self.single_charge = ChargeFactory.default_dict()
         self.single_charge["disposition"] = Disposition(ruling="Acquitted", date=last_week)
         self.charges = []
 
@@ -32,7 +32,7 @@ class TestSingleChargeAcquittals(unittest.TestCase):
 class TestSingleChargeDismissals(unittest.TestCase):
     def setUp(self):
         last_week = datetime.today() - timedelta(days=7)
-        self.single_charge = ChargeFactory.build()
+        self.single_charge = ChargeFactory.default_dict()
         self.single_charge["disposition"] = Disposition(ruling="Dismissed", date=last_week)
         self.charges = []
 
@@ -68,7 +68,7 @@ class TestSingleChargeDismissals(unittest.TestCase):
 class TestSingleChargeNoComplaint(unittest.TestCase):
     def setUp(self):
         last_week = datetime.today() - timedelta(days=7)
-        self.single_charge = ChargeFactory.build()
+        self.single_charge = ChargeFactory.default_dict()
         self.single_charge["disposition"] = Disposition(date=last_week, ruling="No Complaint")
         self.charges = []
 

--- a/src/backend/tests/models/charge_types/test_type_analyzer_duii.py
+++ b/src/backend/tests/models/charge_types/test_type_analyzer_duii.py
@@ -8,7 +8,7 @@ from expungeservice.models.disposition import Disposition
 
 def build_charge(statute, disposition_ruling):
     last_week = datetime.today() - timedelta(days=7)
-    charge = ChargeFactory.build()
+    charge = ChargeFactory.default_dict()
     charge["statute"] = statute
     charge["disposition"] = Disposition(ruling=disposition_ruling, date=last_week)
     return ChargeFactory.create(**charge)

--- a/src/backend/tests/models/charge_types/test_type_analyzer_duii.py
+++ b/src/backend/tests/models/charge_types/test_type_analyzer_duii.py
@@ -11,7 +11,7 @@ def build_charge(statute, disposition_ruling):
     charge = ChargeFactory.build()
     charge["statute"] = statute
     charge["disposition"] = Disposition(ruling=disposition_ruling, date=last_week)
-    return ChargeFactory.save(charge)
+    return ChargeFactory.create(**charge)
 
 
 def test_duii_dismissed():

--- a/src/backend/tests/models/test_charge.py
+++ b/src/backend/tests/models/test_charge.py
@@ -19,19 +19,19 @@ class TestChargeClass(unittest.TestCase):
 
     def test_it_initializes_simple_statute(self):
         self.charge["statute"] = "1231235B"
-        charge = ChargeFactory.save(self.charge)
+        charge = ChargeFactory.create(**self.charge)
 
         assert charge.statute == "1231235B"
 
     def test_it_normalizes_statute(self):
         self.charge["statute"] = "-123.123(5)()B"
-        charge = ChargeFactory.save(self.charge)
+        charge = ChargeFactory.create(**self.charge)
 
         assert charge.statute == "1231235B"
 
     def test_it_converts_statute_to_uppercase(self):
         self.charge["statute"] = "-123.123(5)()b"
-        charge = ChargeFactory.save(self.charge)
+        charge = ChargeFactory.create(**self.charge)
 
         assert charge.statute == "1231235B"
 

--- a/src/backend/tests/models/test_charge.py
+++ b/src/backend/tests/models/test_charge.py
@@ -15,7 +15,7 @@ class TestChargeClass(unittest.TestCase):
     THREE_YEARS_AGO = date.today() + relativedelta(years=-3)
 
     def setUp(self):
-        self.charge = ChargeFactory.build()
+        self.charge = ChargeFactory.default_dict()
 
     def test_it_initializes_simple_statute(self):
         self.charge["statute"] = "1231235B"

--- a/src/backend/tests/models/test_disposition_status.py
+++ b/src/backend/tests/models/test_disposition_status.py
@@ -54,7 +54,7 @@ def test_dispositionless_charge_is_not_convicted_nor_dismissed():
 
 
 def test_charge_with_unrecognized_disposition_eligibility():
-    charge = ChargeFactory.create(disposition=["What am I", date(2001, 1, 1)])
+    charge = ChargeFactory.create(disposition=Disposition(ruling="What am I", date=date(2001, 1, 1)))
     assert not charge.convicted()
     assert not charge.dismissed()
     assert charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS

--- a/src/backend/tests/models/test_record_summarizer.py
+++ b/src/backend/tests/models/test_record_summarizer.py
@@ -1,3 +1,4 @@
+from expungeservice.models.disposition import Disposition
 from expungeservice.models.helpers.record_summarizer import RecordSummarizer
 from expungeservice.expunger import Expunger
 from tests.factories.case_factory import CaseFactory
@@ -12,7 +13,9 @@ def test_record_summarizer_multiple_cases():
     )
     case_all_eligible.charges = [
         ChargeFactory.create(
-            case=case_all_eligible, name="Theft of dignity", disposition=["Convicted", Time.TEN_YEARS_AGO]
+            case=case_all_eligible,
+            name="Theft of dignity",
+            disposition=Disposition(ruling="Convicted", date=Time.TEN_YEARS_AGO),
         )
     ]
 
@@ -20,9 +23,13 @@ def test_record_summarizer_multiple_cases():
         case_number="0001", balance="200.00", date_location=["1/1/1995", "Clackamas"]
     )
     case_partially_eligible.charges = [
-        ChargeFactory.create(case=case_partially_eligible, disposition=["Convicted", Time.TEN_YEARS_AGO]),
         ChargeFactory.create(
-            case=case_partially_eligible, level="Felony Class A", disposition=["Convicted", Time.TEN_YEARS_AGO]
+            case=case_partially_eligible, disposition=Disposition(ruling="Convicted", date=Time.TEN_YEARS_AGO)
+        ),
+        ChargeFactory.create(
+            case=case_partially_eligible,
+            level="Felony Class A",
+            disposition=Disposition(ruling="Convicted", date=Time.TEN_YEARS_AGO),
         ),
     ]
 
@@ -31,21 +38,27 @@ def test_record_summarizer_multiple_cases():
     )
     case_possibly_eligible.charges = [
         ChargeFactory.create(
-            case=case_possibly_eligible, level="Felony Class B", disposition=["Convicted", Time.TEN_YEARS_AGO]
+            case=case_possibly_eligible,
+            level="Felony Class B",
+            disposition=Disposition(ruling="Convicted", date=Time.TEN_YEARS_AGO),
         )
     ]
 
     case_all_ineligible = CaseFactory.create(case_number="0003", balance="400.00", date_location=["1/1/1995", "Baker"])
     case_all_ineligible.charges = [
         ChargeFactory.create(
-            case=case_all_ineligible, level="Felony Class A", disposition=["Convicted", Time.TEN_YEARS_AGO]
+            case=case_all_ineligible,
+            level="Felony Class A",
+            disposition=Disposition(ruling="Convicted", date=Time.TEN_YEARS_AGO),
         )
     ]
 
     case_all_ineligible_2 = CaseFactory.create(case_number="0004", date_location=["1/1/1995", "Baker"])
     case_all_ineligible_2.charges = [
         ChargeFactory.create(
-            case=case_all_ineligible_2, level="Felony Class A", disposition=["Convicted", Time.TEN_YEARS_AGO]
+            case=case_all_ineligible_2,
+            level="Felony Class A",
+            disposition=Disposition(ruling="Convicted", date=Time.TEN_YEARS_AGO),
         )
     ]
     record = RecordFactory.create(

--- a/src/backend/tests/test_friendly_rule.py
+++ b/src/backend/tests/test_friendly_rule.py
@@ -1,6 +1,7 @@
 from dateutil.relativedelta import relativedelta
 
 from expungeservice.expunger import Expunger
+from expungeservice.models.disposition import Disposition
 from expungeservice.models.expungement_result import EligibilityStatus
 from expungeservice.models.record import Record
 from tests.factories.case_factory import CaseFactory
@@ -10,9 +11,9 @@ from datetime import date
 
 
 def test_eligible_mrc_with_single_arrest():
-    three_yr_mrc = ChargeFactory.create(disposition=["Convicted", Time.THREE_YEARS_AGO])
+    three_yr_mrc = ChargeFactory.create(disposition=Disposition(ruling="Convicted", date=Time.THREE_YEARS_AGO))
 
-    arrest = ChargeFactory.create(disposition=["Dismissed", Time.THREE_YEARS_AGO])
+    arrest = ChargeFactory.create(disposition=Disposition(ruling="Dismissed", date=Time.THREE_YEARS_AGO))
 
     case = CaseFactory.create()
     case.charges = [three_yr_mrc, arrest]
@@ -34,9 +35,11 @@ def test_eligible_mrc_with_single_arrest():
 
 def test_arrest_is_unaffected_if_conviction_eligibility_is_older():
     violation_charge = ChargeFactory.create(
-        level="Class A Violation", date=Time.TEN_YEARS_AGO, disposition=["Convicted", Time.LESS_THAN_THREE_YEARS_AGO]
+        level="Class A Violation",
+        date=Time.TEN_YEARS_AGO,
+        disposition=Disposition(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO),
     )
-    arrest = ChargeFactory.create(disposition=["Dismissed", Time.ONE_YEAR_AGO])
+    arrest = ChargeFactory.create(disposition=Disposition(ruling="Dismissed", date=Time.ONE_YEAR_AGO))
 
     case = CaseFactory.create()
     case.charges = [violation_charge, arrest]
@@ -51,11 +54,15 @@ def test_arrest_is_unaffected_if_conviction_eligibility_is_older():
 def test_eligible_mrc_with_violation():
     case = CaseFactory.create()
 
-    three_yr_mrc = ChargeFactory.create(case=case, disposition=["Convicted", Time.THREE_YEARS_AGO])
+    three_yr_mrc = ChargeFactory.create(
+        case=case, disposition=Disposition(ruling="Convicted", date=Time.THREE_YEARS_AGO)
+    )
 
-    arrest = ChargeFactory.create(case=case, disposition=["Dismissed", Time.THREE_YEARS_AGO])
+    arrest = ChargeFactory.create(case=case, disposition=Disposition(ruling="Dismissed", date=Time.THREE_YEARS_AGO))
 
-    violation = ChargeFactory.create(level="Violation", case=case, disposition=["Convicted", Time.THREE_YEARS_AGO])
+    violation = ChargeFactory.create(
+        level="Violation", case=case, disposition=Disposition(ruling="Convicted", date=Time.THREE_YEARS_AGO)
+    )
 
     case.charges = [three_yr_mrc, arrest, violation]
     record = Record([case])
@@ -82,12 +89,14 @@ def test_arrest_time_eligibility_is_set_to_older_violation():
     older_violation = ChargeFactory.create(
         level="Class A Violation",
         date=Time.LESS_THAN_THREE_YEARS_AGO,
-        disposition=["Convicted", Time.LESS_THAN_THREE_YEARS_AGO],
+        disposition=Disposition(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO),
     )
     newer_violation = ChargeFactory.create(
-        level="Class A Violation", date=Time.TWO_YEARS_AGO, disposition=["Convicted", Time.TWO_YEARS_AGO]
+        level="Class A Violation",
+        date=Time.TWO_YEARS_AGO,
+        disposition=Disposition(ruling="Convicted", date=Time.TWO_YEARS_AGO),
     )
-    arrest = ChargeFactory.create(disposition=["Dismissed", Time.ONE_YEAR_AGO])
+    arrest = ChargeFactory.create(disposition=Disposition(ruling="Dismissed", date=Time.ONE_YEAR_AGO))
 
     case = CaseFactory.create()
     case.charges = [older_violation, newer_violation, arrest]
@@ -109,15 +118,19 @@ def test_3_violations_are_time_restricted():
     violation_charge_1 = ChargeFactory.create(
         level="Class A Violation",
         date=Time.LESS_THAN_THREE_YEARS_AGO,
-        disposition=["Convicted", Time.LESS_THAN_THREE_YEARS_AGO],
+        disposition=Disposition(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO),
     )
     violation_charge_2 = ChargeFactory.create(
-        level="Class A Violation", date=Time.TWO_YEARS_AGO, disposition=["Convicted", Time.TWO_YEARS_AGO]
+        level="Class A Violation",
+        date=Time.TWO_YEARS_AGO,
+        disposition=Disposition(ruling="Convicted", date=Time.TWO_YEARS_AGO),
     )
     violation_charge_3 = ChargeFactory.create(
-        level="Class A Violation", date=Time.ONE_YEAR_AGO, disposition=["Convicted", Time.ONE_YEAR_AGO]
+        level="Class A Violation",
+        date=Time.ONE_YEAR_AGO,
+        disposition=Disposition(ruling="Convicted", date=Time.ONE_YEAR_AGO),
     )
-    arrest = ChargeFactory.create(disposition=["Dismissed", Time.ONE_YEAR_AGO])
+    arrest = ChargeFactory.create(disposition=Disposition(ruling="Dismissed", date=Time.ONE_YEAR_AGO))
 
     case = CaseFactory.create()
     case.charges = [violation_charge_3, violation_charge_2, violation_charge_1, arrest]


### PR DESCRIPTION
We now clearly specify the types for `create` such that

```
date: date_class = None,
disposition: Disposition = None,
```

and so we will never be confused as to what needs to be passed in.

I've also removed the `save` method as we were using both `save` and `create` to achieve similar effects.