### PR TITLE
Add person crimes accuracy

### DIFF
--- a/src/backend/expungeservice/models/charge_types/person_crime.py
+++ b/src/backend/expungeservice/models/charge_types/person_crime.py
@@ -5,8 +5,8 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 
 
 @dataclass(eq=False)
-class PersonCrime(Charge):
-    type_name: str = "Person Crime"
+class FelonyClassBPersonCrime(Charge):
+    type_name: str = "Felony Class BPerson Crime"
 
     def _type_eligibility(self):
         if self.dismissed():

--- a/src/backend/expungeservice/models/helpers/charge_classifier.py
+++ b/src/backend/expungeservice/models/helpers/charge_classifier.py
@@ -13,7 +13,7 @@ from expungeservice.models.charge_types.marijuana_ineligible import MarijuanaIne
 from expungeservice.models.charge_types.misdemeanor import Misdemeanor
 from expungeservice.models.charge_types.non_traffic_violation import NonTrafficViolation
 from expungeservice.models.charge_types.parking_ticket import ParkingTicket
-from expungeservice.models.charge_types.person_crime import PersonCrime
+from expungeservice.models.charge_types.person_crime import FelonyClassBPersonCrime
 from expungeservice.models.charge_types.schedule_1_p_c_s import Schedule1PCS
 from expungeservice.models.charge_types.civil_offense import CivilOffense
 from expungeservice.models.charge_types.unclassified_charge import UnclassifiedCharge
@@ -41,7 +41,7 @@ class ChargeClassifier:
         yield ChargeClassifier._traffic_crime(self.statute, self.level)
         yield from ChargeClassifier._classification_by_statute(self.statute, self.chapter, self.section)
         yield ChargeClassifier._parking_ticket(self.violation_type)
-        yield from ChargeClassifier._classification_by_level(self.level, self.section)
+        yield from ChargeClassifier._classification_by_level(self.level, self.statute)
         yield ChargeClassifier._civil_offense(self.statute, self.chapter, self.name)
 
         yield UnclassifiedCharge
@@ -59,11 +59,11 @@ class ChargeClassifier:
         yield ChargeClassifier._schedule_1_pcs(section)
 
     @staticmethod
-    def _classification_by_level(level, section):
+    def _classification_by_level(level, statute):
         yield ChargeClassifier._non_traffic_violation(level)
         yield ChargeClassifier._misdemeanor(level)
         yield ChargeClassifier._felony_class_c(level)
-        yield ChargeClassifier._felony_class_b(level, section)
+        yield ChargeClassifier._felony_class_b(level, statute)
         yield ChargeClassifier._felony_class_a(level)
 
     @staticmethod
@@ -108,12 +108,6 @@ class ChargeClassifier:
         ]
         if section in conditionally_eligible_statutes + eligible_statutes:
             return Subsection12
-
-    @staticmethod
-    def _crime_against_person(section):
-        statute_ranges = (range(163305, 163480), range(163670, 163694), range(167008, 167108), range(167057, 167081))
-        if section.isdigit() and any(int(section) in statute_range for statute_range in statute_ranges):
-            return PersonCrime
 
     @staticmethod
     def _traffic_crime(statute, level):
@@ -171,11 +165,10 @@ class ChargeClassifier:
             return FelonyClassC
 
     @staticmethod
-    def _felony_class_b(level, section):
+    def _felony_class_b(level, statute):
         if level == "Felony Class B":
-            if ChargeClassifier._crime_against_person(section):
-                # rename PersonCrime -> ClassBPersonCrime
-                return PersonCrime
+            if ChargeClassifier._crime_against_person(statute):
+                return FelonyClassBPersonCrime
             else:
                 return FelonyClassB
 
@@ -183,3 +176,101 @@ class ChargeClassifier:
     def _felony_class_a(level):
         if level == "Felony Class A":
             return FelonyClassA
+
+    @staticmethod
+    def _crime_against_person(statute):
+        person_crime_statutes = [
+            "97981",  # Purchase or Sale of a Body Part for Transplantation or Therapy;
+            "97982",  # Alteration of a Document of Gift;
+            # "162165",  # Escape I;
+            # "162185",  # Supplying Contraband as defined in Crime Categories 6 and 7 (OAR 213-018-0070(1) and (2));
+            "163095",  # Aggravated Murder;
+            "163115",  # Murder II;
+            "163115",  # Felony Murder;
+            "163118",  # Manslaughter I;
+            "163125",  # Manslaughter II;
+            # "163145",  # Negligent Homicide;
+            "163149",  # Aggravated Vehicular Homicide;
+            "1631603",  # Felony Assault;
+            # "163165",  # Assault III;
+            # "163175",  # Assault II;
+            "163185",  # Assault I;
+            "1631874",  # Felony Strangulation;
+            "163192",  # Endangering Person Protected by FAPA Order;
+            "163196",  # Aggravated Driving While Suspended or Revoked;
+            # "163205",  # Criminal Mistreatment I;
+            "163207",  # Female Genital Mutilation;
+            "163208",  # Assaulting a Public Safety Officer;
+            "163213",  # Use of Stun Gun, Tear Gas, Mace I;
+            # "163225",  # Kidnapping II;
+            "163235",  # Kidnapping I;
+            "163263",  # Subjecting Another Person to Involuntary Servitude II;
+            "163264",  # Subjecting Another Person to Involuntary Servitude I;
+            "163266",  # Trafficking in Persons;
+            # "163275",  # Coercion as defined in Crime Category 7 (OAR 213-018-0035(1));
+            "163355",  # Rape III;
+            "163365",  # Rape II;
+            "163375",  # Rape I;
+            "163385",  # Sodomy III;
+            "163395",  # Sodomy II;
+            "163405",  # Sodomy I;
+            "163408",  # Sexual Penetration II;
+            "163411",  # Sexual Penetration I;
+            "163413",  # Purchasing Sex With a Minor;
+            "163425",  # Sexual Abuse II;
+            "163427",  # Sexual Abuse I;
+            "163432",  # Online Sexual Corruption of a Child II;
+            "163433",  # Online Sexual Corruption of a Child I;
+            "163452",  # Custodial Sexual Misconduct in the First Degree;
+            "163465",  # Felony Public Indecency;
+            "163472",  # Unlawful Dissemination of Intimate Image;
+            "163479",  # Unlawful Contact with a Child;
+            # "163525",  # Incest;
+            # "163535",  # Abandon Child;
+            "163537",  # Buying/Selling Custody of a Minor;
+            "163547",  # Child Neglect I;
+            "163670",  # Using Child In Display of Sexual Conduct;
+            "163684",  # Encouraging Child Sex Abuse I;
+            "163686",  # Encouraging Child Sex Abuse II;
+            "163688",  # Possession of Material Depicting Sexually Explicit Conduct of Child I;
+            "163689",  # Possession of Material Depicting Sexually Explicit Conduct of Child II;
+            "163701",  # Invasion of Personal Privacy I;
+            "163732",  # Stalking;
+            "163750",  # Violation of Court's Stalking Order;
+            "164075",  # Extortion as defined in Crime Category 7 (OAR 213-018-0075(1));
+            "164225",  # Burglary I as defined in Crime Categories 8 and 9 (OAR 213-018-0025(1) and (2));
+            "164325",  # Arson I;
+            "164342",  # Arson Incident to the Manufacture of a Controlled Substance I;
+            "1643772C",  # Computer Crime—Theft of an Intimate Image;
+            # "164395",  # Robbery III;
+            # "164405",  # Robbery II;
+            "164415",  # Robbery I;
+            "1648863",  # Tree Spiking (Injury);
+            "166070",  # Aggravated Harassment;
+            "166087",  # Abuse of Corpse I;
+            # "166165",  # Bias Crime I;
+            # "166220",  # Unlawful Use of a Weapon;
+            "166275",  # Inmate In Possession of Weapon;
+            "1663853",  # Felony Possession of a Hoax Destructive Device;
+            "166643",  # Unlawful Possession of Soft Body Armor as defined in Crime Category 6 (OAR 213-018-0090(1));
+            "167012",  # Promoting Prostitution;
+            "167017",  # Compelling Prostitution;
+            "167057",  # Luring a Minor;
+            "1673204",  # Felony Animal Abuse I;
+            "167322",  # Aggravated Animal Abuse I;
+            "468951",  # Environmental Endangerment;
+            "4757526A",  # Manufacturing or Delivering a Schedule IV Controlled Substance Thereby Causing Death to a Person;
+            "475908",  # Causing Another to Ingest a Controlled Substance as defined in Crime Categories 8 and 9 (OAR 213-019-0007 and 0008);
+            "475910",  # Unlawful Administration of a Controlled Substance as defined in Crime Categories 5, 8, and 9 (OAR 213-019-0007, -0008, and -0011);
+            # "475B359",  # Arson Incident to Manufacture of Cannabinoid Extract I;
+            # "475B367",  # Causing Another Person to Ingest Marijuana;
+            # "475B371",  # Administration to Another Person Under 18 Years of Age;
+            "6099903B",  # Maintaining Dangerous Dog;
+            # "811705",  # Hit and Run Vehicle (Injury);
+            # "8130105",  # Felony Driving Under the Influence of Intoxicants (as provided in OAR 213-004-0009);
+            "8304752",  # Hit and Run Boat;
+            "8373652B",  # Unlawful Operation of Weaponized Unmanned Aircraft System;
+            "8373652C",  # Unlawful Operation of Weaponized Unmanned Aircraft System;
+        ]
+        if statute in person_crime_statutes:
+            return True

--- a/src/backend/expungeservice/models/helpers/charge_classifier.py
+++ b/src/backend/expungeservice/models/helpers/charge_classifier.py
@@ -41,7 +41,7 @@ class ChargeClassifier:
         yield ChargeClassifier._traffic_crime(self.statute, self.level)
         yield from ChargeClassifier._classification_by_statute(self.statute, self.chapter, self.section)
         yield ChargeClassifier._parking_ticket(self.violation_type)
-        yield from ChargeClassifier._classification_by_level(self.level)
+        yield from ChargeClassifier._classification_by_level(self.level, self.section)
         yield ChargeClassifier._civil_offense(self.statute, self.chapter, self.name)
 
         yield UnclassifiedCharge
@@ -56,15 +56,14 @@ class ChargeClassifier:
         yield ChargeClassifier._marijuana_ineligible(statute, section)
         yield ChargeClassifier._subsection_12(section)
         yield ChargeClassifier._subsection_6(section)
-        yield ChargeClassifier._crime_against_person(section)
         yield ChargeClassifier._schedule_1_pcs(section)
 
     @staticmethod
-    def _classification_by_level(level):
+    def _classification_by_level(level, section):
         yield ChargeClassifier._non_traffic_violation(level)
         yield ChargeClassifier._misdemeanor(level)
         yield ChargeClassifier._felony_class_c(level)
-        yield ChargeClassifier._felony_class_b(level)
+        yield ChargeClassifier._felony_class_b(level, section)
         yield ChargeClassifier._felony_class_a(level)
 
     @staticmethod
@@ -172,9 +171,13 @@ class ChargeClassifier:
             return FelonyClassC
 
     @staticmethod
-    def _felony_class_b(level):
+    def _felony_class_b(level, section):
         if level == "Felony Class B":
-            return FelonyClassB
+            if ChargeClassifier._crime_against_person(section):
+                # rename PersonCrime -> ClassBPersonCrime
+                return PersonCrime
+            else:
+                return FelonyClassB
 
     @staticmethod
     def _felony_class_a(level):

--- a/src/backend/tests/models/charge_types/test_person_crime.py
+++ b/src/backend/tests/models/charge_types/test_person_crime.py
@@ -1,5 +1,5 @@
 from expungeservice.models.expungement_result import EligibilityStatus
-from expungeservice.models.charge_types.person_crime import PersonCrime
+from expungeservice.models.charge_types.person_crime import FelonyClassBPersonCrime
 from expungeservice.models.charge_types.felony_class_c import FelonyClassC
 from tests.factories.charge_factory import ChargeFactory
 from tests.models.test_charge import Dispositions
@@ -8,32 +8,32 @@ import pytest
 person_crime_statutes = [
     "97981",  # Purchase or Sale of a Body Part for Transplantation or Therapy;
     "97982",  # Alteration of a Document of Gift;
-    "162165",  # Escape I;
-    "162185",  # Supplying Contraband as defined in Crime Categories 6 and 7 (OAR 213-018-0070(1) and (2));
+    # "162165",  # Escape I;
+    # "162185",  # Supplying Contraband as defined in Crime Categories 6 and 7 (OAR 213-018-0070(1) and (2));
     "163095",  # Aggravated Murder;
     "163115",  # Murder II;
     "163115",  # Felony Murder;
     "163118",  # Manslaughter I;
     "163125",  # Manslaughter II;
-    "163145",  # Negligent Homicide;
+    # "163145",  # Negligent Homicide;
     "163149",  # Aggravated Vehicular Homicide;
     "1631603",  # Felony Assault;
-    "163165",  # Assault III;
-    "163175",  # Assault II;
+    # "163165",  # Assault III;
+    # "163175",  # Assault II;
     "163185",  # Assault I;
     "1631874",  # Felony Strangulation;
     "163192",  # Endangering Person Protected by FAPA Order;
     "163196",  # Aggravated Driving While Suspended or Revoked;
-    "163205",  # Criminal Mistreatment I;
+    # "163205",  # Criminal Mistreatment I;
     "163207",  # Female Genital Mutilation;
     "163208",  # Assaulting a Public Safety Officer;
     "163213",  # Use of Stun Gun, Tear Gas, Mace I;
-    "163225",  # Kidnapping II;
+    # "163225",  # Kidnapping II;
     "163235",  # Kidnapping I;
     "163263",  # Subjecting Another Person to Involuntary Servitude II;
     "163264",  # Subjecting Another Person to Involuntary Servitude I;
     "163266",  # Trafficking in Persons;
-    "163275",  # Coercion as defined in Crime Category 7 (OAR 213-018-0035(1));
+    # "163275",  # Coercion as defined in Crime Category 7 (OAR 213-018-0035(1));
     "163355",  # Rape III;
     "163365",  # Rape II;
     "163375",  # Rape I;
@@ -51,8 +51,8 @@ person_crime_statutes = [
     "163465",  # Felony Public Indecency;
     "163472",  # Unlawful Dissemination of Intimate Image;
     "163479",  # Unlawful Contact with a Child;
-    "163525",  # Incest;
-    "163535",  # Abandon Child;
+    # "163525",  # Incest;
+    # "163535",  # Abandon Child;
     "163537",  # Buying/Selling Custody of a Minor;
     "163547",  # Child Neglect I;
     "163670",  # Using Child In Display of Sexual Conduct;
@@ -68,14 +68,14 @@ person_crime_statutes = [
     "164325",  # Arson I;
     "164342",  # Arson Incident to the Manufacture of a Controlled Substance I;
     "1643772C",  # Computer Crime—Theft of an Intimate Image;
-    "164395",  # Robbery III;
-    "164405",  # Robbery II;
+    # "164395",  # Robbery III;
+    # "164405",  # Robbery II;
     "164415",  # Robbery I;
     "1648863",  # Tree Spiking (Injury);
     "166070",  # Aggravated Harassment;
     "166087",  # Abuse of Corpse I;
-    "166165",  # Bias Crime I;
-    "166220",  # Unlawful Use of a Weapon;
+    # "166165",  # Bias Crime I;
+    # "166220",  # Unlawful Use of a Weapon;
     "166275",  # Inmate In Possession of Weapon;
     "1663853",  # Felony Possession of a Hoax Destructive Device;
     "166643",  # Unlawful Possession of Soft Body Armor as defined in Crime Category 6 (OAR 213-018-0090(1));
@@ -88,12 +88,12 @@ person_crime_statutes = [
     "4757526A",  # Manufacturing or Delivering a Schedule IV Controlled Substance Thereby Causing Death to a Person;
     "475908",  # Causing Another to Ingest a Controlled Substance as defined in Crime Categories 8 and 9 (OAR 213-019-0007 and 0008);
     "475910",  # Unlawful Administration of a Controlled Substance as defined in Crime Categories 5, 8, and 9 (OAR 213-019-0007, -0008, and -0011);
-    "475B359",  # Arson Incident to Manufacture of Cannabinoid Extract I;
-    "475B367",  # Causing Another Person to Ingest Marijuana;
-    "475B371",  # Administration to Another Person Under 18 Years of Age;
+    # "475B359",  # Arson Incident to Manufacture of Cannabinoid Extract I;
+    # "475B367",  # Causing Another Person to Ingest Marijuana;
+    # "475B371",  # Administration to Another Person Under 18 Years of Age;
     "6099903B",  # Maintaining Dangerous Dog;
-    "811705",  # Hit and Run Vehicle (Injury);
-    "8130105",  # Felony Driving Under the Influence of Intoxicants (as provided in OAR 213-004-0009);
+    # "811705",  # Hit and Run Vehicle (Injury);
+    # "8130105",  # Felony Driving Under the Influence of Intoxicants (as provided in OAR 213-004-0009);
     "8304752",  # Hit and Run Boat;
     "8373652B",  # Unlawful Operation of Weaponized Unmanned Aircraft System;
     "8373652C",  # Unlawful Operation of Weaponized Unmanned Aircraft System;
@@ -108,8 +108,7 @@ def test_felony_b_person_crimes(person_crime_statute):
     charge_dict["level"] = "Felony Class B"
     charge_dict["disposition"] = Dispositions.CONVICTED
     person_crime_felony_class_b_convicted = ChargeFactory.create(**charge_dict)
-
-    assert isinstance(person_crime_felony_class_b_convicted, PersonCrime)
+    assert isinstance(person_crime_felony_class_b_convicted, FelonyClassBPersonCrime)
     assert (
         person_crime_felony_class_b_convicted.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
     )

--- a/src/backend/tests/models/charge_types/test_person_crime.py
+++ b/src/backend/tests/models/charge_types/test_person_crime.py
@@ -1,116 +1,133 @@
 from expungeservice.models.expungement_result import EligibilityStatus
 from expungeservice.models.charge_types.person_crime import PersonCrime
+from expungeservice.models.charge_types.felony_class_c import FelonyClassC
 from tests.factories.charge_factory import ChargeFactory
 from tests.models.test_charge import Dispositions
+import pytest
+
+person_crime_statutes = [
+    "97981",  # Purchase or Sale of a Body Part for Transplantation or Therapy;
+    "97982",  # Alteration of a Document of Gift;
+    "162165",  # Escape I;
+    "162185",  # Supplying Contraband as defined in Crime Categories 6 and 7 (OAR 213-018-0070(1) and (2));
+    "163095",  # Aggravated Murder;
+    "163115",  # Murder II;
+    "163115",  # Felony Murder;
+    "163118",  # Manslaughter I;
+    "163125",  # Manslaughter II;
+    "163145",  # Negligent Homicide;
+    "163149",  # Aggravated Vehicular Homicide;
+    "1631603",  # Felony Assault;
+    "163165",  # Assault III;
+    "163175",  # Assault II;
+    "163185",  # Assault I;
+    "1631874",  # Felony Strangulation;
+    "163192",  # Endangering Person Protected by FAPA Order;
+    "163196",  # Aggravated Driving While Suspended or Revoked;
+    "163205",  # Criminal Mistreatment I;
+    "163207",  # Female Genital Mutilation;
+    "163208",  # Assaulting a Public Safety Officer;
+    "163213",  # Use of Stun Gun, Tear Gas, Mace I;
+    "163225",  # Kidnapping II;
+    "163235",  # Kidnapping I;
+    "163263",  # Subjecting Another Person to Involuntary Servitude II;
+    "163264",  # Subjecting Another Person to Involuntary Servitude I;
+    "163266",  # Trafficking in Persons;
+    "163275",  # Coercion as defined in Crime Category 7 (OAR 213-018-0035(1));
+    "163355",  # Rape III;
+    "163365",  # Rape II;
+    "163375",  # Rape I;
+    "163385",  # Sodomy III;
+    "163395",  # Sodomy II;
+    "163405",  # Sodomy I;
+    "163408",  # Sexual Penetration II;
+    "163411",  # Sexual Penetration I;
+    "163413",  # Purchasing Sex With a Minor;
+    "163425",  # Sexual Abuse II;
+    "163427",  # Sexual Abuse I;
+    "163432",  # Online Sexual Corruption of a Child II;
+    "163433",  # Online Sexual Corruption of a Child I;
+    "163452",  # Custodial Sexual Misconduct in the First Degree;
+    "163465",  # Felony Public Indecency;
+    "163472",  # Unlawful Dissemination of Intimate Image;
+    "163479",  # Unlawful Contact with a Child;
+    "163525",  # Incest;
+    "163535",  # Abandon Child;
+    "163537",  # Buying/Selling Custody of a Minor;
+    "163547",  # Child Neglect I;
+    "163670",  # Using Child In Display of Sexual Conduct;
+    "163684",  # Encouraging Child Sex Abuse I;
+    "163686",  # Encouraging Child Sex Abuse II;
+    "163688",  # Possession of Material Depicting Sexually Explicit Conduct of Child I;
+    "163689",  # Possession of Material Depicting Sexually Explicit Conduct of Child II;
+    "163701",  # Invasion of Personal Privacy I;
+    "163732",  # Stalking;
+    "163750",  # Violation of Court's Stalking Order;
+    "164075",  # Extortion as defined in Crime Category 7 (OAR 213-018-0075(1));
+    "164225",  # Burglary I as defined in Crime Categories 8 and 9 (OAR 213-018-0025(1) and (2));
+    "164325",  # Arson I;
+    "164342",  # Arson Incident to the Manufacture of a Controlled Substance I;
+    "1643772C",  # Computer Crime—Theft of an Intimate Image;
+    "164395",  # Robbery III;
+    "164405",  # Robbery II;
+    "164415",  # Robbery I;
+    "1648863",  # Tree Spiking (Injury);
+    "166070",  # Aggravated Harassment;
+    "166087",  # Abuse of Corpse I;
+    "166165",  # Bias Crime I;
+    "166220",  # Unlawful Use of a Weapon;
+    "166275",  # Inmate In Possession of Weapon;
+    "1663853",  # Felony Possession of a Hoax Destructive Device;
+    "166643",  # Unlawful Possession of Soft Body Armor as defined in Crime Category 6 (OAR 213-018-0090(1));
+    "167012",  # Promoting Prostitution;
+    "167017",  # Compelling Prostitution;
+    "167057",  # Luring a Minor;
+    "1673204",  # Felony Animal Abuse I;
+    "167322",  # Aggravated Animal Abuse I;
+    "468951",  # Environmental Endangerment;
+    "4757526A",  # Manufacturing or Delivering a Schedule IV Controlled Substance Thereby Causing Death to a Person;
+    "475908",  # Causing Another to Ingest a Controlled Substance as defined in Crime Categories 8 and 9 (OAR 213-019-0007 and 0008);
+    "475910",  # Unlawful Administration of a Controlled Substance as defined in Crime Categories 5, 8, and 9 (OAR 213-019-0007, -0008, and -0011);
+    "475B359",  # Arson Incident to Manufacture of Cannabinoid Extract I;
+    "475B367",  # Causing Another Person to Ingest Marijuana;
+    "475B371",  # Administration to Another Person Under 18 Years of Age;
+    "6099903B",  # Maintaining Dangerous Dog;
+    "811705",  # Hit and Run Vehicle (Injury);
+    "8130105",  # Felony Driving Under the Influence of Intoxicants (as provided in OAR 213-004-0009);
+    "8304752",  # Hit and Run Boat;
+    "8373652B",  # Unlawful Operation of Weaponized Unmanned Aircraft System;
+    "8373652C",  # Unlawful Operation of Weaponized Unmanned Aircraft System;
+]
 
 
-def test_misdemeanor_sex_crime():
+@pytest.mark.parametrize("person_crime_statute", person_crime_statutes)
+def test_felony_b_person_crimes(person_crime_statute):
     charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["name"] = "Sexual Abuse in the Third Degree"
-    charge_dict["statute"] = "163.415"
-    charge_dict["level"] = "Misdemeanor Class A"
+    charge_dict["name"] = "Generic"
+    charge_dict["statute"] = person_crime_statute
+    charge_dict["level"] = "Felony Class B"
     charge_dict["disposition"] = Dispositions.CONVICTED
-    misdemeanor_class_a_convicted = ChargeFactory.create(**charge_dict)
+    person_crime_felony_class_b_convicted = ChargeFactory.create(**charge_dict)
 
-    assert isinstance(misdemeanor_class_a_convicted, PersonCrime)
-    assert misdemeanor_class_a_convicted.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert misdemeanor_class_a_convicted.expungement_result.type_eligibility.reason == "Ineligible under 137.225(5)"
-
-
-def test_min_statute_range_for_crimes_against_persons():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["statute"] = "163.305"
-    convicted_charge = ChargeFactory.create(**charge_dict)
-
-    assert isinstance(convicted_charge, PersonCrime)
-    assert convicted_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert convicted_charge.expungement_result.type_eligibility.reason == "Ineligible under 137.225(5)"
+    assert isinstance(person_crime_felony_class_b_convicted, PersonCrime)
+    assert (
+        person_crime_felony_class_b_convicted.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    )
+    assert (
+        person_crime_felony_class_b_convicted.expungement_result.type_eligibility.reason
+        == "Ineligible under 137.225(5)"
+    )
 
 
-def test_max_statute_range_for_crimes_against_persons():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["statute"] = "163.479"
-    convicted_charge = ChargeFactory.create(**charge_dict)
-
-    assert isinstance(convicted_charge, PersonCrime)
-    assert convicted_charge.type_name == "Person Crime"
-    assert convicted_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert convicted_charge.expungement_result.type_eligibility.reason == "Ineligible under 137.225(5)"
-
-
-def test_min_statute_range_for_other_crimes_against_persons():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["statute"] = "163.670"
-    convicted_charge = ChargeFactory.create(**charge_dict)
-
-    assert isinstance(convicted_charge, PersonCrime)
-    assert convicted_charge.type_name == "Person Crime"
-    assert convicted_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert convicted_charge.expungement_result.type_eligibility.reason == "Ineligible under 137.225(5)"
-
-
-def test_max_statute_range_for_other_crimes_against_persons():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["statute"] = "163.693"
-    convicted_charge = ChargeFactory.create(**charge_dict)
-
-    assert isinstance(convicted_charge, PersonCrime)
-    assert convicted_charge.type_name == "Person Crime"
-    assert convicted_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert convicted_charge.expungement_result.type_eligibility.reason == "Ineligible under 137.225(5)"
-
-
-def test_min_statute_range_for_promoting_prostitution():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["statute"] = "167.008"
-    convicted_charge = ChargeFactory.create(**charge_dict)
-
-    assert isinstance(convicted_charge, PersonCrime)
-    assert convicted_charge.type_name == "Person Crime"
-    assert convicted_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert convicted_charge.expungement_result.type_eligibility.reason == "Ineligible under 137.225(5)"
-
-
-def test_max_statute_range_for_promoting_prostitution():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["statute"] = "167.107"
-    convicted_charge = ChargeFactory.create(**charge_dict)
-
-    assert isinstance(convicted_charge, PersonCrime)
-    assert convicted_charge.type_name == "Person Crime"
-    assert convicted_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert convicted_charge.expungement_result.type_eligibility.reason == "Ineligible under 137.225(5)"
-
-
-def test_min_statute_range_for_obscenity_and_minors():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["statute"] = "167.057"
-    convicted_charge = ChargeFactory.create(**charge_dict)
-
-    assert isinstance(convicted_charge, PersonCrime)
-    assert convicted_charge.type_name == "Person Crime"
-    assert convicted_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert convicted_charge.expungement_result.type_eligibility.reason == "Ineligible under 137.225(5)"
-
-
-def test_max_statute_range_for_obscenity_and_minors():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["statute"] = "167.080"
-    convicted_charge = ChargeFactory.create(**charge_dict)
-
-    assert isinstance(convicted_charge, PersonCrime)
-    assert convicted_charge.type_name == "Person Crime"
-    assert convicted_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert convicted_charge.expungement_result.type_eligibility.reason == "Ineligible under 137.225(5)"
-
-
-def test_rape_class_c_felony():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["name"] = "Rape in the Third Degree"
-    charge_dict["statute"] = "163.355"
-    charge_dict["level"] = "Felony Class C"
-    sex_crime_charge = ChargeFactory.create(**charge_dict)
-
-    assert isinstance(sex_crime_charge, PersonCrime)
-    assert sex_crime_charge.type_name == "Person Crime"
-    assert sex_crime_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+# @pytest.mark.parametrize("person_crime_statute", person_crime_statutes)
+# def test_felony_c_person_crimes(person_crime_statute):
+#     charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
+#     charge_dict["name"] = "Generic"
+#     charge_dict["statute"] = person_crime_statute
+#     charge_dict["level"] = "Felony Class C"
+#     charge_dict["disposition"] = Dispositions.CONVICTED
+#     person_crime_felony_class_c_convicted = ChargeFactory.create(**charge_dict)
+#
+#     assert isinstance(person_crime_felony_class_c_convicted, FelonyClassC)
+#     assert person_crime_felony_class_c_convicted.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+#     assert person_crime_felony_class_c_convicted.expungement_result.type_eligibility.reason == "Eligible under 137.225(5)(b)"


### PR DESCRIPTION
Addresses issue #760. 

Related to issue #868.

We may need more tests for person crimes -- right now the person crimes test suite only checks to see if felony b person crimes are accurately classified.