### PR TITLE
Make the rules for Subsection 12 more accurate

### DIFF
--- a/src/backend/expungeservice/models/charge_types/subsection_12.py
+++ b/src/backend/expungeservice/models/charge_types/subsection_12.py
@@ -36,6 +36,8 @@ Dismissals are eligible under 137.225(1)(b)."""
     The following statutes are eligible if tried as an Attempt charge.
     But if this is the case, the actual charge will be filed under a different statute number, meaning this set of statutes never provides additional information for eligibility.
 
+    TODO: We should figure out what the statutes for attempt are so that we can identify those charges and apply this subsection.
+
     eligible_attempt_sections = [
         "163175",
         "162165",
@@ -53,13 +55,6 @@ Dismissals are eligible under 137.225(1)(b)."""
                     EligibilityStatus.NEEDS_MORE_ANALYSIS,
                     reason="Incest is possibly eligible under 137.225(12), if the victim was at least 18 years of age.",
                 )
-                """
-            elif self._section in self.eligible_attempt_sections:
-                return TypeEligibility(
-                    EligibilityStatus.NEEDS_MORE_ANALYSIS,
-                    reason="Criminal Attempt under this statute may be eligible under 137.225(12).",
-                )
-                """
             elif self._section in self.eligible_sections:
                 return TypeEligibility(
                     EligibilityStatus.ELIGIBLE,

--- a/src/backend/expungeservice/models/charge_types/subsection_12.py
+++ b/src/backend/expungeservice/models/charge_types/subsection_12.py
@@ -8,24 +8,60 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 class Subsection12(Charge):
     type_name: str = "Subsection 12"
     expungement_rules: str = (
-        """Subsection (12) names 13 felony statutes that are interpreted as eligible (or conditionally eligible, in the case of 163.525, Incest).
+        """Subsection 12 names 13 felony statutes that are eligible (or conditionally eligible, in the case of 163.525, Incest).
 The subsection describes an irregular criterion for eligibility: Conviction of these charges is eligible unless the court or DA provide reason they should *not* be expunged. This is in contrast to most expungements, for which the person needs to "convince" the court that expungement is in the interest of justice.
-The subsection also says that the listed felonies need to otherwise meet eligibility under the other expungement rules. In practice, this actually is never considered and the listed felonies are considered all eligible. Overall, the subsection is confusing and seems a little nonsensical, but the State has generally settled on expunging any of these charges.
-Applicable subsections: 137.225(12) for convictions; 137.225(1)(b) for dismissals."""
+The subsection also says that the listed felonies need to otherwise meet eligibility under the other expungement rules. In practice, this actually is never considered and the listed felonies are considered all eligible. Overall, the subsection is fairly unclear, but the State has generally settled on expunging any of these charges.
+Dismissals are eligible under 137.225(1)(b)."""
     )
+    eligible_sections = [
+        # In order listed in the subsection
+        # Incest and "attempt" statutes are commented out; see below
+        "163535",  # (Abandonment of a child)
+        # "163175",  # (Attempted Assault II)
+        "163165",  # (Assault III) - supercedes section 6.
+        "163275",  # (Coercion)
+        # "163205",  # (superceded by section 6, Criminal mistreatment in the first degree)
+        # "162165",  # (Attempted escape in the first degree)
+        # "163525", (Incest), see below
+        "166165",  # (Intimidation in the first degree)
+        # "163225",  # (Attempted Kidnapping in the second degree)
+        # "164405",  # (Attempted Robbery in the second degree)
+        "164395",  # (Robbery in the third degree)
+        "162185",  # (Supplying contraband)
+        "166220",  # (Unlawful use of weapon)
+    ]
+    conditionally_eligible_sections = ["163525"]  # (Incest), conditional that the victim was at least 18 years of age.
 
-    # TODO: the elif convicted(): block needs to be added here pending the open issue for a Subsection 12 overhaul.
+    """
+    The following statutes are eligible if tried as an Attempt charge.
+    But if this is the case, the actual charge will be filed under a different statute number, meaning this set of statutes never provides additional information for eligibility.
+
+    eligible_attempt_sections = [
+        "163175",
+        "162165",
+        "163225",
+        "164405",
+    ]
+    """
+
     def _type_eligibility(self):
         if self.dismissed():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Dismissals are eligible under 137.225(1)(b)")
-        else:
-            if self.statute == "163525":
+        elif self.convicted():
+            if self._section == "163525":
                 return TypeEligibility(
                     EligibilityStatus.NEEDS_MORE_ANALYSIS,
                     reason="Incest is possibly eligible under 137.225(12), if the victim was at least 18 years of age.",
                 )
-            else:
+                """
+            elif self._section in self.eligible_attempt_sections:
+                return TypeEligibility(
+                    EligibilityStatus.NEEDS_MORE_ANALYSIS,
+                    reason="Criminal Attempt under this statute may be eligible under 137.225(12).",
+                )
+                """
+            elif self._section in self.eligible_sections:
                 return TypeEligibility(
                     EligibilityStatus.ELIGIBLE,
-                    reason="Eligible under 137.225(12). This subsection is interpreted to override any conflicting subsections.",
+                    reason="Eligible under 137.225(12). This subsection also describes more lenient expungement criteria than other subsections.",
                 )

--- a/src/backend/expungeservice/models/charge_types/subsection_12.py
+++ b/src/backend/expungeservice/models/charge_types/subsection_12.py
@@ -18,9 +18,9 @@ Dismissals are eligible under 137.225(1)(b)."""
         # Incest and "attempt" statutes are commented out; see below
         "163535",  # (Abandonment of a child)
         # "163175",  # (Attempted Assault II)
-        "163165",  # (Assault III) - supercedes section 6.
+        # "163165",  # (Assault III) -superceded by section 6, for the special case of assault of a minor.
         "163275",  # (Coercion)
-        # "163205",  # (superceded by section 6, Criminal mistreatment in the first degree)
+        # "163205",  # (Criminal mistreatment I) superceded by section 6, for the special case of mistreatment of a minor or a senior.
         # "162165",  # (Attempted escape in the first degree)
         # "163525", (Incest), see below
         "166165",  # (Intimidation in the first degree)

--- a/src/backend/expungeservice/models/charge_types/subsection_6.py
+++ b/src/backend/expungeservice/models/charge_types/subsection_6.py
@@ -10,13 +10,14 @@ class Subsection6(Charge):
 
     expungement_rules: str = (
         """Subsection (6) names five felony statutes that have specific circumstances of the case under which they are ineligible.
-However, two of the statutes named -- 163.165(1)(h) (Assault in the third degree) and 163.205 (Criminal mistreatment in the first degree) are also named in subection 12 as eligible. Subsection 12 is interpreted to override other statutes, so in effect this clause of subsection 6 has no effect on eligibility.
+However, two of the statutes named -- 163.165(1)(h) (Assault in the third degree)
 This subsection also specifies conditions under which [SexCrimes](#SexCrime) are eligible or ineligible.
 The three remaining specifications in the statute are:
- * 163.200 (Criminal mistreatment in the second degree) is ineligible if the victim at the time of the crime was 65 years of age or older; otherwise eligible as a (Class A) [Misdemeanor](#Misdemeanor).
+ * 163.200 (Criminal mistreatment II) is ineligible if the victim at the time of the crime was 65 years of age or older; otherwise eligible as a (Class A) [Misdemeanor](#Misdemeanor).
+ * 163.205 (Criminal mistreatment I) is ineligible if the victim at the time of the crime was 65 years of age or older or a minor; otherwise eligible as a [Class C Felony](#FelonyClassC).
  * 163.575 (Endangering the welfare of a minor) (1)(a) is ineligible when the offense constitutes child abuse as defined in ORS 419B.005 (Definitions); otherwise eligible as a (Class A) [Misdemeanor](#Misdemeanor).
  * 163.145 (Criminally negligent homicide) is ineligible when that offense was punishable as a Class C felony.
-Applicable subsections: 137.225(6) for convictions; 137.225(1)(b) for dismissals."""
+Dismissals are eligible under 137.225(1)(b)."""
     )
 
     def _type_eligibility(self):

--- a/src/backend/expungeservice/models/helpers/charge_classifier.py
+++ b/src/backend/expungeservice/models/helpers/charge_classifier.py
@@ -77,7 +77,7 @@ class ChargeClassifier:
     def _subsection_6(section):
         conditionally_ineligible_statutes = [
             "163200",  #  (Criminal mistreatment in the second degree) if the victim at the time of the crime was 65 years of age or older.
-            # 163205, # overridden by subsection 12.(Criminal mistreatment in the first degree) if the victim at the time of the crime was 65 years of age or older, or when the offense constitutes child abuse as defined in ORS 419B.005 (Definitions).
+            "163205",  # (overrides subsection 12.(Criminal mistreatment in the first degree) if the victim at the time of the crime was 65 years of age or older, or when the offense constitutes child abuse as defined in ORS 419B.005 (Definitions).
             "163575",  #  (Endangering the welfare of a minor) (1)(a), when the offense constitutes child abuse as defined in ORS 419B.005 (Definitions).
             "163145",  # (Criminally negligent homicide), when that offense was punishable as a Class C felony.
             # 163.165(1)(h) # overridden by subsection 12.(Assault in the third degree)
@@ -87,27 +87,7 @@ class ChargeClassifier:
 
     @staticmethod
     def _subsection_12(section):
-
-        eligible_statutes = [
-            # In order listed in the subsection
-            "163535",  # added; (Abandonment of a child)
-            "163175",  # (Assault in the second degree)
-            "163165",  # (Assault in the third degree)
-            "163275",  # (Coercion)
-            "163205",  # (Criminal mistreatment in the first degree)
-            "162165",  # (Attempted escape in the first degree)
-            # 163525 (Incest), see below
-            "166165",  # (added; Intimidation in the first degree)
-            "163225",  # (Attempted Kidnapping in the second degree)
-            "164405",  # (Robbery in the second degree)
-            "164395",  # (Robbery in the third degree)
-            "162185",  # (Supplying contraband)
-            "166220",  # (Unlawful use of weapon)
-        ]
-        conditionally_eligible_statutes = [
-            "163525"  # (Incest), conditional that the victim was at least 18 years of age.
-        ]
-        if section in conditionally_eligible_statutes + eligible_statutes:
+        if section in (Subsection12.conditionally_eligible_sections + Subsection12.eligible_sections):
             return Subsection12
 
     @staticmethod

--- a/src/backend/expungeservice/models/helpers/charge_classifier.py
+++ b/src/backend/expungeservice/models/helpers/charge_classifier.py
@@ -80,7 +80,7 @@ class ChargeClassifier:
             "163205",  # (overrides subsection 12.(Criminal mistreatment in the first degree) if the victim at the time of the crime was 65 years of age or older, or when the offense constitutes child abuse as defined in ORS 419B.005 (Definitions).
             "163575",  #  (Endangering the welfare of a minor) (1)(a), when the offense constitutes child abuse as defined in ORS 419B.005 (Definitions).
             "163145",  # (Criminally negligent homicide), when that offense was punishable as a Class C felony.
-            # 163.165(1)(h) # overridden by subsection 12.(Assault in the third degree)
+            "163165",  # ( ineligible if under subection(1)(h) ; Assault in the third degree of a minor 10 years or younger)
         ]
         if section in conditionally_ineligible_statutes:
             return Subsection6

--- a/src/backend/tests/models/charge_types/test_subsection_12.py
+++ b/src/backend/tests/models/charge_types/test_subsection_12.py
@@ -31,19 +31,26 @@ def test_subsection_12_163535():
     assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
     assert (
         subsection_12_charge.expungement_result.type_eligibility.reason
-        == "Eligible under 137.225(12). This subsection is interpreted to override any conflicting subsections."
+        == "Eligible under 137.225(12). This subsection also describes more lenient expungement criteria than other subsections."
     )
 
 
+"""
 def test_subsection_12_163175():
     charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Assault in the second degree"
+    charge_dict["name"] = "Attempted assault in the second degree"
     charge_dict["statute"] = "163.175"
     charge_dict["level"] = "Felony Class B"
     charge_dict["disposition"] = Dispositions.CONVICTED
     subsection_12_charge = ChargeFactory.create(**charge_dict)
 
     assert isinstance(subsection_12_charge, Subsection12)
+    assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert (
+        subsection_12_charge.expungement_result.type_eligibility.reason
+        == "Criminal Attempt under this statute may be eligible under 137.225(12)."
+    )
+"""
 
 
 def test_subsection_12_163165():
@@ -55,6 +62,11 @@ def test_subsection_12_163165():
     subsection_12_charge = ChargeFactory.create(**charge_dict)
 
     assert isinstance(subsection_12_charge, Subsection12)
+    assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert (
+        subsection_12_charge.expungement_result.type_eligibility.reason
+        == "Eligible under 137.225(12). This subsection also describes more lenient expungement criteria than other subsections."
+    )
 
 
 def test_subsection_12_163275():
@@ -66,28 +78,36 @@ def test_subsection_12_163275():
     subsection_12_charge = ChargeFactory.create(**charge_dict)
 
     assert isinstance(subsection_12_charge, Subsection12)
-
-
-def test_subsection_12_163205():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Criminal mistreatment in the first degree"
-    charge_dict["statute"] = "163.205"
-    charge_dict["level"] = "Felony Class C"
-    charge_dict["disposition"] = Dispositions.CONVICTED
-    subsection_12_charge = ChargeFactory.create(**charge_dict)
+    assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert (
+        subsection_12_charge.expungement_result.type_eligibility.reason
+        == "Eligible under 137.225(12). This subsection also describes more lenient expungement criteria than other subsections."
+    )
 
     assert isinstance(subsection_12_charge, Subsection12)
+    assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert (
+        subsection_12_charge.expungement_result.type_eligibility.reason
+        == "Eligible under 137.225(12). This subsection also describes more lenient expungement criteria than other subsections."
+    )
 
 
+"""
 def test_subsection_12_162165():
     charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Escape in the first degree"
+    charge_dict["name"] = "Attempted escape in the first degree"
     charge_dict["statute"] = "162.165"
     charge_dict["level"] = "Felony Class B"
     charge_dict["disposition"] = Dispositions.CONVICTED
     subsection_12_charge = ChargeFactory.create(**charge_dict)
 
     assert isinstance(subsection_12_charge, Subsection12)
+    assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert (
+        subsection_12_charge.expungement_result.type_eligibility.reason
+        == "Criminal Attempt under this statute may be eligible under 137.225(12)."
+    )
+"""
 
 
 def test_subsection_12_163525():
@@ -115,28 +135,44 @@ def test_subsection_12_166165():
     subsection_12_charge = ChargeFactory.create(**charge_dict)
 
     assert isinstance(subsection_12_charge, Subsection12)
+    assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert (
+        subsection_12_charge.expungement_result.type_eligibility.reason
+        == "Eligible under 137.225(12). This subsection also describes more lenient expungement criteria than other subsections."
+    )
 
 
+"""
 def test_subsection_12_163225():
     charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Kidnapping in the second degree"
+    charge_dict["name"] = "Attempted kidnapping in the second degree"
     charge_dict["statute"] = "163.225"
     charge_dict["level"] = "Felony Class B"
     charge_dict["disposition"] = Dispositions.CONVICTED
     subsection_12_charge = ChargeFactory.create(**charge_dict)
 
     assert isinstance(subsection_12_charge, Subsection12)
-
+    assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert (
+        subsection_12_charge.expungement_result.type_eligibility.reason
+        == "Criminal Attempt under this statute may be eligible under 137.225(12)."
+    )
 
 def test_subsection_12_164405():
     charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Robbery in the second degree"
+    charge_dict["name"] = "Attempted robbery in the second degree"
     charge_dict["statute"] = "164.405"
     charge_dict["level"] = "Felony Class B"
     charge_dict["disposition"] = Dispositions.CONVICTED
     subsection_12_charge = ChargeFactory.create(**charge_dict)
 
     assert isinstance(subsection_12_charge, Subsection12)
+    assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert (
+        subsection_12_charge.expungement_result.type_eligibility.reason
+        == "Criminal Attempt under this statute may be eligible under 137.225(12)."
+    )
+"""
 
 
 def test_subsection_12_164395():
@@ -148,6 +184,11 @@ def test_subsection_12_164395():
     subsection_12_charge = ChargeFactory.create(**charge_dict)
 
     assert isinstance(subsection_12_charge, Subsection12)
+    assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert (
+        subsection_12_charge.expungement_result.type_eligibility.reason
+        == "Eligible under 137.225(12). This subsection also describes more lenient expungement criteria than other subsections."
+    )
 
 
 def test_subsection_12_162185():
@@ -159,6 +200,11 @@ def test_subsection_12_162185():
     subsection_12_charge = ChargeFactory.create(**charge_dict)
 
     assert isinstance(subsection_12_charge, Subsection12)
+    assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert (
+        subsection_12_charge.expungement_result.type_eligibility.reason
+        == "Eligible under 137.225(12). This subsection also describes more lenient expungement criteria than other subsections."
+    )
 
 
 def test_subsection_12_166220():
@@ -170,6 +216,11 @@ def test_subsection_12_166220():
     subsection_12_charge = ChargeFactory.create(**charge_dict)
 
     assert isinstance(subsection_12_charge, Subsection12)
+    assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert (
+        subsection_12_charge.expungement_result.type_eligibility.reason
+        == "Eligible under 137.225(12). This subsection also describes more lenient expungement criteria than other subsections."
+    )
 
 
 # Test sub-chapters are not compared when not necessary.
@@ -182,3 +233,8 @@ def test_subsection_12_charge_that_includes_sub_chapter():
     subsection_12_charge = ChargeFactory.create(**charge_dict)
 
     assert isinstance(subsection_12_charge, Subsection12)
+    assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert (
+        subsection_12_charge.expungement_result.type_eligibility.reason
+        == "Eligible under 137.225(12). This subsection also describes more lenient expungement criteria than other subsections."
+    )

--- a/src/backend/tests/models/charge_types/test_subsection_12.py
+++ b/src/backend/tests/models/charge_types/test_subsection_12.py
@@ -18,7 +18,6 @@ def test_subsection_12_dismissed():
         subsection_12_charge.expungement_result.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
     )
 
-
 def test_subsection_12_163535():
     charge_dict = ChargeFactory.default_dict()
     charge_dict["name"] = "Abandonment of a child"
@@ -33,25 +32,6 @@ def test_subsection_12_163535():
         subsection_12_charge.expungement_result.type_eligibility.reason
         == "Eligible under 137.225(12). This subsection also describes more lenient expungement criteria than other subsections."
     )
-
-
-"""
-def test_subsection_12_163175():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Attempted assault in the second degree"
-    charge_dict["statute"] = "163.175"
-    charge_dict["level"] = "Felony Class B"
-    charge_dict["disposition"] = Dispositions.CONVICTED
-    subsection_12_charge = ChargeFactory.create(**charge_dict)
-
-    assert isinstance(subsection_12_charge, Subsection12)
-    assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert (
-        subsection_12_charge.expungement_result.type_eligibility.reason
-        == "Criminal Attempt under this statute may be eligible under 137.225(12)."
-    )
-"""
-
 
 def test_subsection_12_163275():
     charge_dict = ChargeFactory.default_dict()
@@ -74,25 +54,6 @@ def test_subsection_12_163275():
         subsection_12_charge.expungement_result.type_eligibility.reason
         == "Eligible under 137.225(12). This subsection also describes more lenient expungement criteria than other subsections."
     )
-
-
-"""
-def test_subsection_12_162165():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Attempted escape in the first degree"
-    charge_dict["statute"] = "162.165"
-    charge_dict["level"] = "Felony Class B"
-    charge_dict["disposition"] = Dispositions.CONVICTED
-    subsection_12_charge = ChargeFactory.create(**charge_dict)
-
-    assert isinstance(subsection_12_charge, Subsection12)
-    assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert (
-        subsection_12_charge.expungement_result.type_eligibility.reason
-        == "Criminal Attempt under this statute may be eligible under 137.225(12)."
-    )
-"""
-
 
 def test_subsection_12_163525():
     charge_dict = ChargeFactory.default_dict()
@@ -125,40 +86,6 @@ def test_subsection_12_166165():
         == "Eligible under 137.225(12). This subsection also describes more lenient expungement criteria than other subsections."
     )
 
-
-"""
-def test_subsection_12_163225():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Attempted kidnapping in the second degree"
-    charge_dict["statute"] = "163.225"
-    charge_dict["level"] = "Felony Class B"
-    charge_dict["disposition"] = Dispositions.CONVICTED
-    subsection_12_charge = ChargeFactory.create(**charge_dict)
-
-    assert isinstance(subsection_12_charge, Subsection12)
-    assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert (
-        subsection_12_charge.expungement_result.type_eligibility.reason
-        == "Criminal Attempt under this statute may be eligible under 137.225(12)."
-    )
-
-def test_subsection_12_164405():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Attempted robbery in the second degree"
-    charge_dict["statute"] = "164.405"
-    charge_dict["level"] = "Felony Class B"
-    charge_dict["disposition"] = Dispositions.CONVICTED
-    subsection_12_charge = ChargeFactory.create(**charge_dict)
-
-    assert isinstance(subsection_12_charge, Subsection12)
-    assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert (
-        subsection_12_charge.expungement_result.type_eligibility.reason
-        == "Criminal Attempt under this statute may be eligible under 137.225(12)."
-    )
-"""
-
-
 def test_subsection_12_164395():
     charge_dict = ChargeFactory.default_dict()
     charge_dict["name"] = "Robbery in the third degree"
@@ -173,7 +100,6 @@ def test_subsection_12_164395():
         subsection_12_charge.expungement_result.type_eligibility.reason
         == "Eligible under 137.225(12). This subsection also describes more lenient expungement criteria than other subsections."
     )
-
 
 def test_subsection_12_162185():
     charge_dict = ChargeFactory.default_dict()
@@ -190,7 +116,6 @@ def test_subsection_12_162185():
         == "Eligible under 137.225(12). This subsection also describes more lenient expungement criteria than other subsections."
     )
 
-
 def test_subsection_12_166220():
     charge_dict = ChargeFactory.default_dict()
     charge_dict["name"] = "Unlawful use of weapon"
@@ -206,8 +131,7 @@ def test_subsection_12_166220():
         == "Eligible under 137.225(12). This subsection also describes more lenient expungement criteria than other subsections."
     )
 
-
-# Test sub-chapters are not compared when not necessary.
+# Test that sub-chapters are not compared when not necessary.
 def test_subsection_12_charge_that_includes_sub_chapter():
     charge_dict = ChargeFactory.default_dict()
     charge_dict["name"] = "Unlawful use of weapon"

--- a/src/backend/tests/models/charge_types/test_subsection_12.py
+++ b/src/backend/tests/models/charge_types/test_subsection_12.py
@@ -53,22 +53,6 @@ def test_subsection_12_163175():
 """
 
 
-def test_subsection_12_163165():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Assault in the third degree"
-    charge_dict["statute"] = "163.165"
-    charge_dict["level"] = "Felony Class C"
-    charge_dict["disposition"] = Dispositions.CONVICTED
-    subsection_12_charge = ChargeFactory.create(**charge_dict)
-
-    assert isinstance(subsection_12_charge, Subsection12)
-    assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert (
-        subsection_12_charge.expungement_result.type_eligibility.reason
-        == "Eligible under 137.225(12). This subsection also describes more lenient expungement criteria than other subsections."
-    )
-
-
 def test_subsection_12_163275():
     charge_dict = ChargeFactory.default_dict()
     charge_dict["name"] = "Coercion"

--- a/src/backend/tests/models/charge_types/test_subsection_6.py
+++ b/src/backend/tests/models/charge_types/test_subsection_6.py
@@ -20,6 +20,22 @@ def test_subsection_6_dismissed():
     )
 
 
+def test_subsection_6_163165():
+    charge_dict = ChargeFactory.default_dict()
+    charge_dict["name"] = "Assault in the third degree"
+    charge_dict["statute"] = "163.165"
+    charge_dict["level"] = "Felony Class C"
+    charge_dict["disposition"] = Dispositions.CONVICTED
+    subsection_6_charge = ChargeFactory.create(**charge_dict)
+
+    assert isinstance(subsection_6_charge, Subsection6)
+    assert subsection_6_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert (
+        subsection_6_charge.expungement_result.type_eligibility.reason
+        == "Ineligible under 137.225(6) in certain circumstances."
+    )
+
+
 def test_subsection_6_163200():
     charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
     charge_dict["name"] = "Criminal mistreatment in the second degree"

--- a/src/backend/tests/models/charge_types/test_subsection_6.py
+++ b/src/backend/tests/models/charge_types/test_subsection_6.py
@@ -53,3 +53,14 @@ def test_subsection_6_163145():
     subsection_6_charge = ChargeFactory.create(**charge_dict)
 
     assert isinstance(subsection_6_charge, Subsection6)
+
+
+def test_subsection_6_163205():
+    charge_dict = ChargeFactory.default_dict()
+    charge_dict["name"] = "Criminal mistreatment in the first degree"
+    charge_dict["statute"] = "163.205"
+    charge_dict["level"] = "Felony Class C"
+    charge_dict["disposition"] = Dispositions.CONVICTED
+    subsection_6_charge = ChargeFactory.create(**charge_dict)
+
+    assert isinstance(subsection_6_charge, Subsection6)

--- a/src/backend/tests/test_time_analyzer.py
+++ b/src/backend/tests/test_time_analyzer.py
@@ -461,17 +461,17 @@ def test_dismissed_felony_class_b_with_subsequent_conviction():
 
 
 def test_doubly_eligible_b_felony_gets_normal_eligibility_rule():
-    # This charge is both Subsection 12 and also a class B felony. List B classification takes precedence.
-    subsection_12_charge = ChargeFactory.create(
-        name="Assault in the second degree",
-        statute="163.175",
+    # This charge is both Schedule1PCS and also a class B felony. Schedule1PCS classification takes precedence and the B felony time rule does not apply.
+    pcs_charge = ChargeFactory.create(
+        name="Unlawful possession of methamphetamine",
+        statute="475894",
         level="Felony Class B",
         date=Time.LESS_THAN_TWENTY_YEARS_AGO,
         disposition=Disposition(ruling="Convicted", date=Time.LESS_THAN_TWENTY_YEARS_AGO),
     )
 
     case_1 = CaseFactory.create()
-    case_1.charges = [subsection_12_charge]
+    case_1.charges = [pcs_charge]
     subsequent_charge = ChargeFactory.create(disposition=Disposition(ruling="Convicted", date=Time.TEN_YEARS_AGO))
     case_2 = CaseFactory.create()
     case_2.charges = [subsequent_charge]
@@ -479,8 +479,8 @@ def test_doubly_eligible_b_felony_gets_normal_eligibility_rule():
     expunger = Expunger(Record([case_1, case_2]))
     expunger.run()
 
-    assert subsection_12_charge.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert subsection_12_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert pcs_charge.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert pcs_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
 
 
 def test_single_violation_is_time_restricted():


### PR DESCRIPTION
 * Subsection 6 overrides eligibility for Criminal mistreatment I
 * The lists of relevant statutes are migrated from charge_classifer to Subsection12 class fields, as part of the pending refactor for charge_classifier
 * The paragraphs that mention "attempt" are removed from the list of eligible statutes.

The subsection mentions some Attempt charges that are eligible. But because those charges are tried under different statutes from those listed, the statutes listed here have no effect on expungement eligibility. We could still tag these statutes as Needs More Analysis, and the code to do so is included here but commented out.

closes #830 
