### PR TITLE
Time eligibility reasons are updated for clarity

### DIFF
--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -46,11 +46,14 @@ class Expunger:
 
             if charge.convicted():
                 eligibility_dates.append(
-                    (charge.disposition.date + relativedelta(years=3), "Time-ineligible under 137.225(1)(a)")
+                    (
+                        charge.disposition.date + relativedelta(years=3),
+                        "Three years from date of conviction (137.225(1)(a))",
+                    )
                 )
 
             elif charge.dismissed():
-                eligibility_dates.append((charge.date, "Time eligible under 137.225(1)(b)"))
+                eligibility_dates.append((charge.date, "Eligible immediately (137.225(1)(b))"))
             else:
                 raise ValueError("Charge should always convicted or dismissed at this point.")
 
@@ -59,20 +62,27 @@ class Expunger:
 
             if charge.disposition.status == DispositionStatus.NO_COMPLAINT:
                 eligibility_dates.append(
-                    (charge.disposition.date + relativedelta(years=1), "Time-ineligible under 137.225(1)(b)")
+                    (
+                        charge.disposition.date + relativedelta(years=1),
+                        "One year from date of no-complaint arrest (137.225(1)(b))",
+                    )
                 )
 
             if most_recent_blocking_conviction:
+                other = "other " if charge.convicted() else ""
                 eligibility_dates.append(
                     (
                         most_recent_blocking_conviction.disposition.date + relativedelta(years=10),
-                        "Time-ineligible under 137.225(7)(b)",
+                        f"Ten years from most recent {other}conviction (137.225(7)(b))",
                     )
                 )
 
             if charge.dismissed() and most_recent_blocking_dismissal:
                 eligibility_dates.append(
-                    (most_recent_blocking_dismissal.date + relativedelta(years=3), "Recommend sequential expungement")
+                    (
+                        most_recent_blocking_dismissal.date + relativedelta(years=3),
+                        "Three years from most recent other arrest (137.225(8)(a))",
+                    )
                 )
 
             if charge.convicted() and isinstance(charge, FelonyClassB):
@@ -84,7 +94,7 @@ class Expunger:
                         )
                     )
                 else:
-                    eligibility_dates.append((charge.disposition.date + relativedelta(years=20), "137.225(5)(a)(A)(i) - Twenty years from class B felony conviction"))  # type: ignore
+                    eligibility_dates.append((charge.disposition.date + relativedelta(years=20), "Twenty years from class B felony conviction (137.225(5)(a)(A)(i))"))  # type: ignore
 
             charge.set_time_eligibility(eligibility_dates)
         for case in self.record.cases:
@@ -120,7 +130,9 @@ class Expunger:
                         charge.expungement_result.time_eligibility.date_will_be_eligible = (
                             attractor.expungement_result.time_eligibility.date_will_be_eligible
                         )
-                        charge.expungement_result.time_eligibility.reason = "The friendly rule: time eligibility of the arrest matches time eligibility of the conviction."
+                        charge.expungement_result.time_eligibility.reason = (
+                            'Time eligibility of the arrest matches conviction on the same case (the "friendly" rule)'
+                        )
                         # TODO: Feels dangerous; clean up
         return len(open_cases) == 0
 

--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -94,7 +94,7 @@ class Expunger:
                         )
                     )
                 else:
-                    eligibility_dates.append((charge.disposition.date + relativedelta(years=20), "Twenty years from class B felony conviction (137.225(5)(a)(A)(i))"))  # type: ignore
+                    eligibility_dates.append((charge.disposition.date + relativedelta(years=20), "Twenty years from date of class B felony conviction (137.225(5)(a)(A)(i))"))  # type: ignore
 
             charge.set_time_eligibility(eligibility_dates)
         for case in self.record.cases:

--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -69,11 +69,12 @@ class Expunger:
                 )
 
             if most_recent_blocking_conviction:
-                other = "other " if charge.convicted() else ""
+                conviction_string = "other conviction" if charge.convicted() else "conviction"
                 eligibility_dates.append(
                     (
+
                         most_recent_blocking_conviction.disposition.date + relativedelta(years=10),
-                        f"Ten years from most recent {other}conviction (137.225(7)(b))",
+                        f"Ten years from most recent {conviction_string} (137.225(7)(b))",
                     )
                 )
 

--- a/src/backend/tests/test_friendly_rule.py
+++ b/src/backend/tests/test_friendly_rule.py
@@ -24,7 +24,7 @@ def test_eligible_mrc_with_single_arrest():
     assert arrest.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
     assert (
         arrest.expungement_result.time_eligibility.reason
-        == "The friendly rule: time eligibility of the arrest matches time eligibility of the conviction."
+        == 'Time eligibility of the arrest matches conviction on the same case (the "friendly" rule)'
     )
     assert arrest.expungement_result.time_eligibility.date_will_be_eligible == date.today()
 
@@ -76,13 +76,16 @@ def test_eligible_mrc_with_violation():
     assert arrest.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
     assert (
         arrest.expungement_result.time_eligibility.reason
-        == "The friendly rule: time eligibility of the arrest matches time eligibility of the conviction."
+        == 'Time eligibility of the arrest matches conviction on the same case (the "friendly" rule)'
     )
     assert arrest.expungement_result.time_eligibility.date_will_be_eligible == date.today()
 
     assert violation.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
     assert violation.expungement_result.time_eligibility.date_will_be_eligible == date.today() + relativedelta(years=7)
-    assert violation.expungement_result.time_eligibility.reason == "Time-ineligible under 137.225(7)(b)"
+    assert (
+        violation.expungement_result.time_eligibility.reason
+        == "Ten years from most recent other conviction (137.225(7)(b))"
+    )
 
 
 def test_arrest_time_eligibility_is_set_to_older_violation():
@@ -106,7 +109,7 @@ def test_arrest_time_eligibility_is_set_to_older_violation():
     assert arrest.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
     assert (
         arrest.expungement_result.time_eligibility.reason
-        == "The friendly rule: time eligibility of the arrest matches time eligibility of the conviction."
+        == 'Time eligibility of the arrest matches conviction on the same case (the "friendly" rule)'
     )
     assert (
         arrest.expungement_result.time_eligibility.date_will_be_eligible
@@ -146,6 +149,6 @@ def test_3_violations_are_time_restricted():
     assert arrest.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
     assert (
         arrest.expungement_result.time_eligibility.reason
-        == "The friendly rule: time eligibility of the arrest matches time eligibility of the conviction."
+        == 'Time eligibility of the arrest matches conviction on the same case (the "friendly" rule)'
     )
     assert arrest.expungement_result.time_eligibility.date_will_be_eligible == earliest_date_eligible


### PR DESCRIPTION
 Rewrote the time eligibility reasons to read more consistently and be more explicit in their meaning.

Here's an example of what two of these look like in results:

![new_time_eligibility_reasons](https://user-images.githubusercontent.com/2104990/74969349-476fc900-53d1-11ea-91dd-824744bc9d5b.png)

This gets rid of the advice "recommend sequential expungement" because it's pretty hard to suss out exactly when this circumstance applies. The previous behavior was inaccurate, before and after our refactor the time analyzer.

- A dismissal is being time-blocked by a more recent dismissal.
- The more recent dismissal is eligible, making it possible to do the actual two-step expungement. 

We could do this, but we could also expect a user of the app to understand this expungement technique.

Similarly, "ten years from most recent other conviction" doesn't specify whether the other conviction is before or after the charge in question. I don't think that's a significant loss in interpretability / readability because the information is all still there in the results. 
  
closes #619 

I tweaked the language again since our convo on that issue, because I still wanted to have statute references in there. 