### PR TITLE
adding a pre-commit hook for the autogeneration of documentation (#818)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,9 @@ dev_drop_database:
 dev_mock_oeci_up:
 	docker-compose -f docker-compose.dev.yml -f src/frontend/developerUtils/docker-compose.mock-oeci.yml up -d
 
+dev_gen_docs:
+	cd ./src/backend/ && python ./util/generate_charge_types_doc.py
+
 .PHONY: $(REQUIREMENTS_TXT)
 $(REQUIREMENTS_TXT):
 	pipenv lock -r > $@

--- a/src/backend/util/generate_charge_types_doc.py
+++ b/src/backend/util/generate_charge_types_doc.py
@@ -2,13 +2,14 @@
 This util script generates the user-facing documentation for charge types as an md file.
 """
 
-import pkgutil
+import sys
+from os import getcwd
+sys.path.append(getcwd())
 from expungeservice.models.charge import Charge
 from expungeservice.models.helpers.generator import get_charge_classes
 
 
 def generate_charge_type_doc():
-
     manual_doc_string = """# Charge Types
 The expungement system defines this custom set of charge types, to compute their correct type eligibility."
 """
@@ -21,4 +22,5 @@ The expungement system defines this custom set of charge types, to compute their
     doc_file.close()
 
 
-generate_charge_type_doc()
+if __name__ == '__main__':
+    generate_charge_type_doc()


### PR DESCRIPTION
addressing issue #818 
adding a pre-commit hook that uses python to auto-generate the documentation in charge-docs.  Not sure if this is the best way to do it, so welcoming feedback. Tossing this script in your `.git/hooks` folder will allow the docs to be generated when the commit is made, the disadvantage being after your commit is made, you'll want to make another commit to have the updated documentation...?

after creating this and reviewing it, I'm wondering if this would be better as a make target....