### PR TITLE
Deleted old heroku db support (also sqlalchemy, which we don't use)

### DIFF
--- a/src/backend/expungeservice/config.py
+++ b/src/backend/expungeservice/config.py
@@ -11,7 +11,6 @@ class Development(object):
     TESTING = False
     SECRET_KEY = "1234567890987654321234567890987654321234567890987654321234567890987654321234567890987654321234567"
     JWT_EXPIRY_TIMER = datetime.timedelta(minutes=60)
-    SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URL")
     SESSION_COOKIE_SECURE = False
 
 
@@ -22,7 +21,6 @@ class Production(object):
 
     DEBUG = False
     TESTING = False
-    SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URL")
     SECRET_KEY = os.getenv("SECRET_KEY")
     JWT_EXPIRY_TIMER = datetime.timedelta(minutes=60)
     SESSION_COOKIE_SECURE = True

--- a/src/backend/expungeservice/database/database.py
+++ b/src/backend/expungeservice/database/database.py
@@ -6,6 +6,8 @@ import psycopg2
 import psycopg2.extras
 import os
 
+from urllib.parse import urlparse
+
 
 class Database(object):
     """Database connection class.
@@ -98,35 +100,12 @@ Username: {}""".format(
         )
         return s
 
-
 def get_database():
 
-    """
-    Acquiring db access creds depending on the environment variables present.
-    DATABASE_URL is defined in the Heroku container and provides
-    database connection info.
-    """
-    if os.environ.get("DATABASE_URL"):
-        print("using database url: ", os.environ.get("DATABASE_URL"))
-        infostr = os.environ["DATABASE_URL"].split("postgres://")[1]
-        creds, hostdat = infostr.split("@")
-        # An example heroku db url:
-        # postgres://kkpshuqenz:dc7393549121483a18c5b77b47af7f536567d31acb952128ce0bb@ec2-50-16-225-96.compute-1.amazonaws.com:5432/d98vao1s9j9t18
-
-        username = creds.split(":")[0]
-        password = creds.split(":")[1]
-        host = hostdat.split(":")[0]
-        port = 5432
-        name = hostdat.split("/")[1]
-
-    else:
-        """
-        In the dev environment, we use a set of env vars for the db conn:
-        """
-        host = os.environ["PGHOST"]
-        port = int(os.environ["PGPORT"])
-        name = os.environ["PGDATABASE"]
-        username = os.environ["POSTGRES_USERNAME"]
-        password = os.environ["POSTGRES_PASSWORD"]
+    host = os.environ["PGHOST"]
+    port = int(os.environ["PGPORT"])
+    name = os.environ["PGDATABASE"]
+    username = os.environ["POSTGRES_USERNAME"]
+    password = os.environ["POSTGRES_PASSWORD"]
 
     return Database(host=host, port=port, name=name, username=username, password=password)

--- a/src/backend/expungeservice/database/database.py
+++ b/src/backend/expungeservice/database/database.py
@@ -6,8 +6,6 @@ import psycopg2
 import psycopg2.extras
 import os
 
-from urllib.parse import urlparse
-
 
 class Database(object):
     """Database connection class.


### PR DESCRIPTION
Since we moved off of Heroku, we no longer on a db config that uses the env variable `DATABASE_URL` 

replaced #875 