### PR TITLE
Remove date_will_be_eligible from ChargeEligibility

### DIFF
--- a/src/backend/expungeservice/models/expungement_result.py
+++ b/src/backend/expungeservice/models/expungement_result.py
@@ -36,7 +36,6 @@ class TimeEligibility:
 class ChargeEligibility:
     status: ChargeEligibilityStatus
     label: str
-    date_will_be_eligible: Optional[date]
 
 
 @dataclass
@@ -51,46 +50,42 @@ class ExpungementResult:
     def charge_eligibility(self):
         if self.type_eligibility.status == EligibilityStatus.ELIGIBLE:
             if self.time_eligibility and self.time_eligibility.status == EligibilityStatus.ELIGIBLE:
-                return ChargeEligibility(ChargeEligibilityStatus.ELIGIBLE_NOW, "Eligible", None)
+                return ChargeEligibility(ChargeEligibilityStatus.ELIGIBLE_NOW, "Eligible")
 
             elif self.time_eligibility and self.time_eligibility.status == EligibilityStatus.INELIGIBLE:
                 if self.time_eligibility.date_will_be_eligible == date.max:
                     # Currently, no charge types that are type-eligible can be disqualified due to a time-ineligibility date of max, meaning "never"
                     # So this else block has no applicable cases and never runs. But it will apply if a new charge type that qualifies gets added.
-                    return ChargeEligibility(ChargeEligibilityStatus.INELIGIBLE, "Ineligible", None)
+                    return ChargeEligibility(ChargeEligibilityStatus.INELIGIBLE, "Ineligible")
                 elif self.time_eligibility.date_will_be_eligible:
                     return ChargeEligibility(
                         ChargeEligibilityStatus.WILL_BE_ELIGIBLE,
                         f"Eligible {self.time_eligibility.date_will_be_eligible.strftime('%b %-d, %Y')}",
-                        self.time_eligibility.date_will_be_eligible,
                     )
                 else:
                     raise ValueError("There was no date_will_be_eligible.")
             else:
-                return ChargeEligibility(
-                    ChargeEligibilityStatus.UNKNOWN, "Type-eligible but time analysis is missing", None
-                )
+                return ChargeEligibility(ChargeEligibilityStatus.UNKNOWN, "Type-eligible but time analysis is missing")
 
         elif self.type_eligibility.status == EligibilityStatus.NEEDS_MORE_ANALYSIS:
             if self.time_eligibility and self.time_eligibility.status == EligibilityStatus.ELIGIBLE:
-                return ChargeEligibility(ChargeEligibilityStatus.POSSIBLY_ELIGIBILE, "Possibly Eligible (review)", None)
+                return ChargeEligibility(ChargeEligibilityStatus.POSSIBLY_ELIGIBILE, "Possibly Eligible (review)")
 
             elif self.time_eligibility and self.time_eligibility.status == EligibilityStatus.INELIGIBLE:
                 if self.time_eligibility.date_will_be_eligible == date.max:
                     # Currently, this occurs with Class B Felonies only, which can be time ineligible with a date of max, meaning "never"
-                    return ChargeEligibility(ChargeEligibilityStatus.INELIGIBLE, "Ineligible", None)
+                    return ChargeEligibility(ChargeEligibilityStatus.INELIGIBLE, "Ineligible")
                 elif self.time_eligibility.date_will_be_eligible:
                     return ChargeEligibility(
                         ChargeEligibilityStatus.POSSIBLY_WILL_BE_ELIGIBLE,
                         f"Possibly Eligible {self.time_eligibility.date_will_be_eligible.strftime('%b %-d, %Y')} (review)",
-                        self.time_eligibility.date_will_be_eligible,
                     )
                 else:
                     raise ValueError("There was no date_will_be_eligible.")
             else:
                 return ChargeEligibility(
-                    ChargeEligibilityStatus.UNKNOWN, "Possibly eligible but time analysis is missing", None
+                    ChargeEligibilityStatus.UNKNOWN, "Possibly eligible but time analysis is missing"
                 )
 
         elif self.type_eligibility.status == EligibilityStatus.INELIGIBLE:
-            return ChargeEligibility(ChargeEligibilityStatus.INELIGIBLE, "Ineligible", None)
+            return ChargeEligibility(ChargeEligibilityStatus.INELIGIBLE, "Ineligible")

--- a/src/backend/tests/models/test_expungement_result.py
+++ b/src/backend/tests/models/test_expungement_result.py
@@ -8,7 +8,6 @@ def test_eligible():
 
     assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.ELIGIBLE_NOW
     assert expungement_result.charge_eligibility.label == "Eligible"
-    assert expungement_result.charge_eligibility.date_will_be_eligible is None
 
 
 def test_will_be_eligible():
@@ -19,7 +18,6 @@ def test_will_be_eligible():
 
     assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.WILL_BE_ELIGIBLE
     assert expungement_result.charge_eligibility.label == f"Eligible {today.strftime('%b %-d, %Y')}"
-    assert expungement_result.charge_eligibility.date_will_be_eligible == today
 
 
 def test_possibly_eligible():
@@ -30,7 +28,6 @@ def test_possibly_eligible():
 
     assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.POSSIBLY_ELIGIBILE
     assert expungement_result.charge_eligibility.label == "Possibly Eligible (review)"
-    assert expungement_result.charge_eligibility.date_will_be_eligible is None
 
 
 def test_possibly_will_be_eligible():
@@ -41,7 +38,6 @@ def test_possibly_will_be_eligible():
 
     assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.POSSIBLY_WILL_BE_ELIGIBLE
     assert expungement_result.charge_eligibility.label == f"Possibly Eligible {today.strftime('%b %-d, %Y')} (review)"
-    assert expungement_result.charge_eligibility.date_will_be_eligible == today
 
 
 def test_ineligible():


### PR DESCRIPTION
Note how on the frontend the type of ChargeEligibility does not include `date_will_be_eligible`:

```
export interface ChargeEligibility {
  status: string;
  label: string;
}
```