### PR TITLE
Handle friendly rule case where attractor is NEEDS_MORE_ANALYSIS

### DIFF
--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -72,7 +72,6 @@ class Expunger:
                 conviction_string = "other conviction" if charge.convicted() else "conviction"
                 eligibility_dates.append(
                     (
-
                         most_recent_blocking_conviction.disposition.date + relativedelta(years=10),
                         f"Ten years from most recent {conviction_string} (137.225(7)(b))",
                     )
@@ -125,15 +124,24 @@ class Expunger:
                         and charge.expungement_result.time_eligibility.date_will_be_eligible
                         >= attractor.expungement_result.time_eligibility.date_will_be_eligible
                     ):
-                        charge.expungement_result.time_eligibility.status = (
-                            attractor.expungement_result.time_eligibility.status
-                        )
+                        if (
+                            attractor.expungement_result.type_eligibility.status
+                            == EligibilityStatus.NEEDS_MORE_ANALYSIS
+                        ):
+                            # charge's time eligibility status and reason remains as before assuming worst case as friendly rule only improves time eligibility
+                            charge.expungement_result.time_eligibility.date_eligible_without_friendly_rule = (
+                                charge.expungement_result.time_eligibility.date_will_be_eligible
+                            )
+                        else:
+                            # date_eligible_without_friendly_rule remains None
+                            charge.expungement_result.time_eligibility.status = (
+                                attractor.expungement_result.time_eligibility.status
+                            )
+                            charge.expungement_result.time_eligibility.reason = 'Time eligibility of the arrest matches conviction on the same case (the "friendly" rule)'
                         charge.expungement_result.time_eligibility.date_will_be_eligible = (
                             attractor.expungement_result.time_eligibility.date_will_be_eligible
                         )
-                        charge.expungement_result.time_eligibility.reason = (
-                            'Time eligibility of the arrest matches conviction on the same case (the "friendly" rule)'
-                        )
+
                         # TODO: Feels dangerous; clean up
         return len(open_cases) == 0
 

--- a/src/backend/expungeservice/models/expungement_result.py
+++ b/src/backend/expungeservice/models/expungement_result.py
@@ -30,6 +30,7 @@ class TimeEligibility:
     status: EligibilityStatus
     reason: str
     date_will_be_eligible: Optional[date]
+    date_eligible_without_friendly_rule: Optional[date] = None
 
 
 @dataclass
@@ -57,6 +58,17 @@ class ExpungementResult:
                     # Currently, no charge types that are type-eligible can be disqualified due to a time-ineligibility date of max, meaning "never"
                     # So this else block has no applicable cases and never runs. But it will apply if a new charge type that qualifies gets added.
                     return ChargeEligibility(ChargeEligibilityStatus.INELIGIBLE, "Ineligible")
+                elif (
+                    self.time_eligibility.date_will_be_eligible
+                    and self.time_eligibility.date_eligible_without_friendly_rule
+                ):
+                    label_date_eligible = (
+                        self.time_eligibility.date_will_be_eligible.strftime("%b %-d, %Y")
+                        if self.time_eligibility.date_will_be_eligible > date.today()
+                        else "now"
+                    )
+                    label = f"Eligible {label_date_eligible} or {self.time_eligibility.date_eligible_without_friendly_rule.strftime('%b %-d, %Y')} w/o friendly rule (review)"
+                    return ChargeEligibility(ChargeEligibilityStatus.WILL_BE_ELIGIBLE, label)
                 elif self.time_eligibility.date_will_be_eligible:
                     return ChargeEligibility(
                         ChargeEligibilityStatus.WILL_BE_ELIGIBLE,
@@ -75,6 +87,17 @@ class ExpungementResult:
                 if self.time_eligibility.date_will_be_eligible == date.max:
                     # Currently, this occurs with Class B Felonies only, which can be time ineligible with a date of max, meaning "never"
                     return ChargeEligibility(ChargeEligibilityStatus.INELIGIBLE, "Ineligible")
+                elif (
+                    self.time_eligibility.date_will_be_eligible
+                    and self.time_eligibility.date_eligible_without_friendly_rule
+                ):
+                    label_date_eligible = (
+                        self.time_eligibility.date_will_be_eligible.strftime("%b %-d, %Y")
+                        if self.time_eligibility.date_will_be_eligible > date.today()
+                        else "now"
+                    )
+                    label = f"Possibly Eligible {label_date_eligible} or {self.time_eligibility.date_eligible_without_friendly_rule.strftime('%b %-d, %Y')} w/o friendly rule (review)"
+                    return ChargeEligibility(ChargeEligibilityStatus.POSSIBLY_WILL_BE_ELIGIBLE, label)
                 elif self.time_eligibility.date_will_be_eligible:
                     return ChargeEligibility(
                         ChargeEligibilityStatus.POSSIBLY_WILL_BE_ELIGIBLE,

--- a/src/backend/tests/test_friendly_rule.py
+++ b/src/backend/tests/test_friendly_rule.py
@@ -2,7 +2,7 @@ from dateutil.relativedelta import relativedelta
 
 from expungeservice.expunger import Expunger
 from expungeservice.models.disposition import Disposition
-from expungeservice.models.expungement_result import EligibilityStatus
+from expungeservice.models.expungement_result import EligibilityStatus, ChargeEligibilityStatus
 from expungeservice.models.record import Record
 from tests.factories.case_factory import CaseFactory
 from tests.factories.charge_factory import ChargeFactory
@@ -19,18 +19,22 @@ def test_eligible_mrc_with_single_arrest():
     case.charges = [three_yr_mrc, arrest]
     record = Record([case])
     expunger = Expunger(record)
-
     expunger.run()
+
     assert arrest.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
     assert (
         arrest.expungement_result.time_eligibility.reason
         == 'Time eligibility of the arrest matches conviction on the same case (the "friendly" rule)'
     )
     assert arrest.expungement_result.time_eligibility.date_will_be_eligible == date.today()
+    assert arrest.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.ELIGIBLE_NOW
+    assert arrest.expungement_result.charge_eligibility.label == "Eligible"
 
     assert three_yr_mrc.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
     assert three_yr_mrc.expungement_result.time_eligibility.reason == ""
     assert three_yr_mrc.expungement_result.time_eligibility.date_will_be_eligible == date.today()
+    assert three_yr_mrc.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.ELIGIBLE_NOW
+    assert three_yr_mrc.expungement_result.charge_eligibility.label == "Eligible"
 
 
 def test_arrest_is_unaffected_if_conviction_eligibility_is_older():
@@ -86,6 +90,69 @@ def test_eligible_mrc_with_violation():
         violation.expungement_result.time_eligibility.reason
         == "Ten years from most recent other conviction (137.225(7)(b))"
     )
+
+
+def test_needs_more_analysis_mrc_with_single_arrest():
+    charge_dict = ChargeFactory.default_dict()
+    charge_dict["name"] = "Incest"
+    charge_dict["statute"] = "163.525"
+    charge_dict["level"] = "Felony Class C"
+    charge_dict["disposition"] = Disposition(ruling="Convicted", date=Time.THREE_YEARS_AGO)
+    three_yr_mrc = ChargeFactory.create(**charge_dict)
+    arrest = ChargeFactory.create(disposition=Disposition(ruling="Dismissed", date=Time.THREE_YEARS_AGO))
+
+    case = CaseFactory.create()
+    case.charges = [three_yr_mrc, arrest]
+    record = Record([case])
+    expunger = Expunger(record)
+    expunger.run()
+
+    ten_years_from_mrc = three_yr_mrc.disposition.date + Time.TEN_YEARS
+    assert arrest.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert arrest.expungement_result.time_eligibility.reason == "Ten years from most recent conviction (137.225(7)(b))"
+    assert arrest.expungement_result.time_eligibility.date_will_be_eligible == date.today()
+    assert arrest.expungement_result.time_eligibility.date_eligible_without_friendly_rule == ten_years_from_mrc
+    assert arrest.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.WILL_BE_ELIGIBLE
+    assert (
+        arrest.expungement_result.charge_eligibility.label
+        == f"Eligible now or {ten_years_from_mrc.strftime('%b %-d, %Y')} w/o friendly rule (review)"
+    )
+
+    assert three_yr_mrc.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert three_yr_mrc.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert three_yr_mrc.expungement_result.time_eligibility.reason == ""
+    assert three_yr_mrc.expungement_result.time_eligibility.date_will_be_eligible == date.today()
+    assert three_yr_mrc.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.POSSIBLY_ELIGIBILE
+    assert three_yr_mrc.expungement_result.charge_eligibility.label == "Possibly Eligible (review)"
+
+
+def test_very_old_needs_more_analysis_mrc_with_single_arrest():
+    charge_dict = ChargeFactory.default_dict()
+    charge_dict["name"] = "Incest"
+    charge_dict["statute"] = "163.525"
+    charge_dict["level"] = "Felony Class C"
+    charge_dict["disposition"] = Disposition(ruling="Convicted", date=Time.TWENTY_YEARS_AGO)
+    mrc = ChargeFactory.create(**charge_dict)
+    arrest = ChargeFactory.create(disposition=Disposition(ruling="Dismissed", date=Time.THREE_YEARS_AGO))
+
+    case = CaseFactory.create()
+    case.charges = [mrc, arrest]
+    record = Record([case])
+    expunger = Expunger(record)
+    expunger.run()
+
+    three_years_from_mrc = mrc.disposition.date + Time.THREE_YEARS
+    assert arrest.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert arrest.expungement_result.time_eligibility.date_will_be_eligible == three_years_from_mrc
+    assert arrest.expungement_result.time_eligibility.date_eligible_without_friendly_rule == Time.THREE_YEARS_AGO
+    assert arrest.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.ELIGIBLE_NOW
+    assert arrest.expungement_result.charge_eligibility.label == "Eligible"
+
+    assert mrc.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert mrc.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert mrc.expungement_result.time_eligibility.date_will_be_eligible == three_years_from_mrc
+    assert mrc.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.POSSIBLY_ELIGIBILE
+    assert mrc.expungement_result.charge_eligibility.label == "Possibly Eligible (review)"
 
 
 def test_arrest_time_eligibility_is_set_to_older_violation():


### PR DESCRIPTION
Resolves https://github.com/codeforpdx/recordexpungPDX/issues/820

This is a fairly ugly edge case to the friendly rule. We will display two dates for all arrests that have a conviction in the same case with a type eligibility of needs more analysis (where the friendly rule may apply): `date_will_be_eligible` (assuming conviction was type eligible) and `date_eligible_without_friendly_rule` (assuming conviction wasn't type eligible). It is guaranteed that `date_will_be_eligible` is always before `date_eligible_without_friendly_rule`. The time eligibility status and reason for the arrests will reflect the worst case possibility: that the conviction was ineligible and therefore the time eligibility of the arrest is further out. If the time eligibility status of the arrest is ELIGIBLE, then we can safely say assign the arrest ChargeEligibilityStatus.ELIGIBLE_NOW as both `date_will_be_eligible` and `date_eligible_without_friendly_rule` are in the past.

No changes to the frontend should be necessary although now the RecordTime field is only showing the reason for the worse case date. Simply adding including both reasons into the reason string on the backend will not suffice as the icon for when the time eligibility is ELIGIBLE and INELIGIBLE is different.