### PR TITLE
Add logic for 137.225(1)(c) to expunger (Probation Revoked)

### DIFF
--- a/src/backend/expungeservice/crawler/parsers/case_parser.py
+++ b/src/backend/expungeservice/crawler/parsers/case_parser.py
@@ -1,5 +1,6 @@
 import re
 from dataclasses import dataclass
+from datetime import datetime, date
 from typing import List, Dict, Optional, Tuple
 
 from bs4 import BeautifulSoup
@@ -18,7 +19,7 @@ class CaseParserData:
     hashed_charge_data: Dict[int, Dict[str, str]]
     hashed_dispo_data: Dict[int, Dict[str, str]]
     balance_due: str
-    probation_revoked: bool
+    probation_revoked: Optional[date]
 
 
 class CaseParser:
@@ -28,10 +29,13 @@ class CaseParser:
         hashed_charge_data = CaseParser.__build_charge_table_data(soup)
         (
             hashed_dispo_data,
-            latest_probation_revoked_date_string,
+            probation_revoked_date_string,
         ) = CaseParser.__build_hashed_dispo_data_and_probation_revoked(soup)
         balance_due = CaseParser.__build_balance_due(soup)
-        probation_revoked = True if latest_probation_revoked_date_string else False  # TODO: Pass through date
+        if probation_revoked_date_string:
+            probation_revoked = datetime.date(datetime.strptime(probation_revoked_date_string, "%m/%d/%Y"))
+        else:
+            probation_revoked = None  # type: ignore
         return CaseParserData(hashed_charge_data, hashed_dispo_data, balance_due, probation_revoked)
 
     @staticmethod

--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -60,13 +60,15 @@ class Expunger:
                     )
                 )
 
-            if charge.convicted() and charge.case()().get_probation_revoked():
-                eligibility_dates.append(
-                    (
-                        charge.disposition.date + relativedelta(years=10),
-                        "Time-ineligible under 137.225(1)(c). See comments for when there are multiple convictions in a case.",
+            if charge.convicted():
+                probation_revoked_date = charge.case()().get_probation_revoked()
+                if probation_revoked_date:
+                    eligibility_dates.append(
+                        (
+                            probation_revoked_date + relativedelta(years=10),
+                            "Time-ineligible under 137.225(1)(c). Inspect further if the case has multiple convictions on the case.",
+                        )
                     )
-                )
 
             if most_recent_blocking_conviction:
                 conviction_string = "other conviction" if charge.convicted() else "conviction"

--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -6,20 +6,12 @@ from more_itertools import flatten, padnone, take
 
 from expungeservice.models.charge import Charge
 from expungeservice.models.charge_types.felony_class_b import FelonyClassB
-from expungeservice.models.expungement_result import EligibilityStatus
 from expungeservice.models.disposition import DispositionStatus
 from expungeservice.models.expungement_result import EligibilityStatus
 from expungeservice.models.record import Record
 
 
 class Expunger:
-    """
-    The TimeAnalyzer is probably the last major chunk of non-functional code.
-    We mutate the charges in the record directly to add time eligibility information.
-    Hence, for example, it is unsafe to deepcopy any elements in the "chain" stemming from record
-    including closed_charges, charges, self.charges_with_summary.
-    """
-
     def __init__(self, record: Record):
         self.record = record
         self.analyzable_charges = Expunger._without_skippable_charges(self.record.charges)
@@ -65,6 +57,14 @@ class Expunger:
                     (
                         charge.disposition.date + relativedelta(years=1),
                         "One year from date of no-complaint arrest (137.225(1)(b))",
+                    )
+                )
+
+            if charge.convicted() and charge.case()().get_probation_revoked():
+                eligibility_dates.append(
+                    (
+                        charge.disposition.date + relativedelta(years=10),
+                        "Time-ineligible under 137.225(1)(c). See comments for when there are multiple convictions in a case.",
                     )
                 )
 

--- a/src/backend/expungeservice/models/case.py
+++ b/src/backend/expungeservice/models/case.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import datetime, date
+from datetime import datetime, date as date_class
 from typing import List, Optional
 
 from expungeservice.models.charge import Charge
@@ -12,13 +12,13 @@ class Case:
     case_number: str
     citation_number: str
     location: str
-    date: date
+    date: date_class
     violation_type: str
     current_status: str
     charges: List[Charge]
     case_detail_link: str
     __balance_due_in_cents: int = 0
-    __probation_revoked: bool = False
+    __probation_revoked: Optional[date_class] = None
 
     @staticmethod
     def create(info, case_number, citation_number, date_location, type_status, charges, case_detail_link, balance="0"):
@@ -43,10 +43,10 @@ class Case:
         case.set_balance_due(balance)
         return case
 
-    def get_probation_revoked(self) -> bool:
+    def get_probation_revoked(self) -> Optional[date_class]:
         return self.__probation_revoked
 
-    def set_probation_revoked(self, probation_revoked: bool):
+    def set_probation_revoked(self, probation_revoked: Optional[date_class]):
         self.__probation_revoked = probation_revoked
 
     def set_balance_due(self, balance_due_dollar_amount: str):

--- a/src/backend/tests/test_crawler_expunger.py
+++ b/src/backend/tests/test_crawler_expunger.py
@@ -185,3 +185,17 @@ def test_expunger_runs_time_analyzer(record_with_specific_dates):
     assert record.cases[2].charges[0].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
     assert record.cases[2].charges[1].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
     assert record.cases[2].charges[2].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+
+
+@pytest.fixture
+def record_with_revoked_probation(crawler):
+    return CrawlerFactory.create(crawler, cases={"X0001": CaseDetails.CASE_WITH_REVOKED_PROBATION})
+
+
+def test_probation_revoked_affects_time_eligibility(record_with_revoked_probation):
+    record = record_with_revoked_probation
+    expunger = Expunger(record)
+    assert expunger.run()
+    assert record.cases[0].charges[0].expungement_result.time_eligibility.date_will_be_eligible == date_class(
+        2020, 11, 9
+    )


### PR DESCRIPTION
Instead of doing a full text fuzzy search, we now do a fuzzy search per event for "probation revoked" and extract the date. We assume probations apply to every conviction in the case as in practice every case in which there is a probation all convictions are usually merged into the “main” conviction.