### PR TITLE
Add hyperlink to case numbers in error banners

### DIFF
--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -213,7 +213,7 @@ class Expunger:
         cases_with_unrecognized_disposition: Set[Tuple[str, str]] = set()
         for charge in charges:
             if charge.blocks_other_charges():
-                case_number = f"[{charge.case()().case_number}]";
+                case_number = f"[{charge.case()().case_number}]"
                 if not charge.disposition and charge.case()().closed():
                     cases_with_missing_disposition.add(case_number)
                 elif charge.disposition and charge.disposition.status == DispositionStatus.UNRECOGNIZED:

--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -24,7 +24,7 @@ class Expunger:
         """
         open_cases = [case for case in self.record.cases if not case.closed()]
         if len(open_cases) > 0:
-            case_numbers = ",".join([case.case_number for case in open_cases])
+            case_numbers = ",".join([f"[{case.case_number}]" for case in open_cases])
             self.record.errors += [
                 f"All charges are ineligible because there is one or more open case: {case_numbers}. Open cases with valid dispositions are still included in time analysis. Otherwise they are ignored, so time analysis may be inaccurate for other charges."
             ]

--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -213,7 +213,7 @@ class Expunger:
         cases_with_unrecognized_disposition: Set[Tuple[str, str]] = set()
         for charge in charges:
             if charge.blocks_other_charges():
-                case_number = charge.case()().case_number
+                case_number = f"[{charge.case()().case_number}]";
                 if not charge.disposition and charge.case()().closed():
                     cases_with_missing_disposition.add(case_number)
                 elif charge.disposition and charge.disposition.status == DispositionStatus.UNRECOGNIZED:

--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -24,7 +24,7 @@ class Expunger:
         """
         open_cases = [case for case in self.record.cases if not case.closed()]
         if len(open_cases) > 0:
-            case_numbers = ",".join([f"[{case.case_number}]" for case in open_cases])
+            case_numbers = ", ".join([f"[{case.case_number}]" for case in open_cases])
             self.record.errors += [
                 f"All charges are ineligible because there is one or more open case: {case_numbers}. Open cases with valid dispositions are still included in time analysis. Otherwise they are ignored, so time analysis may be inaccurate for other charges."
             ]

--- a/src/backend/tests/test_crawler_expunger.py
+++ b/src/backend/tests/test_crawler_expunger.py
@@ -68,7 +68,7 @@ def test_case_without_dispos(record_without_dispos):
     assert record_without_dispos.cases[0].closed()
     assert expunger.run()
     assert record_without_dispos.errors[0] == (
-        f"""Case {record_without_dispos.cases[0].case_number} has a charge with a missing disposition.
+        f"""Case [{record_without_dispos.cases[0].case_number}] has a charge with a missing disposition.
 This might be an error in the OECI database. Time analysis is ignoring this charge and may be inaccurate for other charges."""
     )
 
@@ -82,7 +82,7 @@ def test_case_with_unrecognized_dispo(record_with_unrecognized_dispo):
     expunger = Expunger(record_with_unrecognized_dispo)
     assert expunger.run()
     assert record_with_unrecognized_dispo.errors[0] == (
-        f"""Case {record_with_unrecognized_dispo.cases[0].case_number} has a charge with an unrecognized disposition (Something unrecognized).
+        f"""Case [{record_with_unrecognized_dispo.cases[0].case_number}] has a charge with an unrecognized disposition (Something unrecognized).
 This might be an error in the OECI database. Time analysis is ignoring this charge and may be inaccurate for other charges."""
     )
 
@@ -105,13 +105,13 @@ def test_case_with_mulitple_disposition_errors(record_with_multiple_disposition_
     unrecognized_error_message = f"""The following cases have charges with an unrecognized disposition.
 This might be an error in the OECI database. Time analysis is ignoring these charges and may be inaccurate for other charges.
 Case numbers: """
-    cases_order_1 = "X0001 (Something unrecognized), X0002 (Something else unrecognized)"
-    cases_order_2 = "X0002 (Something else unrecognized), X0001 (Something unrecognized)"
+    cases_order_1 = "[X0001] (Something unrecognized), [X0002] (Something else unrecognized)"
+    cases_order_2 = "[X0002] (Something else unrecognized), [X0001] (Something unrecognized)"
     assert (
         unrecognized_error_message + cases_order_1 in record_with_multiple_disposition_errors.errors
         or unrecognized_error_message + cases_order_2 in record_with_multiple_disposition_errors.errors
     )
-    missing_error_message = f"""Case X0003 has a charge with a missing disposition.
+    missing_error_message = f"""Case [X0003] has a charge with a missing disposition.
 This might be an error in the OECI database. Time analysis is ignoring this charge and may be inaccurate for other charges."""
     assert missing_error_message in record_with_multiple_disposition_errors.errors
 

--- a/src/frontend/src/components/SearchResults/index.tsx
+++ b/src/frontend/src/components/SearchResults/index.tsx
@@ -14,7 +14,6 @@ export default class SearchResults extends React.Component<Props> {
         const id= "record_error_" + errorIndex;
         
         const errorMessageArray = errorMessage.split(/(\[.*?\])/g); 
-        console.log("Message" + errorMessageArray);
         const errorMessageHTML = errorMessageArray.map(function (element) {
           if (element.match(/^\[.*\]$/)) {
               const caseNumber = element.slice(1, -1);

--- a/src/frontend/src/components/SearchResults/index.tsx
+++ b/src/frontend/src/components/SearchResults/index.tsx
@@ -12,8 +12,19 @@ export default class SearchResults extends React.Component<Props> {
     const errors = ( this.props.record.errors ?
       this.props.record.errors.map(((errorMessage: string, errorIndex: number) => {
         const id= "record_error_" + errorIndex;
+        
+        const errorMessageArray = errorMessage.split(/(\[.*?\])/g); 
+        console.log("Message" + errorMessageArray);
+        const errorMessageHTML = errorMessageArray.map(function (element) {
+          if (element.match(/^\[.*\]$/)) {
+              const caseNumber = element.slice(1, -1);
+              return <a href={"#" + caseNumber}>{caseNumber}</a>;
+          } else {
+              return element;
+          }
+        });
         return <p id={id} className="bg-washed-red mv4 pa3 br3 fw6">
-                  {errorMessage}
+                  {errorMessageHTML}
                </p>
         }
         )


### PR DESCRIPTION
Creates hyperlink on case numbers in the error banners for open cases and bad dispositions. 

Author: @KorynLA 

Created a new branch to update via a rebase on master.