### PR TITLE
Remove ChargeFactory.default_dict()

### DIFF
--- a/src/backend/tests/factories/charge_factory.py
+++ b/src/backend/tests/factories/charge_factory.py
@@ -6,17 +6,6 @@ from tests.factories.case_factory import CaseFactory
 
 class ChargeFactory:
     @staticmethod
-    def default_dict(disposition=None):
-        return {
-            "case": CaseFactory.create(),
-            "name": "Theft of services",
-            "statute": "164.125",
-            "level": "Misdemeanor Class A",
-            "date": date_class(1901, 1, 1),
-            "disposition": disposition,
-        }
-
-    @staticmethod
     def create(
         case=CaseFactory.create(),
         name="Theft of services",

--- a/src/backend/tests/models/charge_types/test_felony_class_a.py
+++ b/src/backend/tests/models/charge_types/test_felony_class_a.py
@@ -6,12 +6,12 @@ from tests.models.test_charge import Dispositions
 
 
 def test_felony_class_a_charge():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Assault in the first degree"
-    charge_dict["statute"] = "163.185"
-    charge_dict["level"] = "Felony Class A"
-    charge_dict["disposition"] = Dispositions.CONVICTED
-    felony_class_a_convicted = ChargeFactory.create(**charge_dict)
+    felony_class_a_convicted = ChargeFactory.create(
+        name="Assault in the first degree",
+        statute="163.185",
+        level="Felony Class A",
+        disposition=Dispositions.CONVICTED,
+    )
 
     assert isinstance(felony_class_a_convicted, FelonyClassA)
     assert felony_class_a_convicted.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
@@ -19,12 +19,12 @@ def test_felony_class_a_charge():
 
 
 def test_felony_class_a_dismissed():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Assault in the first degree"
-    charge_dict["statute"] = "163.185"
-    charge_dict["level"] = "Felony Class A"
-    charge_dict["disposition"] = Dispositions.DISMISSED
-    felony_class_a_dismissed = ChargeFactory.create(**charge_dict)
+    felony_class_a_dismissed = ChargeFactory.create(
+        name="Assault in the first degree",
+        statute="163.185",
+        level="Felony Class A",
+        disposition=Dispositions.DISMISSED,
+    )
 
     assert isinstance(felony_class_a_dismissed, FelonyClassA)
     assert felony_class_a_dismissed.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
@@ -35,12 +35,12 @@ def test_felony_class_a_dismissed():
 
 
 def test_felony_class_a_no_complaint():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["disposition"] = Dispositions.NO_COMPLAINT
-    charge_dict["name"] = "Assault in the first degree"
-    charge_dict["statute"] = "163.185"
-    charge_dict["level"] = "Felony Class A"
-    felony_class_a_no_complaint = ChargeFactory.create(**charge_dict)
+    felony_class_a_no_complaint = ChargeFactory.create(
+        name="Assault in the first degree",
+        statute="163.185",
+        level="Felony Class A",
+        disposition=Dispositions.NO_COMPLAINT,
+    )
 
     assert isinstance(felony_class_a_no_complaint, FelonyClassA)
     assert felony_class_a_no_complaint.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE

--- a/src/backend/tests/models/charge_types/test_felony_class_b.py
+++ b/src/backend/tests/models/charge_types/test_felony_class_b.py
@@ -6,12 +6,12 @@ from tests.models.test_charge import Dispositions
 
 
 def test_class_b_felony_164057():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Aggravated theft in the first degree"
-    charge_dict["statute"] = "164.057"
-    charge_dict["level"] = "Felony Class B"
-    charge_dict["disposition"] = Dispositions.CONVICTED
-    charge = ChargeFactory.create(**charge_dict)
+    charge = ChargeFactory.create(
+        name="Aggravated theft in the first degree",
+        statute="164.057",
+        level="Felony Class B",
+        disposition=Dispositions.CONVICTED,
+    )
 
     assert isinstance(charge, FelonyClassB)
     assert charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
@@ -19,10 +19,8 @@ def test_class_b_felony_164057():
 
 
 def test_class_felony_is_added_to_b_felony_attribute():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Aggravated theft in the first degree"
-    charge_dict["statute"] = "164.057"
-    charge_dict["level"] = "Felony Class B"
-    charge = ChargeFactory.create(**charge_dict)
+    charge = ChargeFactory.create(
+        name="Aggravated theft in the first degree", statute="164.057", level="Felony Class B"
+    )
 
     assert isinstance(charge, FelonyClassB)

--- a/src/backend/tests/models/charge_types/test_felony_class_c.py
+++ b/src/backend/tests/models/charge_types/test_felony_class_c.py
@@ -6,11 +6,9 @@ from tests.models.test_charge import Dispositions
 
 
 def test_felony_c_conviction():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["name"] = "Theft in the first degree"
-    charge_dict["statute"] = "164.055"
-    charge_dict["level"] = "Felony Class C"
-    charge = ChargeFactory.create(**charge_dict)
+    charge = ChargeFactory.create(
+        name="Theft in the first degree", statute="164.055", level="Felony Class C", disposition=Dispositions.CONVICTED
+    )
 
     assert isinstance(charge, FelonyClassC)
     assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
@@ -18,11 +16,9 @@ def test_felony_c_conviction():
 
 
 def test_felony_c_dismissal():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.DISMISSED)
-    charge_dict["name"] = "Theft in the first degree"
-    charge_dict["statute"] = "164.055"
-    charge_dict["level"] = "Felony Class C"
-    charge = ChargeFactory.create(**charge_dict)
+    charge = ChargeFactory.create(
+        name="Theft in the first degree", statute="164.055", level="Felony Class C", disposition=Dispositions.DISMISSED
+    )
 
     assert isinstance(charge, FelonyClassC)
     assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
@@ -30,12 +26,9 @@ def test_felony_c_dismissal():
 
 
 def test_felony_c_no_disposition():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Theft in the first degree"
-    charge_dict["statute"] = "164.055"
-    charge_dict["level"] = "Felony Class C"
-    charge_dict["disposition"] = None
-    charge = ChargeFactory.create(**charge_dict)
+    charge = ChargeFactory.create(
+        name="Theft in the first degree", statute="164.055", level="Felony Class C", disposition=None
+    )
 
     assert isinstance(charge, FelonyClassC)
     assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
@@ -46,12 +39,12 @@ def test_felony_c_no_disposition():
 
 
 def test_felony_c_unrecognized_disposition():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.UNRECOGNIZED_DISPOSITION)
-    charge_dict["name"] = "Theft in the first degree"
-    charge_dict["statute"] = "164.055"
-    charge_dict["level"] = "Felony Class C"
-    charge_dict["disposition"] = None
-    charge = ChargeFactory.create(**charge_dict)
+    charge = ChargeFactory.create(
+        name="Theft in the first degree",
+        statute="164.055",
+        level="Felony Class C",
+        disposition=Dispositions.UNRECOGNIZED_DISPOSITION,
+    )
 
     assert isinstance(charge, FelonyClassC)
     assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE

--- a/src/backend/tests/models/charge_types/test_marijuana_ineligible.py
+++ b/src/backend/tests/models/charge_types/test_marijuana_ineligible.py
@@ -6,11 +6,12 @@ from tests.models.test_charge import Dispositions
 
 
 def test_marijuana_ineligible_statute_475b3493c():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["name"] = "Unlawful Manufacture of Marijuana Item"
-    charge_dict["statute"] = "475B.349(3)(C)"
-    charge_dict["level"] = "Felony Class C"
-    marijuana_felony_class_c = ChargeFactory.create(**charge_dict)
+    marijuana_felony_class_c = ChargeFactory.create(
+        name="Unlawful Manufacture of Marijuana Item",
+        statute="475B.349(3)(C)",
+        level="Felony Class C",
+        disposition=Dispositions.CONVICTED,
+    )
 
     assert isinstance(marijuana_felony_class_c, MarijuanaIneligible)
     assert marijuana_felony_class_c.type_name == "Marijuana Ineligible"
@@ -19,11 +20,12 @@ def test_marijuana_ineligible_statute_475b3493c():
 
 
 def test_marijuana_ineligible_statute_475b359():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["name"] = "Arson incident to manufacture of cannabinoid extract in first degree"
-    charge_dict["statute"] = "475b.359"
-    charge_dict["level"] = "Felony Class A"
-    marijuana_felony_class_a = ChargeFactory.create(**charge_dict)
+    marijuana_felony_class_a = ChargeFactory.create(
+        name="Arson incident to manufacture of cannabinoid extract in first degree",
+        statute="475b.359",
+        level="Felony Class A",
+        disposition=Dispositions.CONVICTED,
+    )
 
     assert isinstance(marijuana_felony_class_a, MarijuanaIneligible)
     assert marijuana_felony_class_a.type_name == "Marijuana Ineligible"
@@ -32,11 +34,12 @@ def test_marijuana_ineligible_statute_475b359():
 
 
 def test_marijuana_ineligible_statute_475b367():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["name"] = "Causing another person to ingest marijuana"
-    charge_dict["statute"] = "475B.367"
-    charge_dict["level"] = "Felony Class A"
-    marijuana_felony_class_a = ChargeFactory.create(**charge_dict)
+    marijuana_felony_class_a = ChargeFactory.create(
+        name="Causing another person to ingest marijuana",
+        statute="475B.367",
+        level="Felony Class A",
+        disposition=Dispositions.CONVICTED,
+    )
 
     assert isinstance(marijuana_felony_class_a, MarijuanaIneligible)
     assert marijuana_felony_class_a.type_name == "Marijuana Ineligible"
@@ -45,11 +48,12 @@ def test_marijuana_ineligible_statute_475b367():
 
 
 def test_marijuana_ineligible_statute_475b371():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["name"] = "Administration to another person under 18 years of age"
-    charge_dict["statute"] = "475B.371"
-    charge_dict["level"] = "Felony Class A"
-    marijuana_felony_class_a = ChargeFactory.create(**charge_dict)
+    marijuana_felony_class_a = ChargeFactory.create(
+        name="Administration to another person under 18 years of age",
+        statute="475B.371",
+        level="Felony Class A",
+        disposition=Dispositions.CONVICTED,
+    )
 
     assert isinstance(marijuana_felony_class_a, MarijuanaIneligible)
     assert marijuana_felony_class_a.type_name == "Marijuana Ineligible"
@@ -58,11 +62,12 @@ def test_marijuana_ineligible_statute_475b371():
 
 
 def test_marijuana_ineligible_statute_167262():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["name"] = "Use of minor in controlled substance or marijuana item offense"
-    charge_dict["statute"] = "167.262"
-    charge_dict["level"] = "Misdemeanor Class A"
-    marijuana_misdemeanor_class_a = ChargeFactory.create(**charge_dict)
+    marijuana_misdemeanor_class_a = ChargeFactory.create(
+        name="Use of minor in controlled substance or marijuana item offense",
+        statute="167.262",
+        level="Misdemeanor Class A",
+        disposition=Dispositions.CONVICTED,
+    )
 
     assert isinstance(marijuana_misdemeanor_class_a, MarijuanaIneligible)
     assert marijuana_misdemeanor_class_a.type_name == "Marijuana Ineligible"
@@ -71,11 +76,12 @@ def test_marijuana_ineligible_statute_167262():
 
 
 def test_marijuana_ineligible_statute_475b3592a():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["name"] = "Arson incident to manufacture of cannabinoid extract in first degree"
-    charge_dict["statute"] = "475b.359(2)(a)"
-    charge_dict["level"] = "Felony Class A"
-    marijuana_felony_class_a = ChargeFactory.create(**charge_dict)
+    marijuana_felony_class_a = ChargeFactory.create(
+        name="Arson incident to manufacture of cannabinoid extract in first degree",
+        statute="475b.359(2)(a)",
+        level="Felony Class A",
+        disposition=Dispositions.CONVICTED,
+    )
 
     assert isinstance(marijuana_felony_class_a, MarijuanaIneligible)
     assert marijuana_felony_class_a.type_name == "Marijuana Ineligible"

--- a/src/backend/tests/models/charge_types/test_midemeanor.py
+++ b/src/backend/tests/models/charge_types/test_midemeanor.py
@@ -4,14 +4,10 @@ from tests.factories.charge_factory import ChargeFactory
 from tests.models.test_charge import Dispositions
 
 
-def test_misdemeanor():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["name"] = "Criminal Trespass in the Second Degree"
-    charge_dict["statute"] = "164.245"
-    charge_dict["level"] = "Misdemeanor Class C"
-    charge_dict["disposition"] = None
-
-    misdemeanor_charge = ChargeFactory.create(**charge_dict)
+def test_misdemeanor_missing_disposition():
+    misdemeanor_charge = ChargeFactory.create(
+        name="Criminal Trespass in the Second Degree", statute="164.245", level="Misdemeanor Class C", disposition=None
+    )
 
     assert isinstance(misdemeanor_charge, Misdemeanor)
     assert misdemeanor_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
@@ -22,11 +18,12 @@ def test_misdemeanor():
 
 
 def test_misdemeanor_164043():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["name"] = "Theft in the third degree"
-    charge_dict["statute"] = "164.043"
-    charge_dict["level"] = "Misdemeanor Class C"
-    charge = ChargeFactory.create(**charge_dict)
+    charge = ChargeFactory.create(
+        name="Theft in the third degree",
+        statute="164.043",
+        level="Misdemeanor Class C",
+        disposition=Dispositions.CONVICTED,
+    )
 
     assert isinstance(charge, Misdemeanor)
     assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
@@ -34,11 +31,9 @@ def test_misdemeanor_164043():
 
 
 def test_misdemeanor_164125():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["name"] = "Theft of services"
-    charge_dict["statute"] = "164.125"
-    charge_dict["level"] = "Misdemeanor Class A"
-    charge = ChargeFactory.create(**charge_dict)
+    charge = ChargeFactory.create(
+        name="Theft of services", statute="164.125", level="Misdemeanor Class A", disposition=Dispositions.CONVICTED
+    )
 
     assert isinstance(charge, Misdemeanor)
     assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
@@ -46,11 +41,12 @@ def test_misdemeanor_164125():
 
 
 def test_drug_free_zone_variance_misdemeanor():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["name"] = "	Drug Free Zone Variance"
-    charge_dict["statute"] = "14B20060"
-    charge_dict["level"] = "Misdemeanor Unclassified"
-    charge = ChargeFactory.create(**charge_dict)
+    charge = ChargeFactory.create(
+        name="	Drug Free Zone Variance",
+        statute="14B20060",
+        level="Misdemeanor Unclassified",
+        disposition=Dispositions.CONVICTED,
+    )
 
     assert isinstance(charge, Misdemeanor)
     assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE

--- a/src/backend/tests/models/charge_types/test_person_felony.py
+++ b/src/backend/tests/models/charge_types/test_person_felony.py
@@ -13,18 +13,15 @@ person_felonies_with_other_charge_type = [
     "8130105",  # Felony Driving Under the Influence of Intoxicants (as provided in OAR 213-004-0009);
     "163145",  # [Subsection 6] Negligent Homicide;
     "163165",  # [Subsection 6] Assault III;
-    "163205", # [Subsection 6]  Criminal Mistreatment I;
+    "163205",  # [Subsection 6]  Criminal Mistreatment I;
 ]
 
 
 @pytest.mark.parametrize("person_felony_statute", PersonFelonyClassB.statutes)
 def test_person_felony_class_b(person_felony_statute):
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["name"] = "Generic"
-    charge_dict["statute"] = person_felony_statute
-    charge_dict["level"] = "Felony Class B"
-    charge_dict["disposition"] = Dispositions.CONVICTED
-    person_felony_class_b_convicted = ChargeFactory.create(**charge_dict)
+    person_felony_class_b_convicted = ChargeFactory.create(
+        name="Generic", statute=person_felony_statute, level="Felony Class B", disposition=Dispositions.CONVICTED
+    )
     assert isinstance(person_felony_class_b_convicted, PersonFelonyClassB)
     assert person_felony_class_b_convicted.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
     assert (
@@ -34,12 +31,9 @@ def test_person_felony_class_b(person_felony_statute):
 
 @pytest.mark.parametrize("person_felony_statute", PersonFelonyClassB.statutes_with_subsection)
 def test_felony_b_person_felony_with_missing_subsection(person_felony_statute):
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["name"] = "Generic"
-    charge_dict["statute"] = person_felony_statute[:6]
-    charge_dict["level"] = "Felony Class B"
-    charge_dict["disposition"] = Dispositions.CONVICTED
-    person_felony_class_b_convicted = ChargeFactory.create(**charge_dict)
+    person_felony_class_b_convicted = ChargeFactory.create(
+        name="Generic", statute=person_felony_statute[:6], level="Felony Class B", disposition=Dispositions.CONVICTED
+    )
     assert isinstance(person_felony_class_b_convicted, PersonFelonyClassB)
     assert (
         person_felony_class_b_convicted.expungement_result.type_eligibility.status
@@ -53,12 +47,12 @@ def test_felony_b_person_felony_with_missing_subsection(person_felony_statute):
 
 @pytest.mark.parametrize("person_felony_statute_with_other_charge_type", person_felonies_with_other_charge_type)
 def test_other_charge_type_true_negatives(person_felony_statute_with_other_charge_type):
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["name"] = "Generic"
-    charge_dict["statute"] = person_felony_statute_with_other_charge_type
-    charge_dict["level"] = "Felony Class B"
-    charge_dict["disposition"] = Dispositions.CONVICTED
-    person_felony_with_other_charge_type_convicted = ChargeFactory.create(**charge_dict)
+    person_felony_with_other_charge_type_convicted = ChargeFactory.create(
+        name="Generic",
+        statute=person_felony_statute_with_other_charge_type,
+        level="Felony Class B",
+        disposition=Dispositions.CONVICTED,
+    )
     assert not isinstance(person_felony_with_other_charge_type_convicted, PersonFelonyClassB)
 
 
@@ -67,10 +61,10 @@ def test_felony_not_b_person_felony(person_felony_statute_not_b_felony):
     """
     Only test the first 5 statutes just to not spam another ~75 tests.
     """
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["name"] = "Generic"
-    charge_dict["statute"] = person_felony_statute_not_b_felony
-    charge_dict["level"] = "Felony Class C"
-    charge_dict["disposition"] = Dispositions.CONVICTED
-    person_felony_not_class_b_convicted = ChargeFactory.create(**charge_dict)
+    person_felony_not_class_b_convicted = ChargeFactory.create(
+        name="Generic",
+        statute=person_felony_statute_not_b_felony,
+        level="Felony Class C",
+        disposition=Dispositions.CONVICTED,
+    )
     assert not isinstance(person_felony_not_class_b_convicted, PersonFelonyClassB)

--- a/src/backend/tests/models/charge_types/test_schedule_1_p_c_s.py
+++ b/src/backend/tests/models/charge_types/test_schedule_1_p_c_s.py
@@ -6,12 +6,12 @@ from tests.models.test_charge import Dispositions
 
 
 def test_pcs_475854():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Unlawful possession of heroin"
-    charge_dict["statute"] = "475.854"
-    charge_dict["level"] = "Misdemeanor Class A"
-    charge_dict["disposition"] = Dispositions.CONVICTED
-    pcs_charge = ChargeFactory.create(**charge_dict)
+    pcs_charge = ChargeFactory.create(
+        name="Unlawful possession of heroin",
+        statute="475.854",
+        level="Misdemeanor Class A",
+        disposition=Dispositions.CONVICTED,
+    )
 
     assert isinstance(pcs_charge, Schedule1PCS)
     assert pcs_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
@@ -19,12 +19,12 @@ def test_pcs_475854():
 
 
 def test_pcs_475874():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Unlawful possession of 3,4-methylenedioxymethamphetamine"
-    charge_dict["statute"] = "475.874"
-    charge_dict["level"] = "Misdemeanor Class A"
-    charge_dict["disposition"] = Dispositions.CONVICTED
-    pcs_charge = ChargeFactory.create(**charge_dict)
+    pcs_charge = ChargeFactory.create(
+        name="Unlawful possession of 3,4-methylenedioxymethamphetamine",
+        statute="475.874",
+        level="Misdemeanor Class A",
+        disposition=Dispositions.CONVICTED,
+    )
 
     assert isinstance(pcs_charge, Schedule1PCS)
     assert pcs_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
@@ -32,12 +32,12 @@ def test_pcs_475874():
 
 
 def test_pcs_475884():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Unlawful possession of cocaine"
-    charge_dict["statute"] = "475.884"
-    charge_dict["level"] = "Misdemeanor Class A"
-    charge_dict["disposition"] = Dispositions.CONVICTED
-    pcs_charge = ChargeFactory.create(**charge_dict)
+    pcs_charge = ChargeFactory.create(
+        name="Unlawful possession of cocaine",
+        statute="475.884",
+        level="Misdemeanor Class A",
+        disposition=Dispositions.CONVICTED,
+    )
 
     assert isinstance(pcs_charge, Schedule1PCS)
     assert pcs_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
@@ -45,12 +45,12 @@ def test_pcs_475884():
 
 
 def test_pcs_475894():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Unlawful possession of methamphetamine"
-    charge_dict["statute"] = "475.894"
-    charge_dict["level"] = "Misdemeanor Class A"
-    charge_dict["disposition"] = Dispositions.CONVICTED
-    pcs_charge = ChargeFactory.create(**charge_dict)
+    pcs_charge = ChargeFactory.create(
+        name="Unlawful possession of methamphetamine",
+        statute="475.894",
+        level="Misdemeanor Class A",
+        disposition=Dispositions.CONVICTED,
+    )
 
     assert isinstance(pcs_charge, Schedule1PCS)
     assert pcs_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
@@ -58,12 +58,9 @@ def test_pcs_475894():
 
 
 def test_pcs_475992():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Poss Controlled Sub 2"
-    charge_dict["statute"] = "4759924B"
-    charge_dict["level"] = "Felony Class C"
-    charge_dict["disposition"] = Dispositions.CONVICTED
-    pcs_charge = ChargeFactory.create(**charge_dict)
+    pcs_charge = ChargeFactory.create(
+        name="Poss Controlled Sub 2", statute="4759924B", level="Felony Class C", disposition=Dispositions.CONVICTED
+    )
 
     assert isinstance(pcs_charge, Schedule1PCS)
     assert pcs_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
@@ -71,26 +68,29 @@ def test_pcs_475992():
 
 
 def test_pcs_dismissed_violation():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Poss Controlled Sub 2"
-    charge_dict["statute"] = "4759924B"
-    charge_dict["disposition"] = Dispositions.DISMISSED
-    for level in ("Class C Violation", "Class c violation", "Class B Violation",
-                  "Class B violation", "Class D Violation", "Class D violation"):
-        charge_dict["level"] = level
-        pcs_charge = ChargeFactory.create(**charge_dict)
+    for level in (
+        "Class C Violation",
+        "Class c violation",
+        "Class B Violation",
+        "Class B violation",
+        "Class D Violation",
+        "Class D violation",
+    ):
+        pcs_charge = ChargeFactory.create(
+            name="Poss Controlled Sub 2", statute="4759924B", disposition=Dispositions.DISMISSED, level=level
+        )
         assert isinstance(pcs_charge, Schedule1PCS)
         assert pcs_charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-        assert pcs_charge.expungement_result.type_eligibility.reason == "Dismissed violations are ineligible by omission from statute"
+        assert (
+            pcs_charge.expungement_result.type_eligibility.reason
+            == "Dismissed violations are ineligible by omission from statute"
+        )
 
 
 def test_pcs_dismissed_nonviolation():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Poss Controlled Sub 2"
-    charge_dict["statute"] = "4759924B"
-    charge_dict["level"] = "Felony Class C"  # also test non-violation
-    charge_dict["disposition"] = Dispositions.DISMISSED
-    pcs_charge = ChargeFactory.create(**charge_dict)
+    pcs_charge = ChargeFactory.create(
+        name="Poss Controlled Sub 2", statute="4759924B", level="Felony Class C", disposition=Dispositions.DISMISSED
+    )  # also test non-violation
     assert isinstance(pcs_charge, Schedule1PCS)
     assert pcs_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
     assert pcs_charge.expungement_result.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"

--- a/src/backend/tests/models/charge_types/test_sex_crimes.py
+++ b/src/backend/tests/models/charge_types/test_sex_crimes.py
@@ -7,27 +7,19 @@ import pytest
 
 @pytest.mark.parametrize("sex_crimes_statute", SexCrime.statutes)
 def test_sex_crimes(sex_crimes_statute):
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["name"] = "Generic"
-    charge_dict["statute"] = sex_crimes_statute
-    charge_dict["level"] = "Felony Class B"
-    charge_dict["disposition"] = Dispositions.CONVICTED
-    sex_crime_convicted = ChargeFactory.create(**charge_dict)
+    sex_crime_convicted = ChargeFactory.create(
+        name="Generic", statute=sex_crimes_statute, level="Felony Class B", disposition=Dispositions.CONVICTED
+    )
     assert isinstance(sex_crime_convicted, SexCrime)
     assert sex_crime_convicted.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert (
-        sex_crime_convicted.expungement_result.type_eligibility.reason == "Ineligible under 137.225(6)(a)"
-    )
+    assert sex_crime_convicted.expungement_result.type_eligibility.reason == "Ineligible under 137.225(6)(a)"
 
 
 @pytest.mark.parametrize("sex_crimes_statute", SexCrime.romeo_and_juliet_exceptions)
 def test_sex_crimes_with_romeo_and_juliet_exception(sex_crimes_statute):
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["name"] = "Generic"
-    charge_dict["statute"] = sex_crimes_statute
-    charge_dict["level"] = "Misdemeanor Class A"
-    charge_dict["disposition"] = Dispositions.CONVICTED
-    sex_crime_romeo_juliet_exception_convicted = ChargeFactory.create(**charge_dict)
+    sex_crime_romeo_juliet_exception_convicted = ChargeFactory.create(
+        name="Generic", statute=sex_crimes_statute, level="Misdemeanor Class A", disposition=Dispositions.CONVICTED
+    )
     assert isinstance(sex_crime_romeo_juliet_exception_convicted, SexCrime)
     assert (
         sex_crime_romeo_juliet_exception_convicted.expungement_result.type_eligibility.status

--- a/src/backend/tests/models/charge_types/test_subsection_6.py
+++ b/src/backend/tests/models/charge_types/test_subsection_6.py
@@ -1,19 +1,16 @@
 from expungeservice.models.expungement_result import EligibilityStatus
 from expungeservice.models.charge_types.subsection_6 import Subsection6
-from expungeservice.models.charge_types.person_felony import PersonFelonyClassB
 from tests.factories.charge_factory import ChargeFactory
 from tests.models.test_charge import Dispositions
-import pytest
 
 
 def test_subsection_6_dismissed():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Criminal mistreatment in the second degree"
-    charge_dict["statute"] = "163.200"
-    charge_dict["level"] = "Misdemeanor Class A"
-    charge_dict["disposition"] = Dispositions.DISMISSED
-
-    subsection_6_charge = ChargeFactory.create(**charge_dict)
+    subsection_6_charge = ChargeFactory.create(
+        name="Criminal mistreatment in the second degree",
+        statute="163.200",
+        level="Misdemeanor Class A",
+        disposition=Dispositions.DISMISSED,
+    )
 
     assert isinstance(subsection_6_charge, Subsection6)
     assert subsection_6_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
@@ -23,12 +20,12 @@ def test_subsection_6_dismissed():
 
 
 def test_subsection_6_163165():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Assault in the third degree"
-    charge_dict["statute"] = "163.165"
-    charge_dict["level"] = "Felony Class C"
-    charge_dict["disposition"] = Dispositions.CONVICTED
-    subsection_6_charge = ChargeFactory.create(**charge_dict)
+    subsection_6_charge = ChargeFactory.create(
+        name="Assault in the third degree",
+        statute="163.165",
+        level="Felony Class C",
+        disposition=Dispositions.CONVICTED,
+    )
 
     assert isinstance(subsection_6_charge, Subsection6)
     assert subsection_6_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
@@ -39,11 +36,12 @@ def test_subsection_6_163165():
 
 
 def test_subsection_6_163200():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["name"] = "Criminal mistreatment in the second degree"
-    charge_dict["statute"] = "163.200"
-    charge_dict["level"] = "Misdemeanor Class A"
-    subsection_6_charge = ChargeFactory.create(**charge_dict)
+    subsection_6_charge = ChargeFactory.create(
+        name="Criminal mistreatment in the second degree",
+        statute="163.200",
+        level="Misdemeanor Class A",
+        disposition=Dispositions.CONVICTED,
+    )
 
     assert isinstance(subsection_6_charge, Subsection6)
     assert subsection_6_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
@@ -54,51 +52,55 @@ def test_subsection_6_163200():
 
 
 def test_subsection_6_163575():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["name"] = "Endangering the welfare of a minor"
-    charge_dict["statute"] = "163.575"
-    charge_dict["level"] = "Misdemeanor Class A"
-    subsection_6_charge = ChargeFactory.create(**charge_dict)
+    subsection_6_charge = ChargeFactory.create(
+        name="Endangering the welfare of a minor",
+        statute="163.575",
+        level="Misdemeanor Class A",
+        disposition=Dispositions.CONVICTED,
+    )
 
     assert isinstance(subsection_6_charge, Subsection6)
 
 
 def test_subsection_6_163205():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Criminal mistreatment in the first degree"
-    charge_dict["statute"] = "163.205"
-    charge_dict["level"] = "Felony Class C"
-    charge_dict["disposition"] = Dispositions.CONVICTED
-    subsection_6_charge = ChargeFactory.create(**charge_dict)
+    subsection_6_charge = ChargeFactory.create(
+        name="Criminal mistreatment in the first degree",
+        statute="163.205",
+        level="Felony Class C",
+        disposition=Dispositions.CONVICTED,
+    )
 
     assert isinstance(subsection_6_charge, Subsection6)
 
 
 def test_subsection_6_163145():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["name"] = "Criminally negligent homicide"
-    charge_dict["statute"] = "163.145"
-    charge_dict["level"] = "Misdemeanor Class A"
-    subsection_6_charge = ChargeFactory.create(**charge_dict)
+    subsection_6_charge = ChargeFactory.create(
+        name="Criminally negligent homicide",
+        statute="163.145",
+        level="Misdemeanor Class A",
+        disposition=Dispositions.CONVICTED,
+    )
 
     assert isinstance(subsection_6_charge, Subsection6)
 
 
 def test_163575_is_still_subsection_6_if_b_felony():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["name"] = "Endangering the welfare of a minor"
-    charge_dict["statute"] = "163.575"
-    charge_dict["level"] = "Felony Class B"
-    subsection_6_charge = ChargeFactory.create(**charge_dict)
+    subsection_6_charge = ChargeFactory.create(
+        name="Endangering the welfare of a minor",
+        statute="163.575",
+        level="Felony Class B",
+        disposition=Dispositions.CONVICTED,
+    )
 
     assert isinstance(subsection_6_charge, Subsection6)
 
 
 def test_163200_is_still_subsection_6_if_b_felony():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["name"] = "Criminal mistreatment in the second degree"
-    charge_dict["statute"] = "163.200"
-    charge_dict["level"] = "Felony Class B"
-    subsection_6_charge = ChargeFactory.create(**charge_dict)
+    subsection_6_charge = ChargeFactory.create(
+        name="Criminal mistreatment in the second degree",
+        statute="163.200",
+        level="Felony Class B",
+        disposition=Dispositions.CONVICTED,
+    )
 
     assert isinstance(subsection_6_charge, Subsection6)

--- a/src/backend/tests/models/charge_types/test_traffic_offenses.py
+++ b/src/backend/tests/models/charge_types/test_traffic_offenses.py
@@ -19,19 +19,13 @@ from tests.models.test_charge import Dispositions
 
 # TODO: we can separate these three types to different test files too.
 def test_traffic_violation_min_statute():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["statute"] = "801.000"
-    charge_dict["level"] = "Violation"
-    charge = ChargeFactory.create(**charge_dict)
+    charge = ChargeFactory.create(statute="801.000", level="Violation")
 
     assert isinstance(charge, TrafficViolation)
 
 
 def test_traffic_violation_max_statute():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["statute"] = "825.999"
-    charge_dict["level"] = "Violation"
-    charge = ChargeFactory.create(**charge_dict)
+    charge = ChargeFactory.create(statute="825.999", level="Violation")
 
     assert isinstance(charge, TrafficViolation)
 
@@ -131,8 +125,6 @@ def test_felony_dismissal_is_eligible():
 
 
 def test_duii():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["statute"] = "813.010"
-    charge = ChargeFactory.create(**charge_dict)
+    charge = ChargeFactory.create(statute="813.010")
 
     assert isinstance(charge, Duii)

--- a/src/backend/tests/models/charge_types/test_type_analyzer_duii.py
+++ b/src/backend/tests/models/charge_types/test_type_analyzer_duii.py
@@ -8,10 +8,7 @@ from expungeservice.models.disposition import Disposition
 
 def build_charge(statute, disposition_ruling):
     last_week = datetime.today() - timedelta(days=7)
-    charge = ChargeFactory.default_dict()
-    charge["statute"] = statute
-    charge["disposition"] = Disposition(ruling=disposition_ruling, date=last_week)
-    return ChargeFactory.create(**charge)
+    return ChargeFactory.create(statute=statute, disposition=Disposition(ruling=disposition_ruling, date=last_week))
 
 
 def test_duii_dismissed():

--- a/src/backend/tests/models/charge_types/test_unclassified.py
+++ b/src/backend/tests/models/charge_types/test_unclassified.py
@@ -5,11 +5,12 @@ from tests.models.test_charge import Dispositions
 
 
 def test_unclassified_charge():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.DISMISSED)
-    charge_dict["name"] = "Assault in the ninth degree"
-    charge_dict["statute"] = "333.333"
-    charge_dict["level"] = "Felony Class F"
-    unclassified_dismissed = ChargeFactory.create(**charge_dict)
+    unclassified_dismissed = ChargeFactory.create(
+        name="Assault in the ninth degree",
+        statute="333.333",
+        level="Felony Class F",
+        disposition=Dispositions.DISMISSED,
+    )
 
     assert isinstance(unclassified_dismissed, UnclassifiedCharge)
     assert unclassified_dismissed.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
@@ -20,11 +21,12 @@ def test_unclassified_charge():
 
 
 def test_charge_that_falls_through():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.DISMISSED)
-    charge_dict["name"] = "Aggravated theft in the first degree"
-    charge_dict["statute"] = "164.057"
-    charge_dict["level"] = "Felony Class F"
-    charge = ChargeFactory.create(**charge_dict)
+    charge = ChargeFactory.create(
+        name="Aggravated theft in the first degree",
+        statute="164.057",
+        level="Felony Class F",
+        disposition=Dispositions.DISMISSED,
+    )
 
     assert isinstance(charge, UnclassifiedCharge)
     assert charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS

--- a/src/backend/tests/models/charge_types/test_violation.py
+++ b/src/backend/tests/models/charge_types/test_violation.py
@@ -6,11 +6,9 @@ from tests.models.test_charge import Dispositions
 
 
 def test_violation():
-    charge_dict = ChargeFactory.default_dict(disposition=Dispositions.CONVICTED)
-    charge_dict["name"] = "Viol Treatment"
-    charge_dict["statute"] = "1615662"
-    charge_dict["level"] = "Violation Unclassified"
-    charge = ChargeFactory.create(**charge_dict)
+    charge = ChargeFactory.create(
+        name="Viol Treatment", statute="1615662", level="Violation Unclassified", disposition=Dispositions.CONVICTED
+    )
 
     assert isinstance(charge, Violation)
     assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE

--- a/src/backend/tests/models/test_charge.py
+++ b/src/backend/tests/models/test_charge.py
@@ -22,24 +22,18 @@ class TestChargeClass(unittest.TestCase):
     LESS_THAN_THREE_YEARS_AGO = date.today() + relativedelta(years=-3, days=+1)
     THREE_YEARS_AGO = date.today() + relativedelta(years=-3)
 
-    def setUp(self):
-        self.charge = ChargeFactory.default_dict()
-
     def test_it_initializes_simple_statute(self):
-        self.charge["statute"] = "1231235B"
-        charge = ChargeFactory.create(**self.charge)
+        charge = ChargeFactory.create(statute="1231235B")
 
         assert charge.statute == "1231235B"
 
     def test_it_normalizes_statute(self):
-        self.charge["statute"] = "-123.123(5)()B"
-        charge = ChargeFactory.create(**self.charge)
+        charge = ChargeFactory.create(statute="-123.123(5)()B")
 
         assert charge.statute == "1231235B"
 
     def test_it_converts_statute_to_uppercase(self):
-        self.charge["statute"] = "-123.123(5)()b"
-        charge = ChargeFactory.create(**self.charge)
+        charge = ChargeFactory.create(statute="-123.123(5)()b")
 
         assert charge.statute == "1231235B"
 

--- a/src/backend/tests/test_friendly_rule.py
+++ b/src/backend/tests/test_friendly_rule.py
@@ -93,12 +93,12 @@ def test_eligible_mrc_with_violation():
 
 
 def test_needs_more_analysis_mrc_with_single_arrest():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Assault in the third degree"
-    charge_dict["statute"] = "163.165"
-    charge_dict["level"] = "Felony Class C"
-    charge_dict["disposition"] = Disposition(ruling="Convicted", date=Time.THREE_YEARS_AGO)
-    three_yr_mrc = ChargeFactory.create(**charge_dict)
+    three_yr_mrc = ChargeFactory.create(
+        name="Assault in the third degree",
+        statute="163.165",
+        level="Felony Class C",
+        disposition=Disposition(ruling="Convicted", date=Time.THREE_YEARS_AGO),
+    )
     arrest = ChargeFactory.create(disposition=Disposition(ruling="Dismissed", date=Time.THREE_YEARS_AGO))
 
     case = CaseFactory.create()
@@ -127,12 +127,12 @@ def test_needs_more_analysis_mrc_with_single_arrest():
 
 
 def test_very_old_needs_more_analysis_mrc_with_single_arrest():
-    charge_dict = ChargeFactory.default_dict()
-    charge_dict["name"] = "Assault in the third degree"
-    charge_dict["statute"] = "163.165"
-    charge_dict["level"] = "Felony Class C"
-    charge_dict["disposition"] = Disposition(ruling="Convicted", date=Time.TWENTY_YEARS_AGO)
-    mrc = ChargeFactory.create(**charge_dict)
+    mrc = ChargeFactory.create(
+        name="Assault in the third degree",
+        statute="163.165",
+        level="Felony Class C",
+        disposition=Disposition(ruling="Convicted", date=Time.TWENTY_YEARS_AGO),
+    )
     arrest = ChargeFactory.create(disposition=Disposition(ruling="Dismissed", date=Time.THREE_YEARS_AGO))
 
     case = CaseFactory.create()


### PR DESCRIPTION
We can just directly pass in the parameters as `create()`'s default parameters are the same as `default_dict`'s.