### PR TITLE
Add ID to Charge

### DIFF
--- a/src/backend/expungeservice/crawler/crawler.py
+++ b/src/backend/expungeservice/crawler/crawler.py
@@ -84,4 +84,4 @@ class Crawler:
             )  # TODO: Log error if format is not correct
             ruling = disposition_data.get("ruling")
             charge["disposition"] = Disposition(date, ruling, "amended" in disposition_data["event"].lower())
-        return ChargeCreator.create(**charge)
+        return ChargeCreator.create(charge_id, **charge)

--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -1,7 +1,7 @@
 import weakref
-from dataclasses import dataclass, InitVar, field
+from dataclasses import dataclass, field
 
-from datetime import date as date_class, datetime
+from datetime import date as date_class
 from typing import Optional
 
 from dateutil.relativedelta import relativedelta
@@ -15,8 +15,9 @@ from expungeservice.models.expungement_result import (
 )
 
 
-@dataclass(eq=False)
+@dataclass
 class Charge:
+    id: str
     name: str
     statute: str
     level: str

--- a/src/backend/expungeservice/models/charge_types/civil_offense.py
+++ b/src/backend/expungeservice/models/charge_types/civil_offense.py
@@ -4,7 +4,7 @@ from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
-@dataclass(eq=False)
+@dataclass
 class CivilOffense(Charge):
     type_name: str = "Civil Offense"
 

--- a/src/backend/expungeservice/models/charge_types/duii.py
+++ b/src/backend/expungeservice/models/charge_types/duii.py
@@ -5,7 +5,7 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 from expungeservice.models.disposition import DispositionStatus
 
 
-@dataclass(eq=False)
+@dataclass
 class Duii(Charge):
     type_name: str = "DUII"
     expungement_rules: str = (

--- a/src/backend/expungeservice/models/charge_types/felony_class_a.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_a.py
@@ -4,7 +4,7 @@ from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
-@dataclass(eq=False)
+@dataclass
 class FelonyClassA(Charge):
     type_name: str = "Felony Class A"
     expungement_rules: str = (

--- a/src/backend/expungeservice/models/charge_types/felony_class_b.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_b.py
@@ -4,7 +4,7 @@ from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
-@dataclass(eq=False)
+@dataclass
 class FelonyClassB(Charge):
     type_name: str = "Felony Class B"
     expungement_rules: str = (

--- a/src/backend/expungeservice/models/charge_types/felony_class_c.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_c.py
@@ -5,7 +5,7 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 from expungeservice.models.disposition import DispositionStatus
 
 
-@dataclass(eq=False)
+@dataclass
 class FelonyClassC(Charge):
     type_name: str = "Felony Class C"
     expungement_rules: str = (

--- a/src/backend/expungeservice/models/charge_types/juvenile_charge.py
+++ b/src/backend/expungeservice/models/charge_types/juvenile_charge.py
@@ -4,7 +4,7 @@ from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
-@dataclass(eq=False)
+@dataclass
 class JuvenileCharge(Charge):
     type_name: str = "Juvenile"
 

--- a/src/backend/expungeservice/models/charge_types/marijuana_ineligible.py
+++ b/src/backend/expungeservice/models/charge_types/marijuana_ineligible.py
@@ -4,7 +4,7 @@ from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
-@dataclass(eq=False)
+@dataclass
 class MarijuanaIneligible(Charge):
     type_name: str = "Marijuana Ineligible"
     expungement_rules: str = """ORS 137.226 makes eligible additional marijuana-related charges - in particular, those crimes which are now considered minor felonies or below. However, there are certain marijuana-related crimes which are still considered major felonies. These are:

--- a/src/backend/expungeservice/models/charge_types/misdemeanor.py
+++ b/src/backend/expungeservice/models/charge_types/misdemeanor.py
@@ -4,7 +4,7 @@ from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
-@dataclass(eq=False)
+@dataclass
 class Misdemeanor(Charge):
     type_name: str = "Misdemeanor"
     expungement_rules: str = """Convictions for misdemeanors are generally eligible under ORS 137.225(5)(b).

--- a/src/backend/expungeservice/models/charge_types/parking_ticket.py
+++ b/src/backend/expungeservice/models/charge_types/parking_ticket.py
@@ -5,7 +5,7 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 from expungeservice.models.disposition import DispositionStatus
 
 
-@dataclass(eq=False)
+@dataclass
 class ParkingTicket(Charge):
     """
     This is a civil offense, and it is also a traffic offense.

--- a/src/backend/expungeservice/models/charge_types/person_felony.py
+++ b/src/backend/expungeservice/models/charge_types/person_felony.py
@@ -5,7 +5,7 @@ from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
-@dataclass(eq=False)
+@dataclass
 class PersonFelonyClassB(Charge):
     type_name: str = "Person Felony Class B"
     expungement_rules: str = (

--- a/src/backend/expungeservice/models/charge_types/schedule_1_p_c_s.py
+++ b/src/backend/expungeservice/models/charge_types/schedule_1_p_c_s.py
@@ -4,7 +4,7 @@ from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
-@dataclass(eq=False)
+@dataclass
 class Schedule1PCS(Charge):
     type_name: str = "Schedule 1 PCS"
 
@@ -12,8 +12,7 @@ class Schedule1PCS(Charge):
         if self.dismissed():
             if "violation" in self.level.lower():
                 return TypeEligibility(
-                    EligibilityStatus.INELIGIBLE,
-                    reason="Dismissed violations are ineligible by omission from statute"
+                    EligibilityStatus.INELIGIBLE, reason="Dismissed violations are ineligible by omission from statute"
                 )
             else:
                 return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Dismissals are eligible under 137.225(1)(b)")

--- a/src/backend/expungeservice/models/charge_types/sex_crimes.py
+++ b/src/backend/expungeservice/models/charge_types/sex_crimes.py
@@ -4,7 +4,7 @@ from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
-@dataclass(eq=False)
+@dataclass
 class SexCrime(Charge):
     type_name: str = "Sex Crime"
     expungement_rules: str = (
@@ -15,42 +15,41 @@ class SexCrime(Charge):
     )
 
     statutes = [
-        '163365',  # Rape II
-        '163375',  # Rape I
-        '163395',  # Sodomy II
-        '163405',  # Sodomy I
-        '163408',  # Sexual Penetration II
-        '163411',  # Sexual Penetration I
-        '163413',  # Purchasing Sex with a Minor
-        '163425',  # Sexual Abuse II
-        '163427',  # Sexual Abuse I
-        '163432',  # Online Sexual Corruption of a Child II
-        '163433',  # Online Sexual Corruption of a Child I
-        '163452',  # Custodial Sexual Misconduct in the First Degree
-        '163454',  # Custodial sexual misconduct in the second degree
-        '163465',  # Felony Public Indecency
-        '163467',  # Private indecency
-        '163472',  # Unlawful Dissemination of Initimate Image
-        '163476',  # Unlawfully being in a location where children regularly congregate
-        '163479',  # Unlawful Contact with a Child
-        '163670',  # Using Child In Display of Sexual Conduct
-        '163684',  # Encouraging Child Sex Abuse I
-        '163686',  # Encouraging Child Sex Abuse II
-        '163687',  # Encouraging child sexual abuse in the third degree
-        '163688',  # Possession of Material Depicting Sexually Explicit Conduct of Child I
-        '163689',  # Possession of Material Depicting Sexually Explicit Conduct of Child II
-        '163693',  # Failure to report Child Pornography
+        "163365",  # Rape II
+        "163375",  # Rape I
+        "163395",  # Sodomy II
+        "163405",  # Sodomy I
+        "163408",  # Sexual Penetration II
+        "163411",  # Sexual Penetration I
+        "163413",  # Purchasing Sex with a Minor
+        "163425",  # Sexual Abuse II
+        "163427",  # Sexual Abuse I
+        "163432",  # Online Sexual Corruption of a Child II
+        "163433",  # Online Sexual Corruption of a Child I
+        "163452",  # Custodial Sexual Misconduct in the First Degree
+        "163454",  # Custodial sexual misconduct in the second degree
+        "163465",  # Felony Public Indecency
+        "163467",  # Private indecency
+        "163472",  # Unlawful Dissemination of Initimate Image
+        "163476",  # Unlawfully being in a location where children regularly congregate
+        "163479",  # Unlawful Contact with a Child
+        "163670",  # Using Child In Display of Sexual Conduct
+        "163684",  # Encouraging Child Sex Abuse I
+        "163686",  # Encouraging Child Sex Abuse II
+        "163687",  # Encouraging child sexual abuse in the third degree
+        "163688",  # Possession of Material Depicting Sexually Explicit Conduct of Child I
+        "163689",  # Possession of Material Depicting Sexually Explicit Conduct of Child II
+        "163693",  # Failure to report Child Pornography
     ]
-
 
     # Romeo and Juliet exception; If a person is convicted of one of the following, and follows certain other
     # requirements which are not identifiable in eCourts, they are eligible.
     romeo_and_juliet_exceptions = [
-        '163355',  # Rape in the third degree
-        '163385',  # Sodomy in the third degree
-        '163415',  # Sexual Abuse in the Third Degree
-        '163435',  # Contributing to the sexual deliquency of a minor
-        '163445',  # Sexual Misconduct
+        "163355",  # Rape in the third degree
+        "163385",  # Sodomy in the third degree
+        "163415",  # Sexual Abuse in the Third Degree
+        "163435",  # Contributing to the sexual deliquency of a minor
+        "163445",  # Sexual Misconduct
     ]
 
     def _type_eligibility(self):

--- a/src/backend/expungeservice/models/charge_types/subsection_6.py
+++ b/src/backend/expungeservice/models/charge_types/subsection_6.py
@@ -4,7 +4,7 @@ from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
-@dataclass(eq=False)
+@dataclass
 class Subsection6(Charge):
     type_name: str = "Subsection 6"
 

--- a/src/backend/expungeservice/models/charge_types/traffic_non_violation.py
+++ b/src/backend/expungeservice/models/charge_types/traffic_non_violation.py
@@ -4,7 +4,7 @@ from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
-@dataclass(eq=False)
+@dataclass
 class TrafficNonViolation(Charge):
     type_name: str = "Traffic Non-Violation"
 

--- a/src/backend/expungeservice/models/charge_types/traffic_violation.py
+++ b/src/backend/expungeservice/models/charge_types/traffic_violation.py
@@ -4,7 +4,7 @@ from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
-@dataclass(eq=False)
+@dataclass
 class TrafficViolation(Charge):
     type_name: str = "Traffic Violation"
     expungement_rules: str = (

--- a/src/backend/expungeservice/models/charge_types/unclassified_charge.py
+++ b/src/backend/expungeservice/models/charge_types/unclassified_charge.py
@@ -4,7 +4,7 @@ from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
-@dataclass(eq=False)
+@dataclass
 class UnclassifiedCharge(Charge):
     type_name: str = "Unclassified"
 

--- a/src/backend/expungeservice/models/charge_types/violation.py
+++ b/src/backend/expungeservice/models/charge_types/violation.py
@@ -4,7 +4,7 @@ from expungeservice.models.charge import Charge
 from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
 
 
-@dataclass(eq=False)
+@dataclass
 class Violation(Charge):
     type_name: str = "Violation"
     expungement_rules: str = """Violation convictions are eligible under ORS 137.225(5)(d).

--- a/src/backend/expungeservice/models/helpers/charge_creator.py
+++ b/src/backend/expungeservice/models/helpers/charge_creator.py
@@ -9,7 +9,7 @@ from expungeservice.models.helpers.charge_classifier import ChargeClassifier
 
 class ChargeCreator:
     @staticmethod
-    def create(**kwargs):
+    def create(charge_id, **kwargs):
         case = kwargs["case"]
         name = kwargs["name"]
         statute = ChargeCreator.__strip_non_alphanumeric_chars(kwargs["statute"])
@@ -22,6 +22,7 @@ class ChargeCreator:
         kwargs["_chapter"] = chapter
         kwargs["_section"] = section
         kwargs["statute"] = statute
+        kwargs["id"] = f"{case.case_number}-{charge_id}"
         return from_dict(data_class=classification, data=kwargs)
 
     @staticmethod

--- a/src/backend/tests/factories/charge_factory.py
+++ b/src/backend/tests/factories/charge_factory.py
@@ -5,8 +5,11 @@ from tests.factories.case_factory import CaseFactory
 
 
 class ChargeFactory:
-    @staticmethod
+    charge_count = 0  # Responsible for giving every Charge in tests an unique deterministic ID
+
+    @classmethod
     def create(
+        cls,
         case=CaseFactory.create(),
         name="Theft of services",
         statute="164.125",
@@ -14,6 +17,7 @@ class ChargeFactory:
         date: date_class = None,
         disposition: Disposition = None,
     ):
+        cls.charge_count += 1
         if disposition and not date:
             date_string = disposition.date.strftime("%m/%d/%Y")
         elif date:
@@ -29,16 +33,18 @@ class ChargeFactory:
             "disposition": disposition,
         }
 
-        return ChargeCreator.create(**kwargs)
+        return ChargeCreator.create(cls.charge_count, **kwargs)
 
-    @staticmethod
+    @classmethod
     def create_dismissed_charge(
+        cls,
         case=CaseFactory.create(),
         name="Theft of services",
         statute="164.125",
         level="Misdemeanor Class A",
         date=date_class(1901, 1, 1),
     ):
+        cls.charge_count += 1
         disposition = Disposition(date=date_class.today(), ruling="Dismissed")
         kwargs = {
             "case": case,
@@ -49,4 +55,4 @@ class ChargeFactory:
             "disposition": disposition,
         }
 
-        return ChargeCreator.create(**kwargs)
+        return ChargeCreator.create(cls.charge_count, **kwargs)


### PR DESCRIPTION
Since there is no official UID given by OECI, we use the combination of the case number and charge list numbering to give each charge an ID: `f"{case.case_number}-{charge_id}"`