### PR TITLE
Remove non admin access to add-user page

### DIFF
--- a/src/frontend/src/components/AddUser/index.tsx
+++ b/src/frontend/src/components/AddUser/index.tsx
@@ -9,6 +9,7 @@ import validateEmail from '../../service/email-validation';
 
 interface Props {
   users: UserState;
+  isAdmin?: boolean;
   addUser: (name: string, email: string, password: string, group: string, admin: boolean) => Promise<void>;
 }
 
@@ -117,6 +118,12 @@ class AddUser extends React.Component<Props, State> {
       }
     })
   }
+
+  public componentDidMount() {
+    if (!this.props.isAdmin) {
+      history.push('/oeci');
+  }
+}
 
   public render() {
     return (

--- a/src/frontend/src/components/Admin/index.tsx
+++ b/src/frontend/src/components/Admin/index.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import UserList from '../UserList/index';
-import GroupList from '../GroupList/index';
 
 class Admin extends React.Component {
   public render() {
+    // The GroupList component should be left off of this page until the feature is fully implemented
     return (
       <main className="mw8 center ph2">
-        <GroupList />
         <UserList />
       </main>
     );


### PR DESCRIPTION
Redirect from add-user page if user is not admin
    
This is a cosmetic change and not a real security measure. The add-user feature is protected on the backend, though, so a secure check for navigating the frontend isn't necessary.
    
Redirects to oeci-login, the default "landing page" for a logged-in user
    
Checks the isAdmin flag when the add-user component loads.
