### PR TITLE
Add skeleton for Ambiguous Charge and Expunger multi-runs

### DIFF
--- a/src/backend/expungeservice/endpoints/search.py
+++ b/src/backend/expungeservice/endpoints/search.py
@@ -11,7 +11,7 @@ from expungeservice.models.ambiguous import AmbiguousCase
 from expungeservice.request import check_data_fields
 from expungeservice.request import error
 from expungeservice.crawler.crawler import Crawler
-from expungeservice.expunger import Expunger
+from expungeservice.expunger import Expunger, ErrorChecker
 from expungeservice.serializer import ExpungeModelEncoder
 from expungeservice.crypto import DataCipher
 from expungeservice.stats import save_result
@@ -68,6 +68,7 @@ class Search(MethodView):
                 0
             ]  # TODO: Fix. We currently pretend we cannot get an ambiguous record/case/charge.
 
+        record.errors += ErrorChecker.check(record)
         expunger = Expunger(record)
         expunger.run()
 

--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -100,7 +100,6 @@ class Expunger:
                     status=EligibilityStatus.INELIGIBLE, reason=reason, date_will_be_eligible=date_will_be_eligible
                 )
             charge_id_to_time_eligibility[charge.id] = time_eligibility
-            charge.set_time_eligibility(time_eligibility)
         for case in self.record.cases:
             non_violation_convictions_in_case = []
             violations_in_case = []
@@ -125,16 +124,15 @@ class Expunger:
                     if (
                         charge.expungement_result.type_eligibility.status != EligibilityStatus.INELIGIBLE
                         and charge.dismissed()
-                        and charge.expungement_result.time_eligibility.date_will_be_eligible
-                        >= attractor.expungement_result.time_eligibility.date_will_be_eligible
+                        and charge_id_to_time_eligibility[charge.id].date_will_be_eligible
+                        >= charge_id_to_time_eligibility[attractor.id].date_will_be_eligible
                     ):
                         time_eligibility = TimeEligibility(
-                            status=attractor.expungement_result.time_eligibility.status,
+                            status=charge_id_to_time_eligibility[attractor.id].status,
                             reason='Time eligibility of the arrest matches conviction on the same case (the "friendly" rule)',
-                            date_will_be_eligible=attractor.expungement_result.time_eligibility.date_will_be_eligible,
+                            date_will_be_eligible=charge_id_to_time_eligibility[attractor.id].date_will_be_eligible,
                         )
                         charge_id_to_time_eligibility[charge.id] = time_eligibility
-                        charge.set_time_eligibility(time_eligibility)
         return charge_id_to_time_eligibility
 
     @staticmethod

--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -16,11 +16,9 @@ class Expunger:
         self.record = record
         self.analyzable_charges = Expunger._without_skippable_charges(self.record.charges)
 
-    def run(self) -> bool:
+    def run(self) -> Dict[str, TimeEligibility]:
         """
         Evaluates the expungement eligibility of a record.
-
-        :return: True if there are no open cases; otherwise False
         """
         open_cases = [case for case in self.record.cases if not case.closed()]
         if len(open_cases) > 0:
@@ -144,7 +142,7 @@ class Expunger:
                         )
                         charge_id_to_time_eligibility[charge.id] = time_eligibility
                         charge.set_time_eligibility(time_eligibility)
-        return len(open_cases) == 0
+        return charge_id_to_time_eligibility
 
     @staticmethod
     def _categorize_charges(charges):

--- a/src/backend/expungeservice/models/ambiguous.py
+++ b/src/backend/expungeservice/models/ambiguous.py
@@ -1,0 +1,9 @@
+from typing import List
+
+from expungeservice.models.case import Case
+from expungeservice.models.charge import Charge
+from expungeservice.models.record import Record
+
+AmbiguousCharge = List[Charge]
+AmbiguousCase = List[Case]
+AmbiguousRecord = List[Record]

--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -88,6 +88,3 @@ If the type eligibility is unknown, the method can return None. """
 
     def hidden_in_record_summary(self):
         return False
-
-    def set_time_eligibility(self, time_eligibility):
-        self.expungement_result.time_eligibility = time_eligibility

--- a/src/backend/expungeservice/models/expungement_result.py
+++ b/src/backend/expungeservice/models/expungement_result.py
@@ -19,13 +19,13 @@ class ChargeEligibilityStatus(str, Enum):
     INELIGIBLE = "Ineligible"
 
 
-@dataclass
+@dataclass(frozen=True)
 class TypeEligibility:
     status: EligibilityStatus
     reason: str
 
 
-@dataclass
+@dataclass(frozen=True)
 class TimeEligibility:
     status: EligibilityStatus
     reason: str

--- a/src/backend/expungeservice/models/expungement_result.py
+++ b/src/backend/expungeservice/models/expungement_result.py
@@ -29,7 +29,7 @@ class TypeEligibility:
 class TimeEligibility:
     status: EligibilityStatus
     reason: str
-    date_will_be_eligible: Optional[date]
+    date_will_be_eligible: date
 
 
 @dataclass

--- a/src/backend/expungeservice/models/helpers/record_merger.py
+++ b/src/backend/expungeservice/models/helpers/record_merger.py
@@ -1,0 +1,13 @@
+from typing import List, Dict
+
+from expungeservice.models.ambiguous import AmbiguousRecord
+from expungeservice.models.expungement_result import TimeEligibility
+from expungeservice.models.record import Record
+
+
+class RecordMerger:
+    @staticmethod
+    def merge(
+        ambiguous_record: AmbiguousRecord, charge_id_to_time_eligibilities: List[Dict[str, TimeEligibility]]
+    ) -> Record:
+        return ambiguous_record[0]

--- a/src/backend/expungeservice/models/helpers/record_merger.py
+++ b/src/backend/expungeservice/models/helpers/record_merger.py
@@ -1,13 +1,29 @@
-from typing import List, Dict
+from typing import List, Dict, Set
 
 from expungeservice.models.ambiguous import AmbiguousRecord
 from expungeservice.models.expungement_result import TimeEligibility
 from expungeservice.models.record import Record
+import collections
 
 
 class RecordMerger:
     @staticmethod
     def merge(
-        ambiguous_record: AmbiguousRecord, charge_id_to_time_eligibilities: List[Dict[str, TimeEligibility]]
+        ambiguous_record: AmbiguousRecord, charge_id_to_time_eligibility_list: List[Dict[str, TimeEligibility]]
     ) -> Record:
-        return ambiguous_record[0]
+        charge_id_to_time_eligibilities: Dict[str, Set[TimeEligibility]] = collections.defaultdict(set)
+        for charge_id_to_time_eligibility in charge_id_to_time_eligibility_list:
+            for k, v in charge_id_to_time_eligibility.items():
+                charge_id_to_time_eligibilities[k].add(v)
+        record = ambiguous_record[0]
+        for charge in record.charges:
+            charge.expungement_result.time_eligibility = RecordMerger.merge_time_eligibilities(
+                charge_id_to_time_eligibilities[charge.id]
+            )
+        return record
+
+    @staticmethod
+    def merge_time_eligibilities(time_eligibilities: Set[TimeEligibility]):
+        return (
+            time_eligibilities.pop()
+        )  # TODO: Fix stub which assumes set is always of size 1 and actually do a meaningful merge.

--- a/src/backend/tests/endpoints/test_search.py
+++ b/src/backend/tests/endpoints/test_search.py
@@ -1,8 +1,10 @@
 import copy
+from typing import List, Any, Callable
 
 import pytest
 
 from expungeservice.endpoints import search
+from expungeservice.models.ambiguous import AmbiguousCase
 from tests.endpoints.endpoint_util import EndpointShared
 from tests.factories.crawler_factory import CrawlerFactory
 
@@ -31,8 +33,13 @@ def mock_login(return_value):
 
 
 # The copy here is required because we mutate the resulting Record object in search
-def mock_search(service, mocked_record_name):
-    return lambda s, first_name, last_name, middle_name, birth_date: copy.copy(service.mock_record[mocked_record_name])
+def mock_search(service, mocked_record_name) -> Callable[[Any, Any, Any, Any, Any], List[AmbiguousCase]]:
+    def compute_ambiguous_cases(s, first_name, last_name, middle_name, birth_date):
+        record = copy.copy(service.mock_record[mocked_record_name])
+        ambiguous_cases = [[case] for case in record.cases]
+        return ambiguous_cases
+
+    return compute_ambiguous_cases
 
 
 def mock_save_result_fail(request_data, record):

--- a/src/backend/tests/factories/crawler_factory.py
+++ b/src/backend/tests/factories/crawler_factory.py
@@ -1,7 +1,10 @@
+from itertools import product
+
 import requests_mock
 
 from expungeservice.crawler.crawler import Crawler
 from expungeservice.crawler.request import URL
+from expungeservice.models.record import Record
 from tests.fixtures.post_login_page import PostLoginPage
 from tests.fixtures.search_page_response import SearchPageResponse
 from tests.fixtures.case_details import CaseDetails
@@ -34,4 +37,7 @@ class CrawlerFactory:
             for key, value in cases.items():
                 m.get("{}{}{}".format(base_url, "CaseDetail.aspx?CaseID=", key), text=value)
 
-            return crawler.search("John", "Doe")
+            ambiguous_cases = crawler.search("John", "Doe")
+            cases_list = [list(cases) for cases in product(*ambiguous_cases)]
+            ambiguous_record = [Record(cases) for cases in cases_list]
+            return ambiguous_record[0]  # TODO: We currently pretend we cannot get an ambiguous record/case/charge

--- a/src/backend/tests/models/test_expungement_result.py
+++ b/src/backend/tests/models/test_expungement_result.py
@@ -1,10 +1,9 @@
 from expungeservice.models.expungement_result import *
-from tests.time import Time
 
 
 def test_eligible():
     type_eligibility = TypeEligibility(EligibilityStatus.ELIGIBLE, "Eligible under some statute")
-    time_eligibility = TimeEligibility(EligibilityStatus.ELIGIBLE, "Eligible under some statute", None)
+    time_eligibility = TimeEligibility(EligibilityStatus.ELIGIBLE, "Eligible under some statute", date.today())
     expungement_result = ExpungementResult(type_eligibility, time_eligibility)
 
     assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.ELIGIBLE_NOW
@@ -23,7 +22,7 @@ def test_will_be_eligible():
 
 def test_possibly_eligible():
     type_eligibility = TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, "Unrecognized charge")
-    time_eligibility = TimeEligibility(EligibilityStatus.ELIGIBLE, "Eligible under some statute", None)
+    time_eligibility = TimeEligibility(EligibilityStatus.ELIGIBLE, "Eligible under some statute", date.today())
     expungement_result = ExpungementResult(type_eligibility, time_eligibility)
 
     assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.POSSIBLY_ELIGIBILE

--- a/src/backend/tests/models/test_record_summarizer.py
+++ b/src/backend/tests/models/test_record_summarizer.py
@@ -65,7 +65,7 @@ def test_record_summarizer_multiple_cases():
         [case_all_eligible, case_partially_eligible, case_possibly_eligible, case_all_ineligible, case_all_ineligible_2]
     )
     expunger = Expunger(record)
-    expunger.run()
+    expunger_result = expunger.run()
     record_summary = RecordSummarizer.summarize(record)
 
     assert record_summary.total_balance_due == 1000.00

--- a/src/backend/tests/models/test_record_summarizer.py
+++ b/src/backend/tests/models/test_record_summarizer.py
@@ -1,4 +1,5 @@
 from expungeservice.models.disposition import Disposition
+from expungeservice.models.helpers.record_merger import RecordMerger
 from expungeservice.models.helpers.record_summarizer import RecordSummarizer
 from expungeservice.expunger import Expunger
 from tests.factories.case_factory import CaseFactory
@@ -66,7 +67,8 @@ def test_record_summarizer_multiple_cases():
     )
     expunger = Expunger(record)
     expunger_result = expunger.run()
-    record_summary = RecordSummarizer.summarize(record)
+    merged_record = RecordMerger.merge([record], [expunger_result])
+    record_summary = RecordSummarizer.summarize(merged_record)
 
     assert record_summary.total_balance_due == 1000.00
     assert record_summary.total_cases == 5

--- a/src/backend/tests/serializer/test_serializer.py
+++ b/src/backend/tests/serializer/test_serializer.py
@@ -32,5 +32,5 @@ def _record(request):
 
 def test_round_trip_various_records(_record):
     expunger = Expunger(_record)
-    expunger.run()
+    expunger_result = expunger.run()
     json.loads(json.dumps(_record, cls=ExpungeModelEncoder))

--- a/src/backend/tests/serializer/test_serializer_generative.py
+++ b/src/backend/tests/serializer/test_serializer_generative.py
@@ -11,5 +11,5 @@ from expungeservice.serializer import ExpungeModelEncoder
 @given(build_record_strategy())
 def test_round_trip_various_records(record):
     expunger = Expunger(record)
-    expunger.run()
+    expunger_result = expunger.run()
     json.loads(json.dumps(record, cls=ExpungeModelEncoder))

--- a/src/backend/tests/test_crawler_expunger.py
+++ b/src/backend/tests/test_crawler_expunger.py
@@ -178,19 +178,20 @@ def record_with_specific_dates(crawler):
 def test_expunger_runs_time_analyzer(record_with_specific_dates):
     record = record_with_specific_dates
     expunger = Expunger(record)
-    assert len(expunger.run()) == 9
+    expunger_result = expunger.run()
+    assert len(expunger_result) == 9
 
-    assert record.cases[0].charges[0].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert record.cases[0].charges[1].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert record.cases[0].charges[2].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[record.cases[0].charges[0].id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[record.cases[0].charges[1].id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[record.cases[0].charges[2].id].status is EligibilityStatus.INELIGIBLE
 
-    assert record.cases[1].charges[0].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert record.cases[1].charges[1].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert record.cases[1].charges[2].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[record.cases[1].charges[0].id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[record.cases[1].charges[1].id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[record.cases[1].charges[2].id].status is EligibilityStatus.INELIGIBLE
 
-    assert record.cases[2].charges[0].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert record.cases[2].charges[1].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert record.cases[2].charges[2].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[record.cases[2].charges[0].id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[record.cases[2].charges[1].id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[record.cases[2].charges[2].id].status is EligibilityStatus.INELIGIBLE
 
 
 @pytest.fixture
@@ -208,7 +209,6 @@ def record_with_revoked_probation(crawler):
 def test_probation_revoked_affects_time_eligibility(record_with_revoked_probation):
     record = record_with_revoked_probation
     expunger = Expunger(record)
-    assert len(expunger.run()) == 6
-    assert record.cases[0].charges[0].expungement_result.time_eligibility.date_will_be_eligible == date_class(
-        2020, 11, 9
-    )
+    expunger_result = expunger.run()
+    assert len(expunger_result) == 6
+    assert expunger_result[record.cases[0].charges[0].id].date_will_be_eligible == date_class(2020, 11, 9)

--- a/src/backend/tests/test_crawler_expunger.py
+++ b/src/backend/tests/test_crawler_expunger.py
@@ -34,7 +34,7 @@ def record_with_open_case(crawler):
 def test_expunger_with_open_case(record_with_open_case):
     expunger = Expunger(record_with_open_case)
 
-    assert not expunger.run()
+    assert len(expunger.run()) == 4
     assert "All charges are ineligible because there is one or more open case" in record_with_open_case.errors[0]
 
 
@@ -45,7 +45,7 @@ def empty_record(crawler):
 
 def test_expunger_with_an_empty_record(empty_record):
     expunger = Expunger(empty_record)
-    assert expunger.run()
+    assert expunger.run() == {}
 
 
 @pytest.fixture
@@ -55,7 +55,7 @@ def partial_dispos_record(crawler):
 
 def test_partial_dispos(partial_dispos_record):
     expunger = Expunger(partial_dispos_record)
-    assert expunger.run()
+    assert len(expunger.run()) == 1
 
 
 @pytest.fixture
@@ -66,7 +66,7 @@ def record_without_dispos(crawler):
 def test_case_without_dispos(record_without_dispos):
     expunger = Expunger(record_without_dispos)
     assert record_without_dispos.cases[0].closed()
-    assert expunger.run()
+    assert expunger.run() == {}
     assert record_without_dispos.errors[0] == (
         f"""Case [{record_without_dispos.cases[0].case_number}] has a charge with a missing disposition.
 This might be an error in the OECI database. Time analysis is ignoring this charge and may be inaccurate for other charges."""
@@ -87,7 +87,7 @@ def record_with_unrecognized_dispo(crawler):
 
 def test_case_with_unrecognized_dispo(record_with_unrecognized_dispo):
     expunger = Expunger(record_with_unrecognized_dispo)
-    assert expunger.run()
+    assert len(expunger.run()) == 6
     assert (
         "The following cases have charges with an unrecognized disposition" in record_with_unrecognized_dispo.errors[0]
     )
@@ -107,7 +107,7 @@ def record_with_multiple_disposition_errors(crawler):
 
 def test_case_with_mulitple_disposition_errors(record_with_multiple_disposition_errors):
     expunger = Expunger(record_with_multiple_disposition_errors)
-    assert expunger.run()
+    assert len(expunger.run()) == 4
     unrecognized_error_message = f"""The following cases have charges with an unrecognized disposition.
 This might be an error in the OECI database. Time analysis is ignoring these charges and may be inaccurate for other charges.
 Case numbers: """
@@ -178,7 +178,7 @@ def record_with_specific_dates(crawler):
 def test_expunger_runs_time_analyzer(record_with_specific_dates):
     record = record_with_specific_dates
     expunger = Expunger(record)
-    assert expunger.run()
+    assert len(expunger.run()) == 9
 
     assert record.cases[0].charges[0].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
     assert record.cases[0].charges[1].expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
@@ -208,7 +208,7 @@ def record_with_revoked_probation(crawler):
 def test_probation_revoked_affects_time_eligibility(record_with_revoked_probation):
     record = record_with_revoked_probation
     expunger = Expunger(record)
-    assert expunger.run()
+    assert len(expunger.run()) == 6
     assert record.cases[0].charges[0].expungement_result.time_eligibility.date_will_be_eligible == date_class(
         2020, 11, 9
     )

--- a/src/backend/tests/test_friendly_rule.py
+++ b/src/backend/tests/test_friendly_rule.py
@@ -20,20 +20,20 @@ def test_eligible_mrc_with_single_arrest():
     case.charges = [three_yr_mrc, arrest]
     record = Record([case])
     expunger = Expunger(record)
-    expunger.run()
+    expunger_result = expunger.run()
 
-    assert arrest.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[arrest.id].status is EligibilityStatus.ELIGIBLE
     assert (
-        arrest.expungement_result.time_eligibility.reason
+        expunger_result[arrest.id].reason
         == 'Time eligibility of the arrest matches conviction on the same case (the "friendly" rule)'
     )
-    assert arrest.expungement_result.time_eligibility.date_will_be_eligible == date.today()
+    assert expunger_result[arrest.id].date_will_be_eligible == date.today()
     assert arrest.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.ELIGIBLE_NOW
     assert arrest.expungement_result.charge_eligibility.label == "Eligible"
 
-    assert three_yr_mrc.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert three_yr_mrc.expungement_result.time_eligibility.reason == ""
-    assert three_yr_mrc.expungement_result.time_eligibility.date_will_be_eligible == date.today()
+    assert expunger_result[three_yr_mrc.id].status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[three_yr_mrc.id].reason == ""
+    assert expunger_result[three_yr_mrc.id].date_will_be_eligible == date.today()
     assert three_yr_mrc.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.ELIGIBLE_NOW
     assert three_yr_mrc.expungement_result.charge_eligibility.label == "Eligible"
 
@@ -49,11 +49,11 @@ def test_arrest_is_unaffected_if_conviction_eligibility_is_older():
     case = CaseFactory.create()
     case.charges = [violation_charge, arrest]
     expunger = Expunger(Record([case]))
-    expunger.run()
+    expunger_result = expunger.run()
 
-    assert arrest.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert arrest.expungement_result.time_eligibility.date_will_be_eligible == arrest.date
-    assert arrest.expungement_result.time_eligibility.reason == ""
+    assert expunger_result[arrest.id].status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[arrest.id].date_will_be_eligible == arrest.date
+    assert expunger_result[arrest.id].reason == ""
 
 
 def test_eligible_mrc_with_violation():
@@ -73,24 +73,21 @@ def test_eligible_mrc_with_violation():
     record = Record([case])
     expunger = Expunger(record)
 
-    expunger.run()
-    assert three_yr_mrc.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert three_yr_mrc.expungement_result.time_eligibility.reason == ""
-    assert three_yr_mrc.expungement_result.time_eligibility.date_will_be_eligible == date.today()
+    expunger_result = expunger.run()
+    assert expunger_result[three_yr_mrc.id].status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[three_yr_mrc.id].reason == ""
+    assert expunger_result[three_yr_mrc.id].date_will_be_eligible == date.today()
 
-    assert arrest.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[arrest.id].status is EligibilityStatus.ELIGIBLE
     assert (
-        arrest.expungement_result.time_eligibility.reason
+        expunger_result[arrest.id].reason
         == 'Time eligibility of the arrest matches conviction on the same case (the "friendly" rule)'
     )
-    assert arrest.expungement_result.time_eligibility.date_will_be_eligible == date.today()
+    assert expunger_result[arrest.id].date_will_be_eligible == date.today()
 
-    assert violation.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert violation.expungement_result.time_eligibility.date_will_be_eligible == date.today() + relativedelta(years=7)
-    assert (
-        violation.expungement_result.time_eligibility.reason
-        == "Ten years from most recent other conviction (137.225(7)(b))"
-    )
+    assert expunger_result[violation.id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[violation.id].date_will_be_eligible == date.today() + relativedelta(years=7)
+    assert expunger_result[violation.id].reason == "Ten years from most recent other conviction (137.225(7)(b))"
 
 
 @pytest.mark.skip()
@@ -107,13 +104,13 @@ def test_needs_more_analysis_mrc_with_single_arrest():
     case.charges = [three_yr_mrc, arrest]
     record = Record([case])
     expunger = Expunger(record)
-    expunger.run()
+    expunger_result = expunger.run()
 
     ten_years_from_mrc = three_yr_mrc.disposition.date + Time.TEN_YEARS
-    assert arrest.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert arrest.expungement_result.time_eligibility.reason == "Ten years from most recent conviction (137.225(7)(b))"
-    assert arrest.expungement_result.time_eligibility.date_will_be_eligible == date.today()
-    assert arrest.expungement_result.time_eligibility.date_eligible_without_friendly_rule == ten_years_from_mrc
+    assert expunger_result[arrest.id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[arrest.id].reason == "Ten years from most recent conviction (137.225(7)(b))"
+    assert expunger_result[arrest.id].date_will_be_eligible == date.today()
+    # assert expunger_result[arrest.id].date_eligible_without_friendly_rule == ten_years_from_mrc
     assert arrest.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.WILL_BE_ELIGIBLE
     assert (
         arrest.expungement_result.charge_eligibility.label
@@ -121,9 +118,9 @@ def test_needs_more_analysis_mrc_with_single_arrest():
     )
 
     assert three_yr_mrc.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert three_yr_mrc.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert three_yr_mrc.expungement_result.time_eligibility.reason == ""
-    assert three_yr_mrc.expungement_result.time_eligibility.date_will_be_eligible == date.today()
+    assert expunger_result[three_yr_mrc.id].status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[three_yr_mrc.id].reason == ""
+    assert expunger_result[three_yr_mrc.id].date_will_be_eligible == date.today()
     assert three_yr_mrc.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.POSSIBLY_ELIGIBILE
     assert three_yr_mrc.expungement_result.charge_eligibility.label == "Possibly Eligible (review)"
 
@@ -142,18 +139,18 @@ def test_very_old_needs_more_analysis_mrc_with_single_arrest():
     case.charges = [mrc, arrest]
     record = Record([case])
     expunger = Expunger(record)
-    expunger.run()
+    expunger_result = expunger.run()
 
     three_years_from_mrc = mrc.disposition.date + Time.THREE_YEARS
-    assert arrest.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert arrest.expungement_result.time_eligibility.date_will_be_eligible == three_years_from_mrc
-    assert arrest.expungement_result.time_eligibility.date_eligible_without_friendly_rule == Time.THREE_YEARS_AGO
+    assert expunger_result[arrest.id].status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[arrest.id].date_will_be_eligible == three_years_from_mrc
+    # assert expunger_result[arrest.id].date_eligible_without_friendly_rule == Time.THREE_YEARS_AGO
     assert arrest.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.ELIGIBLE_NOW
     assert arrest.expungement_result.charge_eligibility.label == "Eligible"
 
     assert mrc.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert mrc.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert mrc.expungement_result.time_eligibility.date_will_be_eligible == three_years_from_mrc
+    assert expunger_result[mrc.id].status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[mrc.id].date_will_be_eligible == three_years_from_mrc
     assert mrc.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.POSSIBLY_ELIGIBILE
     assert mrc.expungement_result.charge_eligibility.label == "Possibly Eligible (review)"
 
@@ -174,17 +171,14 @@ def test_arrest_time_eligibility_is_set_to_older_violation():
     case = CaseFactory.create()
     case.charges = [older_violation, newer_violation, arrest]
     expunger = Expunger(Record([case]))
-    expunger.run()
+    expunger_result = expunger.run()
 
-    assert arrest.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[arrest.id].status is EligibilityStatus.INELIGIBLE
     assert (
-        arrest.expungement_result.time_eligibility.reason
+        expunger_result[arrest.id].reason
         == 'Time eligibility of the arrest matches conviction on the same case (the "friendly" rule)'
     )
-    assert (
-        arrest.expungement_result.time_eligibility.date_will_be_eligible
-        == older_violation.disposition.date + Time.THREE_YEARS
-    )
+    assert expunger_result[arrest.id].date_will_be_eligible == older_violation.disposition.date + Time.THREE_YEARS
 
 
 def test_3_violations_are_time_restricted():
@@ -208,17 +202,17 @@ def test_3_violations_are_time_restricted():
     case = CaseFactory.create()
     case.charges = [violation_charge_3, violation_charge_2, violation_charge_1, arrest]
     expunger = Expunger(Record([case]))
-    expunger.run()
+    expunger_result = expunger.run()
 
     earliest_date_eligible = min(
-        violation_charge_1.expungement_result.time_eligibility.date_will_be_eligible,
-        violation_charge_2.expungement_result.time_eligibility.date_will_be_eligible,
-        violation_charge_3.expungement_result.time_eligibility.date_will_be_eligible,
+        expunger_result[violation_charge_1.id].date_will_be_eligible,
+        expunger_result[violation_charge_2.id].date_will_be_eligible,
+        expunger_result[violation_charge_3.id].date_will_be_eligible,
     )
 
-    assert arrest.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[arrest.id].status is EligibilityStatus.INELIGIBLE
     assert (
-        arrest.expungement_result.time_eligibility.reason
+        expunger_result[arrest.id].reason
         == 'Time eligibility of the arrest matches conviction on the same case (the "friendly" rule)'
     )
-    assert arrest.expungement_result.time_eligibility.date_will_be_eligible == earliest_date_eligible
+    assert expunger_result[arrest.id].date_will_be_eligible == earliest_date_eligible

--- a/src/backend/tests/test_time_analyzer.py
+++ b/src/backend/tests/test_time_analyzer.py
@@ -44,18 +44,18 @@ class TestSingleChargeDismissals(unittest.TestCase):
         record = Record([case])
         expunger = Expunger(record)
 
-        expunger.run()
-        assert three_yr_conviction.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+        expunger_result = expunger.run()
+        assert expunger_result[three_yr_conviction.id].status is EligibilityStatus.INELIGIBLE
         assert (
-            three_yr_conviction.expungement_result.time_eligibility.reason
+            expunger_result[three_yr_conviction.id].reason
             == "Ten years from most recent other conviction (137.225(7)(b))"
         )
-        assert three_yr_conviction.expungement_result.time_eligibility.date_will_be_eligible == date.today() + relativedelta(
+        assert expunger_result[three_yr_conviction.id].date_will_be_eligible == date.today() + relativedelta(
             years=7, days=1
         )
 
-        assert arrest.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
-        assert arrest.expungement_result.time_eligibility.date_will_be_eligible == date.today() + relativedelta(years=7)
+        assert expunger_result[arrest.id].status is EligibilityStatus.INELIGIBLE
+        assert expunger_result[arrest.id].date_will_be_eligible == date.today() + relativedelta(years=7)
 
     def test_ineligible_mrc_with_arrest_on_single_case(self):
         # In this case, the friendly rule doesn't apply because the conviction doesn't become eligible
@@ -76,17 +76,12 @@ class TestSingleChargeDismissals(unittest.TestCase):
         record = Record([case])
         expunger = Expunger(record)
 
-        expunger.run()
-        assert arrest.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
-        assert (
-            arrest.expungement_result.time_eligibility.reason == "Ten years from most recent conviction (137.225(7)(b))"
-        )
-        assert mrc.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
-        assert (
-            mrc.expungement_result.time_eligibility.reason
-            == "Never. Type ineligible charges are always time ineligible."
-        )
-        assert mrc.expungement_result.time_eligibility.date_will_be_eligible == date.max
+        expunger_result = expunger.run()
+        assert expunger_result[arrest.id].status is EligibilityStatus.INELIGIBLE
+        assert expunger_result[arrest.id].reason == "Ten years from most recent conviction (137.225(7)(b))"
+        assert expunger_result[mrc.id].status is EligibilityStatus.INELIGIBLE
+        assert expunger_result[mrc.id].reason == "Never. Type ineligible charges are always time ineligible."
+        assert expunger_result[mrc.id].date_will_be_eligible == date.max
 
     def test_more_than_ten_year_old_conviction(self):
         case = CaseFactory.create()
@@ -95,14 +90,11 @@ class TestSingleChargeDismissals(unittest.TestCase):
         case.charges = [charge]
         record = Record([case])
         expunger = Expunger(record)
-        expunger.run()
+        expunger_result = expunger.run()
 
-        assert charge.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
-        assert charge.expungement_result.time_eligibility.reason == ""
-        assert (
-            charge.expungement_result.time_eligibility.date_will_be_eligible
-            == charge.disposition.date + relativedelta(years=+3)
-        )
+        assert expunger_result[charge.id].status is EligibilityStatus.ELIGIBLE
+        assert expunger_result[charge.id].reason == ""
+        assert expunger_result[charge.id].date_will_be_eligible == charge.disposition.date + relativedelta(years=+3)
 
     def test_10_yr_old_conviction_with_3_yr_old_mrc(self):
         case = CaseFactory.create()
@@ -112,24 +104,15 @@ class TestSingleChargeDismissals(unittest.TestCase):
         case.charges = [ten_yr_charge, three_yr_mrc]
         record = Record([case])
         expunger = Expunger(record)
-        expunger.run()
+        expunger_result = expunger.run()
 
-        assert ten_yr_charge.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
-        assert (
-            ten_yr_charge.expungement_result.time_eligibility.reason
-            == "Ten years from most recent other conviction (137.225(7)(b))"
-        )
-        assert (
-            ten_yr_charge.expungement_result.time_eligibility.date_will_be_eligible
-            == three_yr_mrc.disposition.date + Time.TEN_YEARS
-        )
+        assert expunger_result[ten_yr_charge.id].status is EligibilityStatus.INELIGIBLE
+        assert expunger_result[ten_yr_charge.id].reason == "Ten years from most recent other conviction (137.225(7)(b))"
+        assert expunger_result[ten_yr_charge.id].date_will_be_eligible == three_yr_mrc.disposition.date + Time.TEN_YEARS
 
-        assert three_yr_mrc.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
-        assert three_yr_mrc.expungement_result.time_eligibility.reason == ""
-        assert (
-            three_yr_mrc.expungement_result.time_eligibility.date_will_be_eligible
-            == ten_yr_charge.disposition.date + Time.TEN_YEARS
-        )
+        assert expunger_result[three_yr_mrc.id].status is EligibilityStatus.ELIGIBLE
+        assert expunger_result[three_yr_mrc.id].reason == ""
+        assert expunger_result[three_yr_mrc.id].date_will_be_eligible == ten_yr_charge.disposition.date + Time.TEN_YEARS
 
     def test_10_yr_old_conviction_with_less_than_3_yr_old_mrc(self):
         case = CaseFactory.create()
@@ -141,26 +124,20 @@ class TestSingleChargeDismissals(unittest.TestCase):
         case.charges = [ten_yr_charge, less_than_three_yr_mrc]
         record = Record([case])
         expunger = Expunger(record)
-        expunger.run()
+        expunger_result = expunger.run()
 
-        assert ten_yr_charge.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert expunger_result[ten_yr_charge.id].status is EligibilityStatus.INELIGIBLE
+        assert expunger_result[ten_yr_charge.id].reason == "Ten years from most recent other conviction (137.225(7)(b))"
         assert (
-            ten_yr_charge.expungement_result.time_eligibility.reason
-            == "Ten years from most recent other conviction (137.225(7)(b))"
-        )
-        assert (
-            ten_yr_charge.expungement_result.time_eligibility.date_will_be_eligible
+            expunger_result[ten_yr_charge.id].date_will_be_eligible
             == less_than_three_yr_mrc.disposition.date + Time.TEN_YEARS
         )
 
-        assert less_than_three_yr_mrc.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert expunger_result[less_than_three_yr_mrc.id].status is EligibilityStatus.INELIGIBLE
         assert (
-            less_than_three_yr_mrc.expungement_result.time_eligibility.reason
-            == "Three years from date of conviction (137.225(1)(a))"
+            expunger_result[less_than_three_yr_mrc.id].reason == "Three years from date of conviction (137.225(1)(a))"
         )
-        assert less_than_three_yr_mrc.expungement_result.time_eligibility.date_will_be_eligible == date.today() + relativedelta(
-            days=+1
-        )
+        assert expunger_result[less_than_three_yr_mrc.id].date_will_be_eligible == date.today() + relativedelta(days=+1)
 
     def test_more_than_three_year_rule_conviction(self):
         case = CaseFactory.create()
@@ -169,11 +146,11 @@ class TestSingleChargeDismissals(unittest.TestCase):
         case.charges = [charge]
         record = Record([case])
         expunger = Expunger(record)
-        expunger.run()
+        expunger_result = expunger.run()
 
-        assert charge.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
-        assert charge.expungement_result.time_eligibility.reason == ""
-        assert charge.expungement_result.time_eligibility.date_will_be_eligible == date.today()
+        assert expunger_result[charge.id].status is EligibilityStatus.ELIGIBLE
+        assert expunger_result[charge.id].reason == ""
+        assert expunger_result[charge.id].date_will_be_eligible == date.today()
 
     def test_less_than_three_year_rule_conviction(self):
         case = CaseFactory.create()
@@ -182,13 +159,11 @@ class TestSingleChargeDismissals(unittest.TestCase):
         case.charges = [charge]
         record = Record([case])
         expunger = Expunger(record)
-        expunger.run()
+        expunger_result = expunger.run()
 
-        assert charge.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
-        assert (
-            charge.expungement_result.time_eligibility.reason == "Three years from date of conviction (137.225(1)(a))"
-        )
-        assert charge.expungement_result.time_eligibility.date_will_be_eligible == date.today() + relativedelta(days=+1)
+        assert expunger_result[charge.id].status is EligibilityStatus.INELIGIBLE
+        assert expunger_result[charge.id].reason == "Three years from date of conviction (137.225(1)(a))"
+        assert expunger_result[charge.id].date_will_be_eligible == date.today() + relativedelta(days=+1)
 
     def test_time_eligibility_date_is_none_when_type_ineligible(self):
         case = CaseFactory.create()
@@ -203,14 +178,11 @@ class TestSingleChargeDismissals(unittest.TestCase):
         case.charges = [charge]
         record = Record([case])
         expunger = Expunger(record)
-        expunger.run()
+        expunger_result = expunger.run()
 
-        assert charge.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
-        assert (
-            charge.expungement_result.time_eligibility.reason
-            == "Never. Type ineligible charges are always time ineligible."
-        )
-        assert charge.expungement_result.time_eligibility.date_will_be_eligible is date.max
+        assert expunger_result[charge.id].status is EligibilityStatus.INELIGIBLE
+        assert expunger_result[charge.id].reason == "Never. Type ineligible charges are always time ineligible."
+        assert expunger_result[charge.id].date_will_be_eligible is date.max
 
 
 class TestDismissalBlock(unittest.TestCase):
@@ -224,11 +196,11 @@ class TestDismissalBlock(unittest.TestCase):
     def test_record_with_only_an_mrd_is_time_eligible(self):
         record = Record([self.case_1])
         expunger = Expunger(record)
-        expunger.run()
+        expunger_result = expunger.run()
 
-        assert self.recent_dismissal.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
-        assert self.recent_dismissal.expungement_result.time_eligibility.reason == ""
-        assert self.recent_dismissal.expungement_result.time_eligibility.date_will_be_eligible == Time.TWO_YEARS_AGO
+        assert expunger_result[self.recent_dismissal.id].status is EligibilityStatus.ELIGIBLE
+        assert expunger_result[self.recent_dismissal.id].reason == ""
+        assert expunger_result[self.recent_dismissal.id].date_will_be_eligible == Time.TWO_YEARS_AGO
 
     def test_all_mrd_case_related_dismissals_are_expungeable(self):
         case_related_dismissal = ChargeFactory.create_dismissed_charge(case=self.case_1, date=Time.TWO_YEARS_AGO)
@@ -236,15 +208,15 @@ class TestDismissalBlock(unittest.TestCase):
 
         record = Record([self.case_1])
         expunger = Expunger(record)
-        expunger.run()
+        expunger_result = expunger.run()
 
-        assert self.recent_dismissal.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
-        assert self.recent_dismissal.expungement_result.time_eligibility.reason == ""
-        assert self.recent_dismissal.expungement_result.time_eligibility.date_will_be_eligible == Time.TWO_YEARS_AGO
+        assert expunger_result[self.recent_dismissal.id].status is EligibilityStatus.ELIGIBLE
+        assert expunger_result[self.recent_dismissal.id].reason == ""
+        assert expunger_result[self.recent_dismissal.id].date_will_be_eligible == Time.TWO_YEARS_AGO
 
-        assert case_related_dismissal.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
-        assert case_related_dismissal.expungement_result.time_eligibility.reason == ""
-        assert case_related_dismissal.expungement_result.time_eligibility.date_will_be_eligible == Time.TWO_YEARS_AGO
+        assert expunger_result[case_related_dismissal.id].status is EligibilityStatus.ELIGIBLE
+        assert expunger_result[case_related_dismissal.id].reason == ""
+        assert expunger_result[case_related_dismissal.id].date_will_be_eligible == Time.TWO_YEARS_AGO
 
     def test_mrd_blocks_dismissals_in_unrelated_cases(self):
         unrelated_dismissal = ChargeFactory.create_dismissed_charge(case=self.case_2, date=Time.TEN_YEARS_AGO)
@@ -252,14 +224,14 @@ class TestDismissalBlock(unittest.TestCase):
 
         record = Record([self.case_1, self.case_2])
         expunger = Expunger(record)
-        expunger.run()
+        expunger_result = expunger.run()
 
-        assert unrelated_dismissal.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert expunger_result[unrelated_dismissal.id].status is EligibilityStatus.INELIGIBLE
         assert (
-            unrelated_dismissal.expungement_result.time_eligibility.reason
+            expunger_result[unrelated_dismissal.id].reason
             == "Three years from most recent other arrest (137.225(8)(a))"
         )
-        assert unrelated_dismissal.expungement_result.time_eligibility.date_will_be_eligible == Time.ONE_YEARS_FROM_NOW
+        assert expunger_result[unrelated_dismissal.id].date_will_be_eligible == Time.ONE_YEARS_FROM_NOW
 
     def test_mrd_does_not_block_convictions(self):
         case = CaseFactory.create()
@@ -272,14 +244,13 @@ class TestDismissalBlock(unittest.TestCase):
 
         record = Record([self.case_1, case])
         expunger = Expunger(record)
-        expunger.run()
+        expunger_result = expunger.run()
 
-        assert convicted_charge.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
-        assert convicted_charge.expungement_result.time_eligibility.reason == ""
-        assert (
-            convicted_charge.expungement_result.time_eligibility.date_will_be_eligible
-            == convicted_charge.disposition.date + relativedelta(years=+3)
-        )
+        assert expunger_result[convicted_charge.id].status is EligibilityStatus.ELIGIBLE
+        assert expunger_result[convicted_charge.id].reason == ""
+        assert expunger_result[
+            convicted_charge.id
+        ].date_will_be_eligible == convicted_charge.disposition.date + relativedelta(years=+3)
 
 
 class TestSecondMRCLogic(unittest.TestCase):
@@ -291,7 +262,7 @@ class TestSecondMRCLogic(unittest.TestCase):
         case.charges = [mrc, second_mrc]
         record = Record([case])
         expunger = Expunger(record)
-        expunger.run()
+        return expunger.run()
 
     def test_3_yr_old_conviction_2_yr_old_mrc(self):
         three_years_ago_charge = ChargeFactory.create(
@@ -301,25 +272,25 @@ class TestSecondMRCLogic(unittest.TestCase):
             disposition=Disposition(ruling="Convicted", date=Time.TWO_YEARS_AGO)
         )
 
-        self.run_expunger(two_years_ago_charge, three_years_ago_charge)
+        expunger_result = self.run_expunger(two_years_ago_charge, three_years_ago_charge)
 
-        assert three_years_ago_charge.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert expunger_result[three_years_ago_charge.id].status is EligibilityStatus.INELIGIBLE
         assert (
-            three_years_ago_charge.expungement_result.time_eligibility.reason
+            expunger_result[three_years_ago_charge.id].reason
             == "Ten years from most recent other conviction (137.225(7)(b))"
         )
         assert (
-            three_years_ago_charge.expungement_result.time_eligibility.date_will_be_eligible
+            expunger_result[three_years_ago_charge.id].date_will_be_eligible
             == two_years_ago_charge.disposition.date + Time.TEN_YEARS
         )
 
-        assert two_years_ago_charge.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert expunger_result[two_years_ago_charge.id].status is EligibilityStatus.INELIGIBLE
         assert (
-            two_years_ago_charge.expungement_result.time_eligibility.reason
+            expunger_result[two_years_ago_charge.id].reason
             == "Ten years from most recent other conviction (137.225(7)(b))"
         )
         assert (
-            two_years_ago_charge.expungement_result.time_eligibility.date_will_be_eligible
+            expunger_result[two_years_ago_charge.id].date_will_be_eligible
             == three_years_ago_charge.disposition.date + Time.TEN_YEARS
         )
 
@@ -331,25 +302,25 @@ class TestSecondMRCLogic(unittest.TestCase):
             disposition=Disposition(ruling="Convicted", date=Time.FIVE_YEARS_AGO)
         )
 
-        self.run_expunger(five_year_ago_charge, seven_year_ago_charge)
+        expunger_result = self.run_expunger(five_year_ago_charge, seven_year_ago_charge)
 
-        assert seven_year_ago_charge.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert expunger_result[seven_year_ago_charge.id].status is EligibilityStatus.INELIGIBLE
         assert (
-            seven_year_ago_charge.expungement_result.time_eligibility.reason
+            expunger_result[seven_year_ago_charge.id].reason
             == "Ten years from most recent other conviction (137.225(7)(b))"
         )
         assert (
-            seven_year_ago_charge.expungement_result.time_eligibility.date_will_be_eligible
+            expunger_result[seven_year_ago_charge.id].date_will_be_eligible
             == five_year_ago_charge.disposition.date + Time.TEN_YEARS
         )
 
-        assert five_year_ago_charge.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+        assert expunger_result[five_year_ago_charge.id].status is EligibilityStatus.INELIGIBLE
         assert (
-            five_year_ago_charge.expungement_result.time_eligibility.reason
+            expunger_result[five_year_ago_charge.id].reason
             == "Ten years from most recent other conviction (137.225(7)(b))"
         )
         assert (
-            five_year_ago_charge.expungement_result.time_eligibility.date_will_be_eligible
+            expunger_result[five_year_ago_charge.id].date_will_be_eligible
             == seven_year_ago_charge.disposition.date + Time.TEN_YEARS
         )
 
@@ -362,9 +333,9 @@ class TestSecondMRCLogic(unittest.TestCase):
         )
         eligibility_date = one_year_old_conviction.disposition.date + Time.THREE_YEARS
 
-        self.run_expunger(one_year_old_conviction, nine_year_old_conviction)
+        expunger_result = self.run_expunger(one_year_old_conviction, nine_year_old_conviction)
 
-        assert one_year_old_conviction.expungement_result.time_eligibility.date_will_be_eligible == eligibility_date
+        assert expunger_result[one_year_old_conviction.id].date_will_be_eligible == eligibility_date
 
 
 def create_class_b_felony_charge(date, ruling="Convicted"):
@@ -382,11 +353,11 @@ def test_felony_class_b_greater_than_20yrs():
     charge = create_class_b_felony_charge(Time.TWENTY_YEARS_AGO)
     case.charges = [charge]
     expunger = Expunger(Record([case]))
-    expunger.run()
+    expunger_result = expunger.run()
 
-    assert charge.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert charge.expungement_result.time_eligibility.reason == ""
-    assert charge.expungement_result.time_eligibility.date_will_be_eligible == date.today()
+    assert expunger_result[charge.id].status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[charge.id].reason == ""
+    assert expunger_result[charge.id].date_will_be_eligible == date.today()
 
 
 def test_felony_class_b_less_than_20yrs():
@@ -394,14 +365,13 @@ def test_felony_class_b_less_than_20yrs():
     charge = create_class_b_felony_charge(Time.LESS_THAN_TWENTY_YEARS_AGO)
     case.charges = [charge]
     expunger = Expunger(Record([case]))
-    expunger.run()
+    expunger_result = expunger.run()
 
-    assert charge.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[charge.id].status is EligibilityStatus.INELIGIBLE
     assert (
-        charge.expungement_result.time_eligibility.reason
-        == "Twenty years from date of class B felony conviction (137.225(5)(a)(A)(i))"
+        expunger_result[charge.id].reason == "Twenty years from date of class B felony conviction (137.225(5)(a)(A)(i))"
     )
-    assert charge.expungement_result.time_eligibility.date_will_be_eligible == Time.TOMORROW
+    assert expunger_result[charge.id].date_will_be_eligible == Time.TOMORROW
 
 
 def test_felony_class_b_with_subsequent_conviction():
@@ -413,17 +383,17 @@ def test_felony_class_b_with_subsequent_conviction():
     case_2.charges = [subsequent_charge]
 
     expunger = Expunger(Record([case_1, case_2]))
-    expunger.run()
+    expunger_result = expunger.run()
 
-    assert b_felony_charge.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[b_felony_charge.id].status is EligibilityStatus.INELIGIBLE
     assert (
-        b_felony_charge.expungement_result.time_eligibility.reason
+        expunger_result[b_felony_charge.id].reason
         == "Never. Class B felony can have no subsequent arrests or convictions (137.225(5)(a)(A)(ii))"
     )
-    assert b_felony_charge.expungement_result.time_eligibility.date_will_be_eligible == date.max
+    assert expunger_result[b_felony_charge.id].date_will_be_eligible == date.max
 
     # The Class B felony does not affect eligibility of another charge that is otherwise eligible
-    assert subsequent_charge.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[subsequent_charge.id].status is EligibilityStatus.ELIGIBLE
     assert subsequent_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
 
 
@@ -438,12 +408,12 @@ def test_felony_class_b_with_prior_conviction():
     case_2.charges = [prior_charge]
 
     expunger = Expunger(Record([case_1, case_2]))
-    expunger.run()
+    expunger_result = expunger.run()
 
     assert b_felony_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert b_felony_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
-    assert b_felony_charge.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert b_felony_charge.expungement_result.time_eligibility.reason == ""
+    assert expunger_result[b_felony_charge.id].status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[b_felony_charge.id].reason == ""
 
 
 def test_dismissed_felony_class_b_with_subsequent_conviction():
@@ -455,10 +425,10 @@ def test_dismissed_felony_class_b_with_subsequent_conviction():
     case_2.charges = [subsequent_charge]
 
     expunger = Expunger(Record([case_1, case_2]))
-    expunger.run()
+    expunger_result = expunger.run()
 
     assert b_felony_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert b_felony_charge.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[b_felony_charge.id].status is EligibilityStatus.ELIGIBLE
 
 
 def test_doubly_eligible_b_felony_gets_normal_eligibility_rule():
@@ -478,11 +448,11 @@ def test_doubly_eligible_b_felony_gets_normal_eligibility_rule():
     case_2.charges = [subsequent_charge]
 
     expunger = Expunger(Record([case_1, case_2]))
-    expunger.run()
+    expunger_result = expunger.run()
 
     assert not isinstance(manudel_charge, FelonyClassB)
     assert manudel_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert manudel_charge.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[manudel_charge.id].status is EligibilityStatus.ELIGIBLE
 
 def test_single_violation_is_time_restricted():
     # A single violation doesn't block other records, but it is still subject to the 3 year rule.
@@ -495,16 +465,11 @@ def test_single_violation_is_time_restricted():
     case = CaseFactory.create()
     case.charges = [violation_charge]
     expunger = Expunger(Record([case]))
-    expunger.run()
+    expunger_result = expunger.run()
 
-    assert violation_charge.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert (
-        violation_charge.expungement_result.time_eligibility.reason
-        == "Three years from date of conviction (137.225(1)(a))"
-    )
-    assert violation_charge.expungement_result.time_eligibility.date_will_be_eligible == date.today() + relativedelta(
-        days=+1
-    )
+    assert expunger_result[violation_charge.id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[violation_charge.id].reason == "Three years from date of conviction (137.225(1)(a))"
+    assert expunger_result[violation_charge.id].date_will_be_eligible == date.today() + relativedelta(days=+1)
 
 
 def test_2_violations_are_time_restricted():
@@ -522,25 +487,19 @@ def test_2_violations_are_time_restricted():
     case = CaseFactory.create()
     case.charges = [violation_charge_1, violation_charge_2]
     expunger = Expunger(Record([case]))
-    expunger.run()
+    expunger_result = expunger.run()
 
-    assert violation_charge_1.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[violation_charge_1.id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[violation_charge_1.id].reason == "Three years from date of conviction (137.225(1)(a))"
     assert (
-        violation_charge_1.expungement_result.time_eligibility.reason
-        == "Three years from date of conviction (137.225(1)(a))"
-    )
-    assert (
-        violation_charge_1.expungement_result.time_eligibility.date_will_be_eligible
+        expunger_result[violation_charge_1.id].date_will_be_eligible
         == violation_charge_1.disposition.date + Time.THREE_YEARS
     )
 
-    assert violation_charge_2.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[violation_charge_2.id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[violation_charge_2.id].reason == "Three years from date of conviction (137.225(1)(a))"
     assert (
-        violation_charge_2.expungement_result.time_eligibility.reason
-        == "Three years from date of conviction (137.225(1)(a))"
-    )
-    assert (
-        violation_charge_2.expungement_result.time_eligibility.date_will_be_eligible
+        expunger_result[violation_charge_2.id].date_will_be_eligible
         == violation_charge_2.disposition.date + Time.THREE_YEARS
     )
 
@@ -565,35 +524,32 @@ def test_3_violations_are_time_restricted():
     case = CaseFactory.create()
     case.charges = [violation_charge_3, violation_charge_2, violation_charge_1]
     expunger = Expunger(Record([case]))
-    expunger.run()
+    expunger_result = expunger.run()
 
-    assert violation_charge_1.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[violation_charge_1.id].status is EligibilityStatus.INELIGIBLE
     assert (
-        violation_charge_1.expungement_result.time_eligibility.reason
-        == "Ten years from most recent other conviction (137.225(7)(b))"
+        expunger_result[violation_charge_1.id].reason == "Ten years from most recent other conviction (137.225(7)(b))"
     )
     assert (
-        violation_charge_1.expungement_result.time_eligibility.date_will_be_eligible
+        expunger_result[violation_charge_1.id].date_will_be_eligible
         == violation_charge_2.disposition.date + Time.TEN_YEARS
     )
 
-    assert violation_charge_2.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[violation_charge_2.id].status is EligibilityStatus.INELIGIBLE
     assert (
-        violation_charge_2.expungement_result.time_eligibility.reason
-        == "Ten years from most recent other conviction (137.225(7)(b))"
+        expunger_result[violation_charge_2.id].reason == "Ten years from most recent other conviction (137.225(7)(b))"
     )
     assert (
-        violation_charge_2.expungement_result.time_eligibility.date_will_be_eligible
+        expunger_result[violation_charge_2.id].date_will_be_eligible
         == violation_charge_1.disposition.date + Time.TEN_YEARS
     )
 
-    assert violation_charge_3.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[violation_charge_3.id].status is EligibilityStatus.INELIGIBLE
     assert (
-        violation_charge_3.expungement_result.time_eligibility.reason
-        == "Ten years from most recent other conviction (137.225(7)(b))"
+        expunger_result[violation_charge_3.id].reason == "Ten years from most recent other conviction (137.225(7)(b))"
     )
     assert (
-        violation_charge_3.expungement_result.time_eligibility.date_will_be_eligible
+        expunger_result[violation_charge_3.id].date_will_be_eligible
         == violation_charge_1.disposition.date + Time.TEN_YEARS
     )
 
@@ -612,13 +568,10 @@ def test_nonblocking_charge_is_not_skipped_and_does_not_block():
     case = CaseFactory.create()
     case.charges = [civil_offense, violation_charge]
     expunger = Expunger(Record([case]))
-    expunger.run()
+    expunger_result = expunger.run()
 
-    assert civil_offense.expungement_result.time_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert (
-        civil_offense.expungement_result.time_eligibility.reason
-        == "Never. Type ineligible charges are always time ineligible."
-    )
-    assert civil_offense.expungement_result.time_eligibility.date_will_be_eligible == date.max
+    assert expunger_result[civil_offense.id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[civil_offense.id].reason == "Never. Type ineligible charges are always time ineligible."
+    assert expunger_result[civil_offense.id].date_will_be_eligible == date.max
 
-    assert violation_charge.expungement_result.time_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[violation_charge.id].status is EligibilityStatus.ELIGIBLE


### PR DESCRIPTION
This PR should have no functional changes.

I would recommend reviewing commit by commit.

Notably `Expunger.run` is now side-effect free and information about whether or not there are open cases is now returned from `ErrorChecker.check`.