### PR TITLE
Add ability to display multiple dates for each charge

### DIFF
--- a/src/backend/expungeservice/endpoints/search.py
+++ b/src/backend/expungeservice/endpoints/search.py
@@ -68,7 +68,7 @@ class Search(MethodView):
 
             charge_id_to_time_eligibilities = []
             for record in ambiguous_record:
-                record.errors += ErrorChecker.check(record)
+                record.errors += ErrorChecker.check(record)  # TODO: Fix mutation
                 expunger = Expunger(record)
                 charge_id_to_time_eligibility = expunger.run()
                 charge_id_to_time_eligibilities.append(charge_id_to_time_eligibility)

--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -41,7 +41,7 @@ class Expunger:
             else:
                 raise ValueError("Charge should always convicted or dismissed at this point.")
 
-            if charge.expungement_result.type_eligibility.status == EligibilityStatus.INELIGIBLE:
+            if charge.type_eligibility.status == EligibilityStatus.INELIGIBLE:
                 eligibility_dates.append((date.max, "Never. Type ineligible charges are always time ineligible."))
 
             if charge.disposition.status == DispositionStatus.NO_COMPLAINT:
@@ -122,7 +122,7 @@ class Expunger:
             if attractor:
                 for charge in case.charges:
                     if (
-                        charge.expungement_result.type_eligibility.status != EligibilityStatus.INELIGIBLE
+                        charge.type_eligibility.status != EligibilityStatus.INELIGIBLE
                         and charge.dismissed()
                         and charge_id_to_time_eligibility[charge.id].date_will_be_eligible
                         >= charge_id_to_time_eligibility[attractor.id].date_will_be_eligible

--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -9,7 +9,6 @@ from dateutil.relativedelta import relativedelta
 from expungeservice.models.disposition import Disposition, DispositionStatus
 from expungeservice.models.expungement_result import (
     ExpungementResult,
-    TimeEligibility,
     TypeEligibility,
     EligibilityStatus,
 )
@@ -23,16 +22,16 @@ class Charge:
     level: str
     date: date_class
     disposition: Optional[Disposition]
-    expungement_result: ExpungementResult = field(init=False)
+    type_eligibility: TypeEligibility = field(init=False)
     _chapter: Optional[str]
     _section: str
     _case: weakref.ref
+    expungement_result: ExpungementResult = ExpungementResult()  # TODO: Remove default value
     type_name: str = "Unknown"
     expungement_rules: str = "\\[rules documentation not added yet\\]"
 
     def __post_init__(self):
-        type_eligibility = self._build_type_eligibility()
-        self.expungement_result = ExpungementResult(type_eligibility=type_eligibility, time_eligibility=None)
+        self.type_eligibility = self._build_type_eligibility()
 
     def _build_type_eligibility(self):
         type_eligibility = self._type_eligibility()

--- a/src/backend/expungeservice/models/expungement_result.py
+++ b/src/backend/expungeservice/models/expungement_result.py
@@ -40,52 +40,8 @@ class ChargeEligibility:
 
 @dataclass
 class ExpungementResult:
-    type_eligibility: TypeEligibility
-    time_eligibility: Optional[TimeEligibility]
-
-    def set_type_eligibility(self, type_eligibility):
-        self.type_eligibility = type_eligibility
-
-    @property
-    def charge_eligibility(self):
-        if self.type_eligibility.status == EligibilityStatus.ELIGIBLE:
-            if self.time_eligibility and self.time_eligibility.status == EligibilityStatus.ELIGIBLE:
-                return ChargeEligibility(ChargeEligibilityStatus.ELIGIBLE_NOW, "Eligible")
-
-            elif self.time_eligibility and self.time_eligibility.status == EligibilityStatus.INELIGIBLE:
-                if self.time_eligibility.date_will_be_eligible == date.max:
-                    # Currently, no charge types that are type-eligible can be disqualified due to a time-ineligibility date of max, meaning "never"
-                    # So this else block has no applicable cases and never runs. But it will apply if a new charge type that qualifies gets added.
-                    return ChargeEligibility(ChargeEligibilityStatus.INELIGIBLE, "Ineligible")
-                elif self.time_eligibility.date_will_be_eligible:
-                    return ChargeEligibility(
-                        ChargeEligibilityStatus.WILL_BE_ELIGIBLE,
-                        f"Eligible {self.time_eligibility.date_will_be_eligible.strftime('%b %-d, %Y')}",
-                    )
-                else:
-                    raise ValueError("There was no date_will_be_eligible.")
-            else:
-                return ChargeEligibility(ChargeEligibilityStatus.UNKNOWN, "Type-eligible but time analysis is missing")
-
-        elif self.type_eligibility.status == EligibilityStatus.NEEDS_MORE_ANALYSIS:
-            if self.time_eligibility and self.time_eligibility.status == EligibilityStatus.ELIGIBLE:
-                return ChargeEligibility(ChargeEligibilityStatus.POSSIBLY_ELIGIBILE, "Possibly Eligible (review)")
-
-            elif self.time_eligibility and self.time_eligibility.status == EligibilityStatus.INELIGIBLE:
-                if self.time_eligibility.date_will_be_eligible == date.max:
-                    # Currently, this occurs with Class B Felonies only, which can be time ineligible with a date of max, meaning "never"
-                    return ChargeEligibility(ChargeEligibilityStatus.INELIGIBLE, "Ineligible")
-                elif self.time_eligibility.date_will_be_eligible:
-                    return ChargeEligibility(
-                        ChargeEligibilityStatus.POSSIBLY_WILL_BE_ELIGIBLE,
-                        f"Possibly Eligible {self.time_eligibility.date_will_be_eligible.strftime('%b %-d, %Y')} (review)",
-                    )
-                else:
-                    raise ValueError("There was no date_will_be_eligible.")
-            else:
-                return ChargeEligibility(
-                    ChargeEligibilityStatus.UNKNOWN, "Possibly eligible but time analysis is missing"
-                )
-
-        elif self.type_eligibility.status == EligibilityStatus.INELIGIBLE:
-            return ChargeEligibility(ChargeEligibilityStatus.INELIGIBLE, "Ineligible")
+    type_eligibility: TypeEligibility = TypeEligibility(
+        status=EligibilityStatus.NEEDS_MORE_ANALYSIS, reason="Default value"
+    )  # TODO: Remove default value
+    time_eligibility: Optional[TimeEligibility] = None
+    charge_eligibility: Optional[ChargeEligibility] = None

--- a/src/backend/expungeservice/models/helpers/record_merger.py
+++ b/src/backend/expungeservice/models/helpers/record_merger.py
@@ -1,7 +1,17 @@
-from typing import List, Dict, Set
+from dataclasses import replace
+from datetime import date
+from typing import List, Dict, Set, Optional
 
 from expungeservice.models.ambiguous import AmbiguousRecord
-from expungeservice.models.expungement_result import TimeEligibility
+from expungeservice.models.charge import Charge
+from expungeservice.models.expungement_result import (
+    TimeEligibility,
+    ExpungementResult,
+    TypeEligibility,
+    EligibilityStatus,
+    ChargeEligibility,
+    ChargeEligibilityStatus,
+)
 from expungeservice.models.record import Record
 import collections
 
@@ -16,14 +26,114 @@ class RecordMerger:
             for k, v in charge_id_to_time_eligibility.items():
                 charge_id_to_time_eligibilities[k].add(v)
         record = ambiguous_record[0]
-        for charge in record.charges:
-            charge.expungement_result.time_eligibility = RecordMerger.merge_time_eligibilities(
-                charge_id_to_time_eligibilities[charge.id]
-            )
-        return record
+        new_case_list = []
+        for case in record.cases:
+            new_charges = []
+            for charge in case.charges:
+                time_eligibilities = charge_id_to_time_eligibilities.get(charge.id)
+                merged_type_eligibility = RecordMerger.merge_type_eligibilities(charge.id, case.charges)
+                merged_time_eligibility = RecordMerger.merge_time_eligibilities(time_eligibilities)
+                charge_eligibility = RecordMerger.compute_charge_eligibility(
+                    merged_type_eligibility, time_eligibilities
+                )
+                expungement_result = ExpungementResult(
+                    type_eligibility=merged_type_eligibility,
+                    time_eligibility=merged_time_eligibility,
+                    charge_eligibility=charge_eligibility,
+                )
+                new_charge: Charge = replace(charge, expungement_result=expungement_result)
+                new_charges.append(new_charge)
+            new_case = replace(case, charges=new_charges)
+            new_case_list.append(new_case)
+        return replace(record, cases=new_case_list)
 
     @staticmethod
-    def merge_time_eligibilities(time_eligibilities: Set[TimeEligibility]):
-        return (
-            time_eligibilities.pop()
-        )  # TODO: Fix stub which assumes set is always of size 1 and actually do a meaningful merge.
+    def merge_type_eligibilities(charge_id: str, charges: List[Charge]) -> TypeEligibility:
+        same_charges = list(filter(lambda charge: charge.id == charge_id, charges))
+        status = RecordMerger.compute_type_eligibility_status(same_charges)
+        reason = ", ".join([charge.type_eligibility.reason for charge in same_charges])
+        return TypeEligibility(status=status, reason=reason)
+
+    @staticmethod
+    def compute_type_eligibility_status(charges: List[Charge]):
+        if all([charge.type_eligibility.status == EligibilityStatus.ELIGIBLE for charge in charges]):
+            return EligibilityStatus.ELIGIBLE
+        elif all([charge.type_eligibility.status == EligibilityStatus.INELIGIBLE for charge in charges]):
+            return EligibilityStatus.INELIGIBLE
+        else:
+            return EligibilityStatus.NEEDS_MORE_ANALYSIS
+
+    @staticmethod
+    def merge_time_eligibilities(time_eligibilities: Optional[Set[TimeEligibility]]) -> Optional[TimeEligibility]:
+        if time_eligibilities:
+            status = RecordMerger.compute_time_eligibility_status(time_eligibilities)
+            reason = ", ".join([time_eligibility.reason for time_eligibility in time_eligibilities])
+            date_will_be_eligible = date.max  # TODO: Fix
+            return TimeEligibility(status=status, reason=reason, date_will_be_eligible=date_will_be_eligible)
+        else:
+            return None
+
+    @staticmethod
+    def compute_time_eligibility_status(time_eligibilities: Set[TimeEligibility]):
+        if all([time_eligibility.status == EligibilityStatus.ELIGIBLE for time_eligibility in time_eligibilities]):
+            return EligibilityStatus.ELIGIBLE
+        else:
+            return EligibilityStatus.INELIGIBLE
+
+    # TODO: Think about if it is possible for a NEEDS_MORE_ANALYSIS type eligibility charge to have no disposition and handle.
+    @staticmethod
+    def compute_charge_eligibility(
+        type_eligibility: TypeEligibility, time_eligibilities: Optional[Set[TimeEligibility]]
+    ) -> ChargeEligibility:
+        if type_eligibility.status == EligibilityStatus.INELIGIBLE:
+            return ChargeEligibility(ChargeEligibilityStatus.INELIGIBLE, "Ineligible")
+        elif not time_eligibilities:
+            return ChargeEligibility(ChargeEligibilityStatus.UNKNOWN, "Possibly eligible but time analysis is missing")
+        elif all([time_eligibility.date_will_be_eligible == date.max for time_eligibility in time_eligibilities]):
+            return ChargeEligibility(ChargeEligibilityStatus.INELIGIBLE, "Ineligible")
+        elif any([time_eligibility.date_will_be_eligible == date.max for time_eligibility in time_eligibilities]):
+            at_least_will_be_eligibles = [
+                time_eligibility
+                for time_eligibility in time_eligibilities
+                if time_eligibility.date_will_be_eligible != date.max
+            ]
+            will_be_eligibles = [
+                time_eligibility.date_will_be_eligible.strftime("%b %-d, %Y")
+                for time_eligibility in at_least_will_be_eligibles
+                if time_eligibility.status != EligibilityStatus.ELIGIBLE
+            ]
+            will_be_eligibles_string = ", ".join(will_be_eligibles)
+            if all(
+                [
+                    time_eligibility.status == EligibilityStatus.ELIGIBLE
+                    for time_eligibility in at_least_will_be_eligibles
+                ]
+            ):
+                return ChargeEligibility(ChargeEligibilityStatus.POSSIBLY_ELIGIBILE, f"Possibly Eligible (review)")
+            elif any(
+                [
+                    time_eligibility.status == EligibilityStatus.ELIGIBLE
+                    for time_eligibility in at_least_will_be_eligibles
+                ]
+            ):
+                return ChargeEligibility(
+                    ChargeEligibilityStatus.POSSIBLY_WILL_BE_ELIGIBLE,
+                    f"Possibly Eligible Now, {will_be_eligibles_string} (review)",
+                )
+            else:
+                return ChargeEligibility(
+                    ChargeEligibilityStatus.POSSIBLY_WILL_BE_ELIGIBLE,
+                    f"Possibly Eligible {will_be_eligibles_string} (review)",
+                )
+        elif all([time_eligibility.date_will_be_eligible != date.max for time_eligibility in time_eligibilities]):
+            if all([time_eligibility.status == EligibilityStatus.ELIGIBLE for time_eligibility in time_eligibilities]):
+                return ChargeEligibility(ChargeEligibilityStatus.ELIGIBLE_NOW, "Eligible")
+            else:
+                date_will_be_eligibles = [
+                    time_eligibility.date_will_be_eligible.strftime("%b %-d, %Y")
+                    for time_eligibility in time_eligibilities
+                ]
+                eligible_date_string = ", ".join(date_will_be_eligibles)
+                return ChargeEligibility(ChargeEligibilityStatus.WILL_BE_ELIGIBLE, f"Eligible {eligible_date_string}")
+        else:
+            raise ValueError("Either all, some, or no time eligibilities will have an eligibility date of date.max.")

--- a/src/backend/expungeservice/stats.py
+++ b/src/backend/expungeservice/stats.py
@@ -14,9 +14,7 @@ def save_result(request_data, record):
     search_param_string = user_id + json.dumps(request_data["aliases"], sort_keys=True)
     hashed_search_params = hashlib.sha256(search_param_string.encode()).hexdigest()
     num_charges = len(record.charges)
-    num_eligible_charges = len(
-        [c for c in record.charges if c.expungement_result.type_eligibility.status == EligibilityStatus.ELIGIBLE]
-    )
+    num_eligible_charges = len([c for c in record.charges if c.type_eligibility.status == EligibilityStatus.ELIGIBLE])
     _db_insert_result(g.database, user_id, hashed_search_params, num_charges, num_eligible_charges)
 
 

--- a/src/backend/tests/models/charge_types/test_contempt_of_court.py
+++ b/src/backend/tests/models/charge_types/test_contempt_of_court.py
@@ -6,6 +6,7 @@ from tests.factories.charge_factory import ChargeFactory
 from tests.factories.case_factory import CaseFactory
 from tests.models.test_charge import Dispositions
 
+
 def test_contempt_of_court_dismissed():
     charge_dict = {
         "case": CaseFactory.create(type_status=["Contempt of Court", "Closed"]),
@@ -13,14 +14,13 @@ def test_contempt_of_court_dismissed():
         "statute": "33",
         "level": "N/A",
         "date": date_class(1901, 1, 1),
-        "disposition": Dispositions.DISMISSED
+        "disposition": Dispositions.DISMISSED,
     }
     charge = ChargeFactory.create(**charge_dict)
 
     assert isinstance(charge, ContemptOfCourt)
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert charge.expungement_result.type_eligibility.reason == "Ineligible by omission from statute"
-
+    assert charge.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert charge.type_eligibility.reason == "Ineligible by omission from statute"
 
 
 def test_contempt_of_court_convicted():
@@ -30,13 +30,13 @@ def test_contempt_of_court_convicted():
         "statute": "33065",
         "level": "N/A",
         "date": date_class(1901, 1, 1),
-        "disposition": Dispositions.CONVICTED
+        "disposition": Dispositions.CONVICTED,
     }
     charge = ChargeFactory.create(**charge_dict)
 
     assert isinstance(charge, ContemptOfCourt)
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert charge.expungement_result.type_eligibility.reason == "Ineligible by omission from statute"
+    assert charge.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert charge.type_eligibility.reason == "Ineligible by omission from statute"
 
 
 def test_contempt_of_court_no_disposition():
@@ -45,13 +45,13 @@ def test_contempt_of_court_no_disposition():
         "name": "contempt of court",
         "statute": "33015",
         "level": "misdemeanor",
-        "date": date_class(1901, 1, 1)
+        "date": date_class(1901, 1, 1),
     }
     charge = ChargeFactory.create(**charge_dict)
 
     assert isinstance(charge, ContemptOfCourt)
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert charge.expungement_result.type_eligibility.reason == "Ineligible by omission from statute"
+    assert charge.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert charge.type_eligibility.reason == "Ineligible by omission from statute"
 
 
 def test_contempt_of_court_unrecognized_disposition():
@@ -61,10 +61,10 @@ def test_contempt_of_court_unrecognized_disposition():
         "statute": "33055",
         "level": "violation",
         "date": date_class(1901, 1, 1),
-        "disposition": Dispositions.UNRECOGNIZED_DISPOSITION
+        "disposition": Dispositions.UNRECOGNIZED_DISPOSITION,
     }
     charge = ChargeFactory.create(**charge_dict)
 
     assert isinstance(charge, ContemptOfCourt)
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert charge.expungement_result.type_eligibility.reason == "Ineligible by omission from statute"
+    assert charge.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert charge.type_eligibility.reason == "Ineligible by omission from statute"

--- a/src/backend/tests/models/charge_types/test_felony_class_a.py
+++ b/src/backend/tests/models/charge_types/test_felony_class_a.py
@@ -14,8 +14,8 @@ def test_felony_class_a_charge():
     )
 
     assert isinstance(felony_class_a_convicted, FelonyClassA)
-    assert felony_class_a_convicted.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert felony_class_a_convicted.expungement_result.type_eligibility.reason == "Ineligible by omission from statute"
+    assert felony_class_a_convicted.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert felony_class_a_convicted.type_eligibility.reason == "Ineligible by omission from statute"
 
 
 def test_felony_class_a_dismissed():
@@ -27,11 +27,8 @@ def test_felony_class_a_dismissed():
     )
 
     assert isinstance(felony_class_a_dismissed, FelonyClassA)
-    assert felony_class_a_dismissed.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert (
-        felony_class_a_dismissed.expungement_result.type_eligibility.reason
-        == "Dismissals are eligible under 137.225(1)(b)"
-    )
+    assert felony_class_a_dismissed.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert felony_class_a_dismissed.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
 
 
 def test_felony_class_a_no_complaint():
@@ -43,8 +40,5 @@ def test_felony_class_a_no_complaint():
     )
 
     assert isinstance(felony_class_a_no_complaint, FelonyClassA)
-    assert felony_class_a_no_complaint.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert (
-        felony_class_a_no_complaint.expungement_result.type_eligibility.reason
-        == "Dismissals are eligible under 137.225(1)(b)"
-    )
+    assert felony_class_a_no_complaint.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert felony_class_a_no_complaint.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"

--- a/src/backend/tests/models/charge_types/test_felony_class_b.py
+++ b/src/backend/tests/models/charge_types/test_felony_class_b.py
@@ -14,8 +14,8 @@ def test_class_b_felony_164057():
     )
 
     assert isinstance(charge, FelonyClassB)
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
+    assert charge.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert charge.type_eligibility.reason == "Further Analysis Needed"
 
 
 def test_class_felony_is_added_to_b_felony_attribute():

--- a/src/backend/tests/models/charge_types/test_felony_class_c.py
+++ b/src/backend/tests/models/charge_types/test_felony_class_c.py
@@ -11,8 +11,8 @@ def test_felony_c_conviction():
     )
 
     assert isinstance(charge, FelonyClassC)
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert charge.expungement_result.type_eligibility.reason == "Eligible under 137.225(5)(b)"
+    assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert charge.type_eligibility.reason == "Eligible under 137.225(5)(b)"
 
 
 def test_felony_c_dismissal():
@@ -21,8 +21,8 @@ def test_felony_c_dismissal():
     )
 
     assert isinstance(charge, FelonyClassC)
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert charge.expungement_result.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
+    assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert charge.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
 
 
 def test_felony_c_no_disposition():
@@ -31,9 +31,9 @@ def test_felony_c_no_disposition():
     )
 
     assert isinstance(charge, FelonyClassC)
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
     assert (
-        charge.expungement_result.type_eligibility.reason
+        charge.type_eligibility.reason
         == "Eligible under 137.225(5)(b) for convictions or under 137.225(1)(b) for dismissals"
     )
 
@@ -47,8 +47,8 @@ def test_felony_c_unrecognized_disposition():
     )
 
     assert isinstance(charge, FelonyClassC)
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
     assert (
-        charge.expungement_result.type_eligibility.reason
+        charge.type_eligibility.reason
         == "Eligible under 137.225(5)(b) for convictions or under 137.225(1)(b) for dismissals"
     )

--- a/src/backend/tests/models/charge_types/test_juvenile_charge.py
+++ b/src/backend/tests/models/charge_types/test_juvenile_charge.py
@@ -11,5 +11,5 @@ def test_juvenile_charge():
     juvenile_charge = ChargeFactory.create(case=case, disposition=Dispositions.DISMISSED)
 
     assert isinstance(juvenile_charge, JuvenileCharge)
-    assert juvenile_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert juvenile_charge.expungement_result.type_eligibility.reason == "Potentially eligible under 419A.262"
+    assert juvenile_charge.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert juvenile_charge.type_eligibility.reason == "Potentially eligible under 419A.262"

--- a/src/backend/tests/models/charge_types/test_manufacture_delivery.py
+++ b/src/backend/tests/models/charge_types/test_manufacture_delivery.py
@@ -4,16 +4,16 @@ from tests.factories.charge_factory import ChargeFactory
 from tests.models.test_charge import Dispositions
 import pytest
 
+
 def test_manufacture_delivery_dismissed():
     manufacture_delivery_charge = ChargeFactory.create(
         name="Manufacture/Delivery", statute="4759922b", level="Felony Class A", disposition=Dispositions.DISMISSED
     )
 
     assert isinstance(manufacture_delivery_charge, ManufactureDelivery)
-    assert manufacture_delivery_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert (
-        manufacture_delivery_charge.expungement_result.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
-    )
+    assert manufacture_delivery_charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert manufacture_delivery_charge.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
+
 
 def test_manufacture_delivery_missing_disposition():
     manufacture_delivery_charge = ChargeFactory.create(
@@ -21,21 +21,22 @@ def test_manufacture_delivery_missing_disposition():
     )
 
     assert isinstance(manufacture_delivery_charge, ManufactureDelivery)
-    assert manufacture_delivery_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert (
-        manufacture_delivery_charge.expungement_result.type_eligibility.reason == "Possibly eligible. See additional legal details."
-    )
+    assert manufacture_delivery_charge.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert manufacture_delivery_charge.type_eligibility.reason == "Possibly eligible. See additional legal details."
+
 
 def test_manufacture_delivery_unrecognized_disposition():
     manufacture_delivery_charge = ChargeFactory.create(
-        name="Manufacture/Delivery", statute="4759922b", level="Felony Class B", disposition=Dispositions.UNRECOGNIZED_DISPOSITION
+        name="Manufacture/Delivery",
+        statute="4759922b",
+        level="Felony Class B",
+        disposition=Dispositions.UNRECOGNIZED_DISPOSITION,
     )
 
     assert isinstance(manufacture_delivery_charge, ManufactureDelivery)
-    assert manufacture_delivery_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert (
-        manufacture_delivery_charge.expungement_result.type_eligibility.reason == "Possibly eligible. See additional legal details."
-    )
+    assert manufacture_delivery_charge.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert manufacture_delivery_charge.type_eligibility.reason == "Possibly eligible. See additional legal details."
+
 
 def test_manufacture_delivery_manudel():
     manufacture_delivery_charge = ChargeFactory.create(
@@ -43,30 +44,43 @@ def test_manufacture_delivery_manudel():
     )
 
     assert isinstance(manufacture_delivery_charge, ManufactureDelivery)
-    assert manufacture_delivery_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert manufacture_delivery_charge.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert (
-        manufacture_delivery_charge.expungement_result.type_eligibility.reason == "This may be eligible if it is a charge for marijuana, under 137.226. See additional legal details."
+        manufacture_delivery_charge.type_eligibility.reason
+        == "This may be eligible if it is a charge for marijuana, under 137.226. See additional legal details."
     )
+
 
 def test_manufacture_delivery_manudel_felony_unclassified():
     manufacture_delivery_charge = ChargeFactory.create(
-        name="Manu/Del Cntrld Sub-SC 1", statute="4759921B", level="Felony Unclassified", disposition=Dispositions.CONVICTED
+        name="Manu/Del Cntrld Sub-SC 1",
+        statute="4759921B",
+        level="Felony Unclassified",
+        disposition=Dispositions.CONVICTED,
     )
 
     assert isinstance(manufacture_delivery_charge, ManufactureDelivery)
-    assert manufacture_delivery_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert manufacture_delivery_charge.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+
 
 def test_manufacture_delivery_manufacturing_name():
     manufacture_delivery_charge = ChargeFactory.create(
-        name="MANUFACTURING CONTROLLED SUB", statute="4759921A", level="Felony Unclassified", disposition=Dispositions.CONVICTED
+        name="MANUFACTURING CONTROLLED SUB",
+        statute="4759921A",
+        level="Felony Unclassified",
+        disposition=Dispositions.CONVICTED,
     )
 
     assert isinstance(manufacture_delivery_charge, ManufactureDelivery)
-    assert manufacture_delivery_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert manufacture_delivery_charge.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+
 
 def test_manufacture_delivery_1():
     manufacture_delivery_charge = ChargeFactory.create(
-        name="MANUFACTURING CONTROLLED SUB 2", statute="4759921A", level="Felony Unclassified", disposition=Dispositions.CONVICTED
+        name="MANUFACTURING CONTROLLED SUB 2",
+        statute="4759921A",
+        level="Felony Unclassified",
+        disposition=Dispositions.CONVICTED,
     )
 
     assert not isinstance(manufacture_delivery_charge, ManufactureDelivery)

--- a/src/backend/tests/models/charge_types/test_marijuana_eligible.py
+++ b/src/backend/tests/models/charge_types/test_marijuana_eligible.py
@@ -4,26 +4,31 @@ from tests.factories.charge_factory import ChargeFactory
 from tests.models.test_charge import Dispositions
 import pytest
 
+
 def test_delivery_to_minor_4758604A():
     marijuana_eligible_charge = ChargeFactory.create(
-        name="Delivery of Marijuana to Minor", statute="4758604A", level="Felony Class A", disposition=Dispositions.DISMISSED
+        name="Delivery of Marijuana to Minor",
+        statute="4758604A",
+        level="Felony Class A",
+        disposition=Dispositions.DISMISSED,
     )
     assert isinstance(marijuana_eligible_charge, MarijuanaEligible)
-    assert marijuana_eligible_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert (
-        marijuana_eligible_charge.expungement_result.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
-    )
+    assert marijuana_eligible_charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert marijuana_eligible_charge.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
+
 
 def test_marijuana_eligible_convicted():
     marijuana_eligible_charge = ChargeFactory.create(
-        name="Delivery of Marijuana to Minor", statute="4758604A", level="Felony Class A", disposition=Dispositions.CONVICTED
+        name="Delivery of Marijuana to Minor",
+        statute="4758604A",
+        level="Felony Class A",
+        disposition=Dispositions.CONVICTED,
     )
 
     assert isinstance(marijuana_eligible_charge, MarijuanaEligible)
-    assert marijuana_eligible_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert (
-        marijuana_eligible_charge.expungement_result.type_eligibility.reason == "Eligible under 137.226"
-    )
+    assert marijuana_eligible_charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert marijuana_eligible_charge.type_eligibility.reason == "Eligible under 137.226"
+
 
 def test_marijuana_eligible_missing_dispo():
     marijuana_eligible_charge = ChargeFactory.create(
@@ -31,25 +36,35 @@ def test_marijuana_eligible_missing_dispo():
     )
 
     assert isinstance(marijuana_eligible_charge, MarijuanaEligible)
-    assert marijuana_eligible_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert marijuana_eligible_charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
     assert (
-        marijuana_eligible_charge.expungement_result.type_eligibility.reason == "Always eligible under 137.226 (for convictions) or 137.225(1)(b) (for dismissals)"
+        marijuana_eligible_charge.type_eligibility.reason
+        == "Always eligible under 137.226 (for convictions) or 137.225(1)(b) (for dismissals)"
     )
+
 
 def test_marijuana_eligible_unrecognized_dispo():
     marijuana_eligible_charge = ChargeFactory.create(
-        name="Delivery of Marijuana to Minor", statute="4758604A", level="Felony Class A", disposition=Dispositions.UNRECOGNIZED_DISPOSITION
+        name="Delivery of Marijuana to Minor",
+        statute="4758604A",
+        level="Felony Class A",
+        disposition=Dispositions.UNRECOGNIZED_DISPOSITION,
     )
 
     assert isinstance(marijuana_eligible_charge, MarijuanaEligible)
-    assert marijuana_eligible_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert marijuana_eligible_charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
     assert (
-        marijuana_eligible_charge.expungement_result.type_eligibility.reason == "Always eligible under 137.226 (for convictions) or 137.225(1)(b) (for dismissals)"
+        marijuana_eligible_charge.type_eligibility.reason
+        == "Always eligible under 137.226 (for convictions) or 137.225(1)(b) (for dismissals)"
     )
+
 
 def test_delivery_4758602():
     marijuana_eligible_charge = ChargeFactory.create(
-        name="Delivery of Marijuana for Consideration", statute="4758602", level="Felony Class B", disposition=Dispositions.CONVICTED
+        name="Delivery of Marijuana for Consideration",
+        statute="4758602",
+        level="Felony Class B",
+        disposition=Dispositions.CONVICTED,
     )
 
     assert isinstance(marijuana_eligible_charge, MarijuanaEligible)

--- a/src/backend/tests/models/charge_types/test_marijuana_ineligible.py
+++ b/src/backend/tests/models/charge_types/test_marijuana_ineligible.py
@@ -15,8 +15,8 @@ def test_marijuana_ineligible_statute_475b3493c():
 
     assert isinstance(marijuana_felony_class_c, MarijuanaIneligible)
     assert marijuana_felony_class_c.type_name == "Marijuana Ineligible"
-    assert marijuana_felony_class_c.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert marijuana_felony_class_c.expungement_result.type_eligibility.reason == "Ineligible under 137.226"
+    assert marijuana_felony_class_c.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert marijuana_felony_class_c.type_eligibility.reason == "Ineligible under 137.226"
 
 
 def test_marijuana_ineligible_statute_475b359():
@@ -29,8 +29,8 @@ def test_marijuana_ineligible_statute_475b359():
 
     assert isinstance(marijuana_felony_class_a, MarijuanaIneligible)
     assert marijuana_felony_class_a.type_name == "Marijuana Ineligible"
-    assert marijuana_felony_class_a.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert marijuana_felony_class_a.expungement_result.type_eligibility.reason == "Ineligible under 137.226"
+    assert marijuana_felony_class_a.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert marijuana_felony_class_a.type_eligibility.reason == "Ineligible under 137.226"
 
 
 def test_marijuana_ineligible_statute_475b367():
@@ -43,8 +43,8 @@ def test_marijuana_ineligible_statute_475b367():
 
     assert isinstance(marijuana_felony_class_a, MarijuanaIneligible)
     assert marijuana_felony_class_a.type_name == "Marijuana Ineligible"
-    assert marijuana_felony_class_a.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert marijuana_felony_class_a.expungement_result.type_eligibility.reason == "Ineligible under 137.226"
+    assert marijuana_felony_class_a.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert marijuana_felony_class_a.type_eligibility.reason == "Ineligible under 137.226"
 
 
 def test_marijuana_ineligible_statute_475b371():
@@ -57,8 +57,8 @@ def test_marijuana_ineligible_statute_475b371():
 
     assert isinstance(marijuana_felony_class_a, MarijuanaIneligible)
     assert marijuana_felony_class_a.type_name == "Marijuana Ineligible"
-    assert marijuana_felony_class_a.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert marijuana_felony_class_a.expungement_result.type_eligibility.reason == "Ineligible under 137.226"
+    assert marijuana_felony_class_a.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert marijuana_felony_class_a.type_eligibility.reason == "Ineligible under 137.226"
 
 
 def test_marijuana_ineligible_statute_167262():
@@ -71,8 +71,8 @@ def test_marijuana_ineligible_statute_167262():
 
     assert isinstance(marijuana_misdemeanor_class_a, MarijuanaIneligible)
     assert marijuana_misdemeanor_class_a.type_name == "Marijuana Ineligible"
-    assert marijuana_misdemeanor_class_a.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert marijuana_misdemeanor_class_a.expungement_result.type_eligibility.reason == "Ineligible under 137.226"
+    assert marijuana_misdemeanor_class_a.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert marijuana_misdemeanor_class_a.type_eligibility.reason == "Ineligible under 137.226"
 
 
 def test_marijuana_ineligible_statute_475b3592a():
@@ -85,5 +85,5 @@ def test_marijuana_ineligible_statute_475b3592a():
 
     assert isinstance(marijuana_felony_class_a, MarijuanaIneligible)
     assert marijuana_felony_class_a.type_name == "Marijuana Ineligible"
-    assert marijuana_felony_class_a.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert marijuana_felony_class_a.expungement_result.type_eligibility.reason == "Ineligible under 137.226"
+    assert marijuana_felony_class_a.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert marijuana_felony_class_a.type_eligibility.reason == "Ineligible under 137.226"

--- a/src/backend/tests/models/charge_types/test_midemeanor.py
+++ b/src/backend/tests/models/charge_types/test_midemeanor.py
@@ -10,9 +10,9 @@ def test_misdemeanor_missing_disposition():
     )
 
     assert isinstance(misdemeanor_charge, Misdemeanor)
-    assert misdemeanor_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert misdemeanor_charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
     assert (
-        misdemeanor_charge.expungement_result.type_eligibility.reason
+        misdemeanor_charge.type_eligibility.reason
         == "Misdemeanors are always eligible under 137.225(5)(b) for convictions, or 137.225(1)(b) for dismissals"
     )
 
@@ -26,8 +26,8 @@ def test_misdemeanor_164043():
     )
 
     assert isinstance(charge, Misdemeanor)
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert charge.expungement_result.type_eligibility.reason == "Eligible under 137.225(5)(b)"
+    assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert charge.type_eligibility.reason == "Eligible under 137.225(5)(b)"
 
 
 def test_misdemeanor_164125():
@@ -36,8 +36,8 @@ def test_misdemeanor_164125():
     )
 
     assert isinstance(charge, Misdemeanor)
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert charge.expungement_result.type_eligibility.reason == "Eligible under 137.225(5)(b)"
+    assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert charge.type_eligibility.reason == "Eligible under 137.225(5)(b)"
 
 
 def test_drug_free_zone_variance_misdemeanor():
@@ -49,5 +49,5 @@ def test_drug_free_zone_variance_misdemeanor():
     )
 
     assert isinstance(charge, Misdemeanor)
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert charge.expungement_result.type_eligibility.reason == "Eligible under 137.225(5)(b)"
+    assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert charge.type_eligibility.reason == "Eligible under 137.225(5)(b)"

--- a/src/backend/tests/models/charge_types/test_parking_ticket.py
+++ b/src/backend/tests/models/charge_types/test_parking_ticket.py
@@ -21,8 +21,8 @@ def test_parking_ticket_conviction():
 
     assert isinstance(charge, ParkingTicket)
     assert not charge.blocks_other_charges()
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert charge.expungement_result.type_eligibility.reason == "Ineligible under 137.225(7)(a)"
+    assert charge.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert charge.type_eligibility.reason == "Ineligible under 137.225(7)(a)"
 
 
 def test_parking_ticket_dismissal():
@@ -38,8 +38,8 @@ def test_parking_ticket_dismissal():
 
     assert isinstance(charge, ParkingTicket)
     assert not charge.blocks_other_charges()
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert charge.expungement_result.type_eligibility.reason == "Ineligible by omission from statute"
+    assert charge.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert charge.type_eligibility.reason == "Ineligible by omission from statute"
 
 
 def test_parking_ticket_no_disposition():
@@ -55,9 +55,9 @@ def test_parking_ticket_no_disposition():
 
     assert isinstance(charge, ParkingTicket)
     assert not charge.blocks_other_charges()
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert charge.type_eligibility.status is EligibilityStatus.INELIGIBLE
     assert (
-        charge.expungement_result.type_eligibility.reason
+        charge.type_eligibility.reason
         == "Always ineligible under 137.225(7)(a) (for convictions) or by omission from statute (for dismissals)"
     )
 
@@ -75,8 +75,8 @@ def test_parking_ticket_unrecognized_disposition():
 
     assert isinstance(charge, ParkingTicket)
     assert not charge.blocks_other_charges()
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert charge.type_eligibility.status is EligibilityStatus.INELIGIBLE
     assert (
-        charge.expungement_result.type_eligibility.reason
+        charge.type_eligibility.reason
         == "Always ineligible under 137.225(7)(a) (for convictions) or by omission from statute (for dismissals)"
     )

--- a/src/backend/tests/models/charge_types/test_person_felony.py
+++ b/src/backend/tests/models/charge_types/test_person_felony.py
@@ -23,10 +23,8 @@ def test_person_felony_class_b(person_felony_statute):
         name="Generic", statute=person_felony_statute, level="Felony Class B", disposition=Dispositions.CONVICTED
     )
     assert isinstance(person_felony_class_b_convicted, PersonFelonyClassB)
-    assert person_felony_class_b_convicted.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert (
-        person_felony_class_b_convicted.expungement_result.type_eligibility.reason == "Ineligible under 137.225(5)(a)"
-    )
+    assert person_felony_class_b_convicted.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert person_felony_class_b_convicted.type_eligibility.reason == "Ineligible under 137.225(5)(a)"
 
 
 @pytest.mark.parametrize("person_felony_statute", PersonFelonyClassB.statutes_with_subsection)
@@ -35,12 +33,9 @@ def test_felony_b_person_felony_with_missing_subsection(person_felony_statute):
         name="Generic", statute=person_felony_statute[:6], level="Felony Class B", disposition=Dispositions.CONVICTED
     )
     assert isinstance(person_felony_class_b_convicted, PersonFelonyClassB)
+    assert person_felony_class_b_convicted.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert (
-        person_felony_class_b_convicted.expungement_result.type_eligibility.status
-        is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    )
-    assert (
-        person_felony_class_b_convicted.expungement_result.type_eligibility.reason
+        person_felony_class_b_convicted.type_eligibility.reason
         == "OECI may be missing a statute subsection which would make this charge a person crime, and thus ineligible under 137.225(5)(a)"
     )
 

--- a/src/backend/tests/models/charge_types/test_sex_crimes.py
+++ b/src/backend/tests/models/charge_types/test_sex_crimes.py
@@ -11,8 +11,8 @@ def test_sex_crimes(sex_crimes_statute):
         name="Generic", statute=sex_crimes_statute, level="Felony Class B", disposition=Dispositions.CONVICTED
     )
     assert isinstance(sex_crime_convicted, SexCrime)
-    assert sex_crime_convicted.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert sex_crime_convicted.expungement_result.type_eligibility.reason == "Ineligible under 137.225(6)(a)"
+    assert sex_crime_convicted.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert sex_crime_convicted.type_eligibility.reason == "Ineligible under 137.225(6)(a)"
 
 
 @pytest.mark.parametrize("sex_crimes_statute", SexCrime.romeo_and_juliet_exceptions)
@@ -21,11 +21,8 @@ def test_sex_crimes_with_romeo_and_juliet_exception(sex_crimes_statute):
         name="Generic", statute=sex_crimes_statute, level="Misdemeanor Class A", disposition=Dispositions.CONVICTED
     )
     assert isinstance(sex_crime_romeo_juliet_exception_convicted, SexCrime)
+    assert sex_crime_romeo_juliet_exception_convicted.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert (
-        sex_crime_romeo_juliet_exception_convicted.expungement_result.type_eligibility.status
-        is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    )
-    assert (
-        sex_crime_romeo_juliet_exception_convicted.expungement_result.type_eligibility.reason
+        sex_crime_romeo_juliet_exception_convicted.type_eligibility.reason
         == "Romeo and Juliet exception, needs other eligibility requirements. See 163A.140(1)"
     )

--- a/src/backend/tests/models/charge_types/test_subsection_6.py
+++ b/src/backend/tests/models/charge_types/test_subsection_6.py
@@ -13,10 +13,8 @@ def test_subsection_6_dismissed():
     )
 
     assert isinstance(subsection_6_charge, Subsection6)
-    assert subsection_6_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert (
-        subsection_6_charge.expungement_result.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
-    )
+    assert subsection_6_charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert subsection_6_charge.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
 
 
 def test_subsection_6_163165():
@@ -28,11 +26,8 @@ def test_subsection_6_163165():
     )
 
     assert isinstance(subsection_6_charge, Subsection6)
-    assert subsection_6_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert (
-        subsection_6_charge.expungement_result.type_eligibility.reason
-        == "Ineligible under 137.225(6) in certain circumstances."
-    )
+    assert subsection_6_charge.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert subsection_6_charge.type_eligibility.reason == "Ineligible under 137.225(6) in certain circumstances."
 
 
 def test_subsection_6_163200():
@@ -44,11 +39,8 @@ def test_subsection_6_163200():
     )
 
     assert isinstance(subsection_6_charge, Subsection6)
-    assert subsection_6_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert (
-        subsection_6_charge.expungement_result.type_eligibility.reason
-        == "Ineligible under 137.225(6) in certain circumstances."
-    )
+    assert subsection_6_charge.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert subsection_6_charge.type_eligibility.reason == "Ineligible under 137.225(6) in certain circumstances."
 
 
 def test_subsection_6_163575():

--- a/src/backend/tests/models/charge_types/test_traffic_offenses.py
+++ b/src/backend/tests/models/charge_types/test_traffic_offenses.py
@@ -36,8 +36,8 @@ def test_convicted_violation_is_not_type_eligible():
     )
 
     assert isinstance(charge, TrafficViolation)
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert charge.expungement_result.type_eligibility.reason == "Ineligible under 137.225(7)(a)"
+    assert charge.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert charge.type_eligibility.reason == "Ineligible under 137.225(7)(a)"
     assert not charge.blocks_other_charges()
 
 
@@ -47,11 +47,8 @@ def test_dismissed_violation_is_not_type_eligible():
     )
 
     assert isinstance(charge, TrafficViolation)
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert (
-        charge.expungement_result.type_eligibility.reason
-        == "Dismissed violations are ineligible by omission from statute"
-    )
+    assert charge.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert charge.type_eligibility.reason == "Dismissed violations are ineligible by omission from statute"
     assert not charge.blocks_other_charges()
 
 
@@ -59,8 +56,8 @@ def test_convicted_infraction_is_not_type_eligible():
     charge = ChargeFactory.create(statute="811135", level="Infraction Class B", disposition=Dispositions.CONVICTED)
 
     assert isinstance(charge, TrafficViolation)
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert charge.expungement_result.type_eligibility.reason == "Ineligible under 137.225(7)(a)"
+    assert charge.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert charge.type_eligibility.reason == "Ineligible under 137.225(7)(a)"
     assert not charge.blocks_other_charges()
 
 
@@ -68,23 +65,21 @@ def test_dismissed_infraction_is_not_type_eligible():
     charge = ChargeFactory.create(statute="811135", level="Infraction Class B", disposition=Dispositions.DISMISSED)
 
     assert isinstance(charge, TrafficViolation)
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert (
-        charge.expungement_result.type_eligibility.reason
-        == "Dismissed violations are ineligible by omission from statute"
-    )
+    assert charge.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert charge.type_eligibility.reason == "Dismissed violations are ineligible by omission from statute"
     assert not charge.blocks_other_charges()
 
 
 def test_no_dispo_violation_is_not_type_eligible():
     charge = ChargeFactory.create(statute="801.000", level="Class C Traffic Violation", disposition=None)
 
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert charge.type_eligibility.status is EligibilityStatus.INELIGIBLE
     assert (
-        charge.expungement_result.type_eligibility.reason
+        charge.type_eligibility.reason
         == "Always ineligible under 137.225(7)(a) (for convictions) or by omission from statute (for dismissals)"
     )
     assert not charge.blocks_other_charges()
+
 
 def test_unrecognized_violation_is_not_type_eligible():
     charge = ChargeFactory.create(
@@ -92,9 +87,13 @@ def test_unrecognized_violation_is_not_type_eligible():
     )
 
     assert isinstance(charge, TrafficViolation)
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert charge.expungement_result.type_eligibility.reason == "Always ineligible under 137.225(7)(a) (for convictions) or by omission from statute (for dismissals)"
+    assert charge.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert (
+        charge.type_eligibility.reason
+        == "Always ineligible under 137.225(7)(a) (for convictions) or by omission from statute (for dismissals)"
+    )
     assert not charge.blocks_other_charges()
+
 
 """
 800 level misdemeanors and felonies are eligible Only If the case was dismissed
@@ -104,32 +103,32 @@ def test_unrecognized_violation_is_not_type_eligible():
 def test_misdemeanor_conviction_is_not_eligible():
     charge = ChargeFactory.create(statute="814.010(4)", level="Misdemeanor Class A", disposition=Dispositions.CONVICTED)
 
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert charge.expungement_result.type_eligibility.reason == "Ineligible under 137.225(7)(a)"
+    assert charge.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert charge.type_eligibility.reason == "Ineligible under 137.225(7)(a)"
     assert charge.blocks_other_charges()
 
 
 def test_misdemeanor_dismissal_is_eligible():
     charge = ChargeFactory.create(statute="814.010(4)", level="Misdemeanor Class A", disposition=Dispositions.DISMISSED)
 
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert charge.expungement_result.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
+    assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert charge.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
     assert charge.blocks_other_charges()
 
 
 def test_felony_conviction_is_not_eligible():
     charge = ChargeFactory.create(statute="819.300", level="Felony Class C", disposition=Dispositions.CONVICTED)
 
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert charge.expungement_result.type_eligibility.reason == "Ineligible under 137.225(7)(a)"
+    assert charge.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert charge.type_eligibility.reason == "Ineligible under 137.225(7)(a)"
     assert charge.blocks_other_charges()
 
 
 def test_felony_dismissal_is_eligible():
     charge = ChargeFactory.create(statute="819.300", level="Felony Class C", disposition=Dispositions.DISMISSED)
 
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert charge.expungement_result.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
+    assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert charge.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
     assert charge.blocks_other_charges()
 
 

--- a/src/backend/tests/models/charge_types/test_type_analyzer_duii.py
+++ b/src/backend/tests/models/charge_types/test_type_analyzer_duii.py
@@ -14,9 +14,9 @@ def build_charge(statute, disposition_ruling):
 def test_duii_dismissed():
     duii_dismissed = build_charge(statute="813.010", disposition_ruling="Acquitted")
 
-    assert duii_dismissed.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert duii_dismissed.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert (
-        duii_dismissed.expungement_result.type_eligibility.reason
+        duii_dismissed.type_eligibility.reason
         == "Further Analysis Needed - Dismissed charge may have been Diverted, making it ineligible under 137.225(8)(b)"
     )
 
@@ -24,9 +24,9 @@ def test_duii_dismissed():
 def test_duii_diverted():
     duii_diverted = build_charge(statute="813.011", disposition_ruling="Diverted")
 
-    assert duii_diverted.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert duii_diverted.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert (
-        duii_diverted.expungement_result.type_eligibility.reason
+        duii_diverted.type_eligibility.reason
         == "Further Analysis Needed - Dismissed charge may have been Diverted, making it ineligible under 137.225(8)(b)"
     )
 
@@ -34,7 +34,5 @@ def test_duii_diverted():
 def test_duii_convicted():
     duii_convicted = build_charge(statute="813.123", disposition_ruling="Convicted")
 
-    assert duii_convicted.expungement_result.type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert (
-        duii_convicted.expungement_result.type_eligibility.reason == "137.225(7)(a) - Traffic offenses are ineligible"
-    )
+    assert duii_convicted.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert duii_convicted.type_eligibility.reason == "137.225(7)(a) - Traffic offenses are ineligible"

--- a/src/backend/tests/models/charge_types/test_unclassified.py
+++ b/src/backend/tests/models/charge_types/test_unclassified.py
@@ -13,11 +13,8 @@ def test_unclassified_charge():
     )
 
     assert isinstance(unclassified_dismissed, UnclassifiedCharge)
-    assert unclassified_dismissed.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert (
-        unclassified_dismissed.expungement_result.type_eligibility.reason
-        == "Unrecognized Charge : Further Analysis Needed"
-    )
+    assert unclassified_dismissed.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert unclassified_dismissed.type_eligibility.reason == "Unrecognized Charge : Further Analysis Needed"
 
 
 def test_charge_that_falls_through():
@@ -29,40 +26,34 @@ def test_charge_that_falls_through():
     )
 
     assert isinstance(charge, UnclassifiedCharge)
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert charge.expungement_result.type_eligibility.reason == "Unrecognized Charge : Further Analysis Needed"
+    assert charge.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert charge.type_eligibility.reason == "Unrecognized Charge : Further Analysis Needed"
+
 
 def test_unrecognized_disposition():
     unclassified_dismissed = ChargeFactory.create(
-        name="Unknown",
-        statute="333.333",
-        level="Felony Class F",
-        disposition=Dispositions.UNRECOGNIZED_DISPOSITION,
+        name="Unknown", statute="333.333", level="Felony Class F", disposition=Dispositions.UNRECOGNIZED_DISPOSITION,
     )
     assert isinstance(unclassified_dismissed, UnclassifiedCharge)
-    assert unclassified_dismissed.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert unclassified_dismissed.expungement_result.type_eligibility.reason == "Unrecognized Charge : Further Analysis Needed"
+    assert unclassified_dismissed.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert unclassified_dismissed.type_eligibility.reason == "Unrecognized Charge : Further Analysis Needed"
+
 
 def test_convicted_disposition():
     unclassified_convicted = ChargeFactory.create(
-        name="Unknown",
-        statute="333.333",
-        level="Felony Class F",
-        disposition=Dispositions.CONVICTED,
+        name="Unknown", statute="333.333", level="Felony Class F", disposition=Dispositions.CONVICTED,
     )
-   
+
     assert isinstance(unclassified_convicted, UnclassifiedCharge)
-    assert unclassified_convicted.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert unclassified_convicted.expungement_result.type_eligibility.reason == "Unrecognized Charge : Further Analysis Needed"
+    assert unclassified_convicted.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert unclassified_convicted.type_eligibility.reason == "Unrecognized Charge : Further Analysis Needed"
+
 
 def test_no_disposition():
     unclassified_dispo_none = ChargeFactory.create(
-        name="Unknown",
-        statute="333.333",
-        level="Felony Class F",
-        disposition=None,
+        name="Unknown", statute="333.333", level="Felony Class F", disposition=None,
     )
-   
+
     assert isinstance(unclassified_dispo_none, UnclassifiedCharge)
-    assert unclassified_dispo_none.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert unclassified_dispo_none.expungement_result.type_eligibility.reason == "Unrecognized Charge : Further Analysis Needed"
+    assert unclassified_dispo_none.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert unclassified_dispo_none.type_eligibility.reason == "Unrecognized Charge : Further Analysis Needed"

--- a/src/backend/tests/models/charge_types/test_violation.py
+++ b/src/backend/tests/models/charge_types/test_violation.py
@@ -11,5 +11,5 @@ def test_violation():
     )
 
     assert isinstance(charge, Violation)
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert charge.expungement_result.type_eligibility.reason == "Eligible under 137.225(5)(d)"
+    assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert charge.type_eligibility.reason == "Eligible under 137.225(5)(d)"

--- a/src/backend/tests/models/test_disposition_status.py
+++ b/src/backend/tests/models/test_disposition_status.py
@@ -42,8 +42,8 @@ def test_dispositionless_charge_is_not_convicted_nor_dismissed():
 
     assert not charge.convicted()
     assert not charge.dismissed()
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert charge.expungement_result.type_eligibility.reason == "Disposition not found. Needs further analysis"
+    assert charge.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert charge.type_eligibility.reason == "Disposition not found. Needs further analysis"
 
 
 def test_charge_with_unrecognized_disposition_eligibility():
@@ -52,5 +52,5 @@ def test_charge_with_unrecognized_disposition_eligibility():
     )
     assert not charge.convicted()
     assert not charge.dismissed()
-    assert charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert charge.expungement_result.type_eligibility.reason == "Disposition not recognized. Needs further analysis"
+    assert charge.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert charge.type_eligibility.reason == "Disposition not recognized. Needs further analysis"

--- a/src/backend/tests/models/test_expungement_result.py
+++ b/src/backend/tests/models/test_expungement_result.py
@@ -1,81 +1,90 @@
 from expungeservice.models.expungement_result import *
+from expungeservice.models.helpers.record_merger import RecordMerger
+from tests.time import Time
 
 
 def test_eligible():
     type_eligibility = TypeEligibility(EligibilityStatus.ELIGIBLE, "Eligible under some statute")
     time_eligibility = TimeEligibility(EligibilityStatus.ELIGIBLE, "Eligible under some statute", date.today())
-    expungement_result = ExpungementResult(type_eligibility, time_eligibility)
+    charge_eligibility = RecordMerger.compute_charge_eligibility(type_eligibility, {time_eligibility})
 
-    assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.ELIGIBLE_NOW
-    assert expungement_result.charge_eligibility.label == "Eligible"
+    assert charge_eligibility.status == ChargeEligibilityStatus.ELIGIBLE_NOW
+    assert charge_eligibility.label == "Eligible"
 
 
 def test_will_be_eligible():
     today = date.today()
     type_eligibility = TypeEligibility(EligibilityStatus.ELIGIBLE, "Eligible under some statute")
     time_eligibility = TimeEligibility(EligibilityStatus.INELIGIBLE, "Ineligible under some statute", today)
-    expungement_result = ExpungementResult(type_eligibility, time_eligibility)
+    charge_eligibility = RecordMerger.compute_charge_eligibility(type_eligibility, {time_eligibility})
 
-    assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.WILL_BE_ELIGIBLE
-    assert expungement_result.charge_eligibility.label == f"Eligible {today.strftime('%b %-d, %Y')}"
+    assert charge_eligibility.status == ChargeEligibilityStatus.WILL_BE_ELIGIBLE
+    assert charge_eligibility.label == f"Eligible {today.strftime('%b %-d, %Y')}"
 
 
 def test_possibly_eligible():
     type_eligibility = TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, "Unrecognized charge")
-    time_eligibility = TimeEligibility(EligibilityStatus.ELIGIBLE, "Eligible under some statute", date.today())
-    expungement_result = ExpungementResult(type_eligibility, time_eligibility)
+    time_eligibility = TimeEligibility(EligibilityStatus.ELIGIBLE, "Eligible under for some reason", date.today())
+    time_eligibility_2 = TimeEligibility(EligibilityStatus.INELIGIBLE, "Ineligible under some statute", date.max)
+    charge_eligibility = RecordMerger.compute_charge_eligibility(
+        type_eligibility, {time_eligibility, time_eligibility_2}
+    )
 
-    assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.POSSIBLY_ELIGIBILE
-    assert expungement_result.charge_eligibility.label == "Possibly Eligible (review)"
+    assert charge_eligibility.status == ChargeEligibilityStatus.POSSIBLY_ELIGIBILE
+    assert charge_eligibility.label == "Possibly Eligible (review)"
 
 
 def test_possibly_will_be_eligible():
-    today = date.today()
     type_eligibility = TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, "Unrecognized charge")
-    time_eligibility = TimeEligibility(EligibilityStatus.INELIGIBLE, "Ineligible under some statute", today)
-    expungement_result = ExpungementResult(type_eligibility, time_eligibility)
+    time_eligibility = TimeEligibility(
+        EligibilityStatus.INELIGIBLE, "Ineligible for some reason", Time.ONE_YEARS_FROM_NOW
+    )
+    time_eligibility_2 = TimeEligibility(EligibilityStatus.INELIGIBLE, "Ineligible under some statute", date.max)
+    charge_eligibility = RecordMerger.compute_charge_eligibility(
+        type_eligibility, {time_eligibility, time_eligibility_2}
+    )
 
-    assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.POSSIBLY_WILL_BE_ELIGIBLE
-    assert expungement_result.charge_eligibility.label == f"Possibly Eligible {today.strftime('%b %-d, %Y')} (review)"
+    assert charge_eligibility.status == ChargeEligibilityStatus.POSSIBLY_WILL_BE_ELIGIBLE
+    assert charge_eligibility.label == f"Possibly Eligible {Time.ONE_YEARS_FROM_NOW.strftime('%b %-d, %Y')} (review)"
 
 
 def test_ineligible():
     type_eligibility = TypeEligibility(EligibilityStatus.INELIGIBLE, "Ineligible under some statute")
-    expungement_result = ExpungementResult(type_eligibility, None)
+    charge_eligibility = RecordMerger.compute_charge_eligibility(type_eligibility, set())
 
-    assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.INELIGIBLE
-    assert expungement_result.charge_eligibility.label == "Ineligible"
+    assert charge_eligibility.status == ChargeEligibilityStatus.INELIGIBLE
+    assert charge_eligibility.label == "Ineligible"
 
 
 def test_type_eligible_never_becomes_eligible():
     type_eligibility = TypeEligibility(EligibilityStatus.ELIGIBLE, "Eligible under some statute")
     time_eligibility = TimeEligibility(EligibilityStatus.INELIGIBLE, "Never eligible under some statute", date.max)
-    expungement_result = ExpungementResult(type_eligibility, time_eligibility)
+    charge_eligibility = RecordMerger.compute_charge_eligibility(type_eligibility, {time_eligibility})
 
-    assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.INELIGIBLE
-    assert expungement_result.charge_eligibility.label == "Ineligible"
+    assert charge_eligibility.status == ChargeEligibilityStatus.INELIGIBLE
+    assert charge_eligibility.label == "Ineligible"
 
 
 def test_type_possibly_eligible_never_becomes_eligible():
     type_eligibility = TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, "Unrecognized charge")
     time_eligibility = TimeEligibility(EligibilityStatus.INELIGIBLE, "Never eligible under some statute", date.max)
-    expungement_result = ExpungementResult(type_eligibility, time_eligibility)
+    charge_eligibility = RecordMerger.compute_charge_eligibility(type_eligibility, {time_eligibility})
 
-    assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.INELIGIBLE
-    assert expungement_result.charge_eligibility.label == "Ineligible"
+    assert charge_eligibility.status == ChargeEligibilityStatus.INELIGIBLE
+    assert charge_eligibility.label == "Ineligible"
 
 
 def test_type_eligible_but_time_eligibility_missing():
     type_eligibility = TypeEligibility(EligibilityStatus.ELIGIBLE, "Eligible under some statute")
-    expungement_result = ExpungementResult(type_eligibility, None)
+    charge_eligibility = RecordMerger.compute_charge_eligibility(type_eligibility, set())
 
-    assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.UNKNOWN
-    assert expungement_result.charge_eligibility.label == "Type-eligible but time analysis is missing"
+    assert charge_eligibility.status == ChargeEligibilityStatus.UNKNOWN
+    assert charge_eligibility.label == "Possibly eligible but time analysis is missing"
 
 
 def test_possibly_type_eligible_but_time_eligibility_missing():
     type_eligibility = TypeEligibility(EligibilityStatus.NEEDS_MORE_ANALYSIS, "Unrecognized charge")
-    expungement_result = ExpungementResult(type_eligibility, None)
+    charge_eligibility = RecordMerger.compute_charge_eligibility(type_eligibility, set())
 
-    assert expungement_result.charge_eligibility.status == ChargeEligibilityStatus.UNKNOWN
-    assert expungement_result.charge_eligibility.label == "Possibly eligible but time analysis is missing"
+    assert charge_eligibility.status == ChargeEligibilityStatus.UNKNOWN
+    assert charge_eligibility.label == "Possibly eligible but time analysis is missing"

--- a/src/backend/tests/test_friendly_rule.py
+++ b/src/backend/tests/test_friendly_rule.py
@@ -36,16 +36,16 @@ def test_eligible_mrc_with_single_arrest():
 
     merged_record = RecordMerger.merge([record], [expunger_result])
     assert (
-        merged_record.cases[0].charges[0].expungement_result.charge_eligibility.status
+        merged_record.cases[0].charges[0].expungement_result.charge_eligibility.status  # type: ignore
         == ChargeEligibilityStatus.ELIGIBLE_NOW
     )
-    assert merged_record.cases[0].charges[0].expungement_result.charge_eligibility.label == "Eligible"
+    assert merged_record.cases[0].charges[0].expungement_result.charge_eligibility.label == "Eligible"  # type: ignore
 
     assert (
-        merged_record.cases[0].charges[1].expungement_result.charge_eligibility.status
+        merged_record.cases[0].charges[1].expungement_result.charge_eligibility.status  # type: ignore
         == ChargeEligibilityStatus.ELIGIBLE_NOW
     )
-    assert merged_record.cases[0].charges[1].expungement_result.charge_eligibility.label == "Eligible"
+    assert merged_record.cases[0].charges[1].expungement_result.charge_eligibility.label == "Eligible"  # type: ignore
 
 
 def test_arrest_is_unaffected_if_conviction_eligibility_is_older():

--- a/src/backend/tests/test_time_analyzer.py
+++ b/src/backend/tests/test_time_analyzer.py
@@ -394,7 +394,7 @@ def test_felony_class_b_with_subsequent_conviction():
 
     # The Class B felony does not affect eligibility of another charge that is otherwise eligible
     assert expunger_result[subsequent_charge.id].status is EligibilityStatus.ELIGIBLE
-    assert subsequent_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert subsequent_charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
 
 
 def test_felony_class_b_with_prior_conviction():
@@ -410,8 +410,8 @@ def test_felony_class_b_with_prior_conviction():
     expunger = Expunger(Record([case_1, case_2]))
     expunger_result = expunger.run()
 
-    assert b_felony_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert b_felony_charge.expungement_result.type_eligibility.reason == "Further Analysis Needed"
+    assert b_felony_charge.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert b_felony_charge.type_eligibility.reason == "Further Analysis Needed"
     assert expunger_result[b_felony_charge.id].status is EligibilityStatus.ELIGIBLE
     assert expunger_result[b_felony_charge.id].reason == ""
 
@@ -427,7 +427,7 @@ def test_dismissed_felony_class_b_with_subsequent_conviction():
     expunger = Expunger(Record([case_1, case_2]))
     expunger_result = expunger.run()
 
-    assert b_felony_charge.expungement_result.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert b_felony_charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
     assert expunger_result[b_felony_charge.id].status is EligibilityStatus.ELIGIBLE
 
 
@@ -451,8 +451,9 @@ def test_doubly_eligible_b_felony_gets_normal_eligibility_rule():
     expunger_result = expunger.run()
 
     assert not isinstance(manudel_charge, FelonyClassB)
-    assert manudel_charge.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert manudel_charge.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert expunger_result[manudel_charge.id].status is EligibilityStatus.ELIGIBLE
+
 
 def test_single_violation_is_time_restricted():
     # A single violation doesn't block other records, but it is still subject to the 3 year rule.


### PR DESCRIPTION
`charge.type_eligibility` represents the type eligibility of a charge. `charge.expungement_result.type_eligibility` now represents the merged type eligibility of a charge post-merge as a single charge can be a superposition of multiple charge subclasses.