### PR TITLE
Deploy rework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,19 +116,19 @@ $(REQUIREMENTS_TXT):
 
 .ONESHELL:
 deploy_staging_update_repo:
-	cd ~/recordexpungPDX/
+	cd /deployments/staging/recordexpungPDX
 	git reset --hard
 	git checkout staging
 	git pull origin staging:staging
 
 .ONESHELL:
 deploy_staging_backend: deploy_staging_update_repo
-	cd ~/recordexpungPDX/src/backend/
+	cd /deployments/staging/recordexpungPDX/src/backend/
 	kill $(ps -ef | grep -v grep | grep 127.0.0.1:3032 | awk '{print $2}')
-	$(shell tr '\n' ' ' < ~/recordexpungPDX/config/expungeservice/expungeservice.staging.env) nohup pipenv run uwsgi --socket 127.0.0.1:3032 --module expungeservice.wsgi &
+	$(shell tr '\n' ' ' < /deployments/staging/recordexpungPDX/recordexpungPDX/config/expungeservice/expungeservice.staging.env) nohup pipenv run uwsgi --socket 127.0.0.1:3032 --module expungeservice.wsgi &
 
 .ONESHELL:
 deploy_staging_frontend: deploy_staging_update_repo
-	cd ~/recordexpungPDX/src/frontend/
+	cd /deployments/staging/recordexpungPDX/src/frontend/
 	npm run build
 	cp -r build/* /var/www/dev.recordsponge.com/html/

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ deploy_staging_update_repo:
 deploy_staging_backend: deploy_staging_update_repo
 	cd /deployments/staging/recordexpungPDX/src/backend/
 	kill $(ps -ef | grep -v grep | grep 127.0.0.1:3032 | awk '{print $2}')
-	$(shell tr '\n' ' ' < /deployments/staging/recordexpungPDX/recordexpungPDX/config/expungeservice/expungeservice.staging.env) nohup pipenv run uwsgi --socket 127.0.0.1:3032 --module expungeservice.wsgi &
+	$(shell tr '\n' ' ' < /deployments/staging/recordexpungPDX/config/expungeservice/expungeservice.staging.env) nohup pipenv run uwsgi --socket 127.0.0.1:3032 --module expungeservice.wsgi &
 
 .ONESHELL:
 deploy_staging_frontend: deploy_staging_update_repo

--- a/Makefile
+++ b/Makefile
@@ -113,3 +113,22 @@ deploy_staging_frontend: #deploy_staging_update_repo
 .PHONY: $(REQUIREMENTS_TXT)
 $(REQUIREMENTS_TXT):
 	pipenv lock -r > $@
+
+.ONESHELL:
+deploy_staging_update_repo:
+	cd ~/recordexpungPDX/
+	git reset --hard
+	git checkout staging
+	git pull origin staging:staging
+
+.ONESHELL:
+deploy_staging_backend: deploy_staging_update_repo
+	cd ~/recordexpungPDX/src/backend/
+	kill $(ps -ef | grep -v grep | grep 127.0.0.1:3032 | awk '{print $2}')
+	$(shell tr '\n' ' ' < ~/recordexpungPDX/config/expungeservice/expungeservice.staging.env) nohup pipenv run uwsgi --socket 127.0.0.1:3032 --module expungeservice.wsgi &
+
+.ONESHELL:
+deploy_staging_frontend: deploy_staging_update_repo
+	cd ~/recordexpungPDX/src/frontend/
+	npm run build
+	cp -r build/* /var/www/dev.recordsponge.com/html/


### PR DESCRIPTION
addresses #936 

Note that the only thing I've changed here is the Makefile, whereas `staging` branch on recordexpungPDX is significantly behind `master`, so I merged those changes in.  I can branch off of staging instead if we don't want the latest changes from `master` as well. 

Open question that I have is that I'd like to try this out on just the staging branch first before running the production deployment (moving over from kent's home dir to the shared directory), so I haven't made any changes to the production deployment process yet.  I'd like to get a bit of feedback first.

The basic gist of this is that we now have a directory structure that looks like:

```
root@ubuntu-s-3vcpu-1gb-nyc3-01:/deployments# pwd
/deployments
root@ubuntu-s-3vcpu-1gb-nyc3-01:/deployments# ls -alh
total 16K
drwxr-xr-x  4 root root      4.0K Mar 12 02:48 .
drwxr-xr-x 24 root root      4.0K Mar 12 02:48 ..
drwxrwx---  3 root deployers 4.0K Mar 12 02:50 prod
drwxrwx---  3 root deployers 4.0K Mar 12 02:51 staging
```

Where the `prod` and `staging` directories contain a `recordexpungPDX` directory with source code. The group `deployers` contains:

```
root@ubuntu-s-3vcpu-1gb-nyc3-01:/deployments# cat /etc/group | grep deployers
deployers:x:1004:logan,jordan,kent,kenichi
```

Then we will run our deployments out of prod and staging directories.

-Logan 