### PR TITLE
Fix typo in marijuana eligible test

### DIFF
--- a/src/backend/tests/models/test_record_summarizer_by_charge_type.py
+++ b/src/backend/tests/models/test_record_summarizer_by_charge_type.py
@@ -24,31 +24,19 @@ from tests.factories.charge_factory import ChargeFactory
 from tests.factories.case_factory import CaseFactory
 from tests.models.test_charge import Dispositions
 
+
 def test_civil_offense_hidden_in_summary():
     charge = ChargeFactory.create(
         case=CaseFactory.create(type_status=["Civil Offense", "Closed"]),
         name="Defamation",
         statute="99",
         level="N/A",
-        disposition=Dispositions.CONVICTED
+        disposition=Dispositions.CONVICTED,
     )
 
     assert isinstance(charge, CivilOffense)
     assert charge.hidden_in_record_summary() == False
 
-'''
-def test_contempt_of_court_hidden_in_summary():
-    charge = ChargeFactory.create(
-        case=CaseFactory.create(type_status=["Contempt of Court", "Closed"]),
-        name="contempt of court",
-        statute="33",
-        level="N/A",
-        disposition=Dispositions.CONVICTED
-    )
-
-    assert isinstance(charge, ContemptOfCourt)
-    assert charge.hidden_in_record_summary() == False
-'''
 
 def test_duii_hidden_in_summary():
     charges = ChargeFactory.create_ambiguous_charge(
@@ -56,13 +44,14 @@ def test_duii_hidden_in_summary():
         name="Driving Under the Influence",
         statute="813.010",
         level="N/A",
-        disposition=Dispositions.DISMISSED
+        disposition=Dispositions.DISMISSED,
     )
 
     assert isinstance(charges[0], Duii)
     assert charges[0].hidden_in_record_summary() == False
     assert isinstance(charges[1], DivertedDuii)
     assert charges[1].hidden_in_record_summary() == False
+
 
 def test_felony_class_a_hidden_in_summary():
     charge = ChargeFactory.create(
@@ -71,11 +60,12 @@ def test_felony_class_a_hidden_in_summary():
         statute="163.185",
         level="Felony Class A",
         date=date_class(1901, 1, 1),
-        disposition=Dispositions.CONVICTED
+        disposition=Dispositions.CONVICTED,
     )
 
     assert isinstance(charge, FelonyClassA)
     assert charge.hidden_in_record_summary() == False
+
 
 def test_felony_class_b_hidden_in_summary():
     charge = ChargeFactory.create(
@@ -84,11 +74,12 @@ def test_felony_class_b_hidden_in_summary():
         statute="164.057",
         level="Felony Class B",
         date=date_class(1901, 1, 1),
-        disposition=Dispositions.CONVICTED
+        disposition=Dispositions.CONVICTED,
     )
 
     assert isinstance(charge, FelonyClassB)
     assert charge.hidden_in_record_summary() == False
+
 
 def test_felony_class_c_hidden_in_summary():
     charge = ChargeFactory.create(
@@ -97,7 +88,7 @@ def test_felony_class_c_hidden_in_summary():
         statute="164.055",
         level="Felony Class C",
         date=date_class(1901, 1, 1),
-        disposition=Dispositions.CONVICTED
+        disposition=Dispositions.CONVICTED,
     )
 
     assert isinstance(charge, FelonyClassC)
@@ -111,13 +102,14 @@ def test_juvenile_charge_hidden_in_summary():
         statute="N/A",
         level="N/A",
         date=date_class(1901, 1, 1),
-        disposition=Dispositions.CONVICTED
+        disposition=Dispositions.CONVICTED,
     )
 
     assert isinstance(charge, JuvenileCharge)
     assert charge.hidden_in_record_summary() == False
 
-def test_marijuana_ineligible_hidden_in_summary():
+
+def test_marijuana_eligible_hidden_in_summary():
     charge = ChargeFactory.create(
         name="Delivery of Marijuana to Minor",
         statute="4758604A",
@@ -127,6 +119,7 @@ def test_marijuana_ineligible_hidden_in_summary():
     assert isinstance(charge, MarijuanaEligible)
     assert charge.hidden_in_record_summary() == False
 
+
 def test_marijuana_ineligible_hidden_in_summary():
     charge = ChargeFactory.create(
         case=CaseFactory.create(type_status=["Offense Felony Class C", "Closed"]),
@@ -134,11 +127,12 @@ def test_marijuana_ineligible_hidden_in_summary():
         statute="475B.349(3)(C)",
         level="Felony Class C",
         date=date_class(1901, 1, 1),
-        disposition=Dispositions.CONVICTED
+        disposition=Dispositions.CONVICTED,
     )
 
     assert isinstance(charge, MarijuanaIneligible)
     assert charge.hidden_in_record_summary() == False
+
 
 def test_misdemeanor_hidden_in_summary():
     charge = ChargeFactory.create(
@@ -147,11 +141,12 @@ def test_misdemeanor_hidden_in_summary():
         statute="164.043",
         level="Misdemeanor Class C",
         date=date_class(1901, 1, 1),
-        disposition=Dispositions.CONVICTED
+        disposition=Dispositions.CONVICTED,
     )
 
     assert isinstance(charge, Misdemeanor)
     assert charge.hidden_in_record_summary() == False
+
 
 def test_parking_ticket_hidden_in_summary():
     charge = ChargeFactory.create(
@@ -160,11 +155,12 @@ def test_parking_ticket_hidden_in_summary():
         statute="109",
         level="Violation Unclassified",
         date=date_class(1901, 1, 1),
-        disposition=Dispositions.CONVICTED
+        disposition=Dispositions.CONVICTED,
     )
 
     assert isinstance(charge, ParkingTicket)
     assert charge.hidden_in_record_summary() == True
+
 
 def test_person_felony_hidden_in_summary():
     charge = ChargeFactory.create(
@@ -173,7 +169,7 @@ def test_person_felony_hidden_in_summary():
         statute="97981",
         level="Felony Class B",
         date=date_class(1901, 1, 1),
-        disposition=Dispositions.CONVICTED
+        disposition=Dispositions.CONVICTED,
     )
 
     assert isinstance(charge, PersonFelonyClassB)
@@ -187,11 +183,12 @@ def test_sex_crimes_hidden_in_summary():
         statute="163365",
         level="Misdemeanor Class A",
         date=date_class(1901, 1, 1),
-        disposition=Dispositions.CONVICTED
+        disposition=Dispositions.CONVICTED,
     )
 
     assert isinstance(charge, SexCrime)
     assert charge.hidden_in_record_summary() == False
+
 
 def test_subsection_6_hidden_in_summary():
     charges = ChargeFactory.create_ambiguous_charge(
@@ -200,13 +197,14 @@ def test_subsection_6_hidden_in_summary():
         statute="163.200",
         level="Misdemeanor Class A",
         date=date_class(1901, 1, 1),
-        disposition=Dispositions.CONVICTED
+        disposition=Dispositions.CONVICTED,
     )
 
     assert isinstance(charges[0], Subsection6)
     assert charges[0].hidden_in_record_summary() == False
     assert isinstance(charges[1], Misdemeanor)
     assert charges[1].hidden_in_record_summary() == False
+
 
 def test_traffic_non_violation_hidden_in_summary():
     charge = ChargeFactory.create(
@@ -215,11 +213,12 @@ def test_traffic_non_violation_hidden_in_summary():
         statute="802",
         level="felony violation",
         date=date_class(1901, 1, 1),
-        disposition=Dispositions.CONVICTED
+        disposition=Dispositions.CONVICTED,
     )
 
     assert isinstance(charge, TrafficNonViolation)
     assert charge.hidden_in_record_summary() == False
+
 
 def test_traffic_violation_hidden_in_summary():
     charge = ChargeFactory.create(
@@ -228,11 +227,12 @@ def test_traffic_violation_hidden_in_summary():
         statute="801",
         level="Violation",
         date=date_class(1901, 1, 1),
-        disposition=Dispositions.CONVICTED
+        disposition=Dispositions.CONVICTED,
     )
 
     assert isinstance(charge, TrafficViolation)
     assert charge.hidden_in_record_summary() == True
+
 
 def test_unclassified_charge_hidden_in_summary():
     charge = ChargeFactory.create(
@@ -241,11 +241,12 @@ def test_unclassified_charge_hidden_in_summary():
         statute="333.333",
         level="Felony Class F",
         date=date_class(1901, 1, 1),
-        disposition=Dispositions.CONVICTED
+        disposition=Dispositions.CONVICTED,
     )
 
     assert isinstance(charge, UnclassifiedCharge)
     assert charge.hidden_in_record_summary() == False
+
 
 def test_violation_hidden_in_summary():
     charge = ChargeFactory.create(
@@ -254,7 +255,7 @@ def test_violation_hidden_in_summary():
         statute="333.333",
         level="Felony Class F",
         date=date_class(1901, 1, 1),
-        disposition=Dispositions.DISMISSED
+        disposition=Dispositions.DISMISSED,
     )
 
     assert isinstance(charge, UnclassifiedCharge)


### PR DESCRIPTION
Remove comment out test

Otherwise we get

```
$ make dev_test
docker exec -t d0230fdfad88 mypy
tests/models/test_record_summarizer_by_charge_type.py:130: error: Name 'test_marijuana_ineligible_hidden_in_summary' already defined on line 120
Found 1 error in 1 file (checked 126 source files)
make: *** [dev_test] Error 1
```