### PR TITLE
Add charge type for dismissed criminal charges

### DIFF
--- a/src/backend/expungeservice/models/charge_types/dismissed_charge.py
+++ b/src/backend/expungeservice/models/charge_types/dismissed_charge.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+from expungeservice.models.charge import Charge
+from expungeservice.models.expungement_result import TypeEligibility, EligibilityStatus
+
+
+@dataclass
+class DismissedCharge(Charge):
+    type_name: str = "Dismissed Criminal Charge"
+    expungement_rules: str = ("""""")
+
+    def _type_eligibility(self):
+        return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Dismissals are eligible under 137.225(1)(b)",)

--- a/src/backend/expungeservice/models/charge_types/dismissed_charge.py
+++ b/src/backend/expungeservice/models/charge_types/dismissed_charge.py
@@ -7,7 +7,7 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 @dataclass
 class DismissedCharge(Charge):
     type_name: str = "Dismissed Criminal Charge"
-    expungement_rules: str = ("""""")
+    expungement_rules: str = ("""All non-duii criminal charges that are dismissed fall under this charge type.""")
 
     def _type_eligibility(self):
         return TypeEligibility(

--- a/src/backend/expungeservice/models/charge_types/dismissed_charge.py
+++ b/src/backend/expungeservice/models/charge_types/dismissed_charge.py
@@ -10,4 +10,6 @@ class DismissedCharge(Charge):
     expungement_rules: str = ("""""")
 
     def _type_eligibility(self):
-        return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Dismissals are eligible under 137.225(1)(b)",)
+        return TypeEligibility(
+            EligibilityStatus.ELIGIBLE, reason="Dismissals are generally eligible under 137.225(1)(b)",
+        )

--- a/src/backend/expungeservice/models/charge_types/duii.py
+++ b/src/backend/expungeservice/models/charge_types/duii.py
@@ -34,11 +34,4 @@ class DivertedDuii(Charge):
         reflect this and in others it will say Dismissed.  We need to handle
         both possibilities.
         """
-        if self.dismissed():
-            return TypeEligibility(
-                EligibilityStatus.INELIGIBLE, reason="137.225(8)(b) - Diverted DUIIs are ineligible",
-            )
-        elif self.convicted():
-            return TypeEligibility(
-                EligibilityStatus.INELIGIBLE, reason="137.225(7)(a) - Traffic offenses are ineligible"
-            )
+        return TypeEligibility(EligibilityStatus.INELIGIBLE, reason="137.225(8)(b) - Diverted DUIIs are ineligible",)

--- a/src/backend/expungeservice/models/charge_types/duii.py
+++ b/src/backend/expungeservice/models/charge_types/duii.py
@@ -17,7 +17,7 @@ Therefore, to determine whether a dismissal is eligible, ask the client whether 
 
     def _type_eligibility(self):
         if self.dismissed():
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Dismissals are eligible under 137.225(1)(b)",)
+            raise ValueError("Dismissed criminal charges should have been caught by another class.")
         elif self.convicted():
             return TypeEligibility(
                 EligibilityStatus.INELIGIBLE, reason="137.225(7)(a) - Traffic offenses are ineligible"

--- a/src/backend/expungeservice/models/charge_types/felony_class_a.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_a.py
@@ -15,6 +15,6 @@ Class A felony dismissals are always eligible under 137.225(5)(a).
 
     def _type_eligibility(self):
         if self.dismissed():
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Dismissals are eligible under 137.225(1)(b)")
+            raise ValueError("Dismissed criminal charges should have been caught by another class.")
         elif self.convicted():
             return TypeEligibility(EligibilityStatus.INELIGIBLE, reason="Ineligible by omission from statute")

--- a/src/backend/expungeservice/models/charge_types/felony_class_b.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_b.py
@@ -21,7 +21,7 @@ If a class B felony is eligible under any other subsection of the statute, that 
 
     def _type_eligibility(self):
         if self.dismissed():
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Dismissals are eligible under 137.225(1)(b)")
+            raise ValueError("Dismissed criminal charges should have been caught by another class.")
         elif self.convicted():
             return TypeEligibility(
                 EligibilityStatus.ELIGIBLE,

--- a/src/backend/expungeservice/models/charge_types/felony_class_c.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_c.py
@@ -17,7 +17,7 @@ Class C felony dismissals are always eligible under 137.225(1)(b)."""
 
     def _type_eligibility(self):
         if self.dismissed():
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Dismissals are eligible under 137.225(1)(b)")
+            raise ValueError("Dismissed criminal charges should have been caught by another class.")
         elif self.convicted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.225(5)(b)")
         elif not self.disposition or self.disposition.status == DispositionStatus.UNRECOGNIZED:

--- a/src/backend/expungeservice/models/charge_types/marijuana_eligible.py
+++ b/src/backend/expungeservice/models/charge_types/marijuana_eligible.py
@@ -11,9 +11,10 @@ class MarijuanaEligible(Charge):
     expungement_rules: str = """ORS 137.226 makes eligible additional marijuana-related charges - in particular, those crimes which are now considered minor felonies or below.
     One way to identify a marijuana crime is if it has the statute section 475860.
     Also if "marijuana", "marij", or "mj" are in the charge name, we conclude it's a marijuana eligible charge (after filtering out MarijuanaIneligible charges by statute)."""
+
     def _type_eligibility(self):
         if self.dismissed():
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Dismissals are eligible under 137.225(1)(b)")
+            raise ValueError("Dismissed criminal charges should have been caught by another class.")
         elif self.convicted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.226")
         elif not self.disposition or self.disposition.status == DispositionStatus.UNRECOGNIZED:

--- a/src/backend/expungeservice/models/charge_types/marijuana_ineligible.py
+++ b/src/backend/expungeservice/models/charge_types/marijuana_ineligible.py
@@ -16,6 +16,6 @@ class MarijuanaIneligible(Charge):
 
     def _type_eligibility(self):
         if self.dismissed():
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Dismissals are eligible under 137.225(1)(b)")
+            raise ValueError("Dismissed criminal charges should have been caught by another class.")
         elif self.convicted():
             return TypeEligibility(EligibilityStatus.INELIGIBLE, reason="Ineligible under 137.226")

--- a/src/backend/expungeservice/models/charge_types/misdemeanor.py
+++ b/src/backend/expungeservice/models/charge_types/misdemeanor.py
@@ -14,7 +14,7 @@ Dismissals for misdemeanors are generally eligible under ORS 137.225(1)(b). Exce
 
     def _type_eligibility(self):
         if self.dismissed():
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Dismissals are eligible under 137.225(1)(b)")
+            raise ValueError("Dismissed criminal charges should have been caught by another class.")
         elif self.convicted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.225(5)(b)")
         else:

--- a/src/backend/expungeservice/models/charge_types/person_felony.py
+++ b/src/backend/expungeservice/models/charge_types/person_felony.py
@@ -130,6 +130,6 @@ A person felony that is below a class B felony is not considered under this subs
 
     def _type_eligibility(self):
         if self.dismissed():
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Dismissals are eligible under 137.225(1)(b)")
+            raise ValueError("Dismissed criminal charges should have been caught by another class.")
         elif self.convicted():
             return TypeEligibility(EligibilityStatus.INELIGIBLE, reason="Ineligible under 137.225(5)(a)")

--- a/src/backend/expungeservice/models/charge_types/sex_crimes.py
+++ b/src/backend/expungeservice/models/charge_types/sex_crimes.py
@@ -54,7 +54,7 @@ class SexCrime(Charge):
 
     def _type_eligibility(self):
         if self.dismissed():
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Dismissals are eligible under 137.225(1)(b)")
+            raise ValueError("Dismissed criminal charges should have been caught by another class.")
         elif self.convicted():
             return TypeEligibility(EligibilityStatus.INELIGIBLE, reason="Ineligible under 137.225(6)(a)")
 
@@ -63,7 +63,7 @@ class SexCrime(Charge):
 class RomeoAndJulietIneligibleSexCrime(Charge):
     def _type_eligibility(self):
         if self.dismissed():
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Dismissals are eligible under 137.225(1)(b)")
+            raise ValueError("Dismissed criminal charges should have been caught by another class.")
         elif self.convicted():
             return TypeEligibility(
                 EligibilityStatus.INELIGIBLE, reason="Failure to meet requirements under 163A.140(1)"

--- a/src/backend/expungeservice/models/charge_types/sex_crimes.py
+++ b/src/backend/expungeservice/models/charge_types/sex_crimes.py
@@ -61,6 +61,9 @@ class SexCrime(Charge):
 
 @dataclass
 class RomeoAndJulietIneligibleSexCrime(Charge):
+    type_name: str = "Romeo And Juliet Ineligible Sex Crime"
+    expungement_rules: str = ("""TODO""")
+
     def _type_eligibility(self):
         if self.dismissed():
             raise ValueError("Dismissed criminal charges should have been caught by another class.")

--- a/src/backend/expungeservice/models/charge_types/subsection_6.py
+++ b/src/backend/expungeservice/models/charge_types/subsection_6.py
@@ -16,8 +16,7 @@ The three remaining specifications in the statute are:
  * 163.200 (Criminal mistreatment II) is ineligible if the victim at the time of the crime was 65 years of age or older; otherwise eligible as a (Class A) [Misdemeanor](#Misdemeanor).
  * 163.205 (Criminal mistreatment I) is ineligible if the victim at the time of the crime was 65 years of age or older or a minor; otherwise eligible as a [Class C Felony](#FelonyClassC).
  * 163.575 (Endangering the welfare of a minor) (1)(a) is ineligible when the offense constitutes child abuse as defined in ORS 419B.005 (Definitions); otherwise eligible as a (Class A) [Misdemeanor](#Misdemeanor).
- * 163.145 (Criminally negligent homicide) is ineligible when that offense was punishable as a Class C felony.
-Dismissals are eligible under 137.225(1)(b)."""
+ * 163.145 (Criminally negligent homicide) is ineligible when that offense was punishable as a Class C felony."""
     )
 
     def _type_eligibility(self):

--- a/src/backend/expungeservice/models/charge_types/subsection_6.py
+++ b/src/backend/expungeservice/models/charge_types/subsection_6.py
@@ -22,6 +22,6 @@ Dismissals are eligible under 137.225(1)(b)."""
 
     def _type_eligibility(self):
         if self.dismissed():
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Dismissals are eligible under 137.225(1)(b)")
+            raise ValueError("Dismissed criminal charges should have been caught by another class.")
         elif self.convicted():
             return TypeEligibility(EligibilityStatus.INELIGIBLE, reason="Ineligible under 137.225(6)",)

--- a/src/backend/expungeservice/models/charge_types/traffic_non_violation.py
+++ b/src/backend/expungeservice/models/charge_types/traffic_non_violation.py
@@ -10,6 +10,6 @@ class TrafficNonViolation(Charge):
 
     def _type_eligibility(self):
         if self.dismissed():
-            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Dismissals are eligible under 137.225(1)(b)")
+            raise ValueError("Dismissed criminal charges should have been caught by another class.")
         elif self.convicted():
             return TypeEligibility(EligibilityStatus.INELIGIBLE, reason="Ineligible under 137.225(7)(a)")

--- a/src/backend/expungeservice/models/helpers/charge_creator.py
+++ b/src/backend/expungeservice/models/helpers/charge_creator.py
@@ -19,7 +19,10 @@ class ChargeCreator:
         level = kwargs["level"]
         chapter = ChargeCreator._set_chapter(kwargs["statute"])
         section = ChargeCreator.__set_section(statute)
-        classifications = ChargeClassifier(violation_type, name, statute, level, chapter, section).classify()
+        disposition = kwargs.get("disposition")
+        classifications = ChargeClassifier(
+            violation_type, name, statute, level, chapter, section, disposition
+        ).classify()
         kwargs["date"] = datetime.date(datetime.strptime(kwargs["date"], "%m/%d/%Y"))
         kwargs["_chapter"] = chapter
         kwargs["_section"] = section

--- a/src/backend/tests/models/charge_types/test_felony_class_a.py
+++ b/src/backend/tests/models/charge_types/test_felony_class_a.py
@@ -29,7 +29,7 @@ def test_felony_class_a_dismissed():
 
     assert isinstance(felony_class_a_dismissed, DismissedCharge)
     assert felony_class_a_dismissed.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert felony_class_a_dismissed.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
+    assert felony_class_a_dismissed.type_eligibility.reason == "Dismissals are generally eligible under 137.225(1)(b)"
 
 
 def test_felony_class_a_no_complaint():
@@ -42,4 +42,6 @@ def test_felony_class_a_no_complaint():
 
     assert isinstance(felony_class_a_no_complaint, DismissedCharge)
     assert felony_class_a_no_complaint.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert felony_class_a_no_complaint.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
+    assert (
+        felony_class_a_no_complaint.type_eligibility.reason == "Dismissals are generally eligible under 137.225(1)(b)"
+    )

--- a/src/backend/tests/models/charge_types/test_felony_class_a.py
+++ b/src/backend/tests/models/charge_types/test_felony_class_a.py
@@ -1,3 +1,4 @@
+from expungeservice.models.charge_types.dismissed_charge import DismissedCharge
 from expungeservice.models.charge_types.felony_class_a import FelonyClassA
 from expungeservice.models.expungement_result import EligibilityStatus
 
@@ -26,7 +27,7 @@ def test_felony_class_a_dismissed():
         disposition=Dispositions.DISMISSED,
     )
 
-    assert isinstance(felony_class_a_dismissed, FelonyClassA)
+    assert isinstance(felony_class_a_dismissed, DismissedCharge)
     assert felony_class_a_dismissed.type_eligibility.status is EligibilityStatus.ELIGIBLE
     assert felony_class_a_dismissed.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
 
@@ -39,6 +40,6 @@ def test_felony_class_a_no_complaint():
         disposition=Dispositions.NO_COMPLAINT,
     )
 
-    assert isinstance(felony_class_a_no_complaint, FelonyClassA)
+    assert isinstance(felony_class_a_no_complaint, DismissedCharge)
     assert felony_class_a_no_complaint.type_eligibility.status is EligibilityStatus.ELIGIBLE
     assert felony_class_a_no_complaint.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"

--- a/src/backend/tests/models/charge_types/test_felony_class_c.py
+++ b/src/backend/tests/models/charge_types/test_felony_class_c.py
@@ -23,7 +23,7 @@ def test_felony_c_dismissal():
 
     assert isinstance(charge, DismissedCharge)
     assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert charge.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
+    assert charge.type_eligibility.reason == "Dismissals are generally eligible under 137.225(1)(b)"
 
 
 def test_felony_c_no_disposition():

--- a/src/backend/tests/models/charge_types/test_felony_class_c.py
+++ b/src/backend/tests/models/charge_types/test_felony_class_c.py
@@ -1,3 +1,4 @@
+from expungeservice.models.charge_types.dismissed_charge import DismissedCharge
 from expungeservice.models.charge_types.felony_class_c import FelonyClassC
 from expungeservice.models.expungement_result import EligibilityStatus
 
@@ -20,7 +21,7 @@ def test_felony_c_dismissal():
         name="Theft in the first degree", statute="164.055", level="Felony Class C", disposition=Dispositions.DISMISSED
     )
 
-    assert isinstance(charge, FelonyClassC)
+    assert isinstance(charge, DismissedCharge)
     assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
     assert charge.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
 

--- a/src/backend/tests/models/charge_types/test_manufacture_delivery.py
+++ b/src/backend/tests/models/charge_types/test_manufacture_delivery.py
@@ -11,7 +11,7 @@ def test_manufacture_delivery_dismissed():
     type_eligibility = RecordMerger.merge_type_eligibilities(charges)
 
     assert type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
+    assert type_eligibility.reason == "Dismissals are generally eligible under 137.225(1)(b)"
 
 
 def test_manufacture_delivery_missing_disposition():

--- a/src/backend/tests/models/charge_types/test_marijuana_eligible.py
+++ b/src/backend/tests/models/charge_types/test_marijuana_eligible.py
@@ -1,8 +1,8 @@
+from expungeservice.models.charge_types.dismissed_charge import DismissedCharge
 from expungeservice.models.expungement_result import EligibilityStatus
 from expungeservice.models.charge_types.marijuana_eligible import MarijuanaEligible
 from tests.factories.charge_factory import ChargeFactory
 from tests.models.test_charge import Dispositions
-import pytest
 
 
 def test_delivery_to_minor_4758604A():
@@ -12,7 +12,7 @@ def test_delivery_to_minor_4758604A():
         level="Felony Class A",
         disposition=Dispositions.DISMISSED,
     )
-    assert isinstance(marijuana_eligible_charge, MarijuanaEligible)
+    assert isinstance(marijuana_eligible_charge, DismissedCharge)
     assert marijuana_eligible_charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
     assert marijuana_eligible_charge.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
 

--- a/src/backend/tests/models/charge_types/test_marijuana_eligible.py
+++ b/src/backend/tests/models/charge_types/test_marijuana_eligible.py
@@ -14,7 +14,7 @@ def test_delivery_to_minor_4758604A():
     )
     assert isinstance(marijuana_eligible_charge, DismissedCharge)
     assert marijuana_eligible_charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert marijuana_eligible_charge.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
+    assert marijuana_eligible_charge.type_eligibility.reason == "Dismissals are generally eligible under 137.225(1)(b)"
 
 
 def test_marijuana_eligible_convicted():

--- a/src/backend/tests/models/charge_types/test_subsection_6.py
+++ b/src/backend/tests/models/charge_types/test_subsection_6.py
@@ -1,3 +1,4 @@
+from expungeservice.models.charge_types.dismissed_charge import DismissedCharge
 from expungeservice.models.charge_types.felony_class_b import FelonyClassB
 from expungeservice.models.charge_types.felony_class_c import FelonyClassC
 from expungeservice.models.charge_types.misdemeanor import Misdemeanor
@@ -18,8 +19,7 @@ def test_subsection_6_dismissed():
     )
     type_eligibility = RecordMerger.merge_type_eligibilities(charges)
 
-    assert isinstance(charges[0], Subsection6)
-    assert isinstance(charges[1], Misdemeanor)
+    assert isinstance(charges[0], DismissedCharge)
     assert type_eligibility.status is EligibilityStatus.ELIGIBLE
     assert type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
 

--- a/src/backend/tests/models/charge_types/test_subsection_6.py
+++ b/src/backend/tests/models/charge_types/test_subsection_6.py
@@ -21,7 +21,7 @@ def test_subsection_6_dismissed():
 
     assert isinstance(charges[0], DismissedCharge)
     assert type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
+    assert type_eligibility.reason == "Dismissals are generally eligible under 137.225(1)(b)"
 
 
 def test_subsection_6_163165():

--- a/src/backend/tests/models/charge_types/test_traffic_offenses.py
+++ b/src/backend/tests/models/charge_types/test_traffic_offenses.py
@@ -8,7 +8,7 @@ Rules for 800 Level charges are as follows:
 800 level misdemeanor and felony arrests block like other arrests
 800 level convictions of any kind are not type eligible
 """
-
+from expungeservice.models.charge_types.dismissed_charge import DismissedCharge
 from expungeservice.models.expungement_result import EligibilityStatus
 from expungeservice.models.charge_types.traffic_violation import TrafficViolation
 from expungeservice.models.charge_types.duii import Duii, DivertedDuii
@@ -133,7 +133,7 @@ def test_felony_dismissal_is_eligible():
 
 
 def test_duii():
-    charges = ChargeFactory.create_ambiguous_charge(statute="813.010")
+    charges = ChargeFactory.create_ambiguous_charge(statute="813.010", disposition=Dispositions.DISMISSED)
 
-    assert isinstance(charges[0], Duii)
+    assert isinstance(charges[0], DismissedCharge)
     assert isinstance(charges[1], DivertedDuii)

--- a/src/backend/tests/models/charge_types/test_traffic_offenses.py
+++ b/src/backend/tests/models/charge_types/test_traffic_offenses.py
@@ -112,7 +112,7 @@ def test_misdemeanor_dismissal_is_eligible():
     charge = ChargeFactory.create(statute="814.010(4)", level="Misdemeanor Class A", disposition=Dispositions.DISMISSED)
 
     assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert charge.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
+    assert charge.type_eligibility.reason == "Dismissals are generally eligible under 137.225(1)(b)"
     assert charge.blocks_other_charges()
 
 
@@ -128,7 +128,7 @@ def test_felony_dismissal_is_eligible():
     charge = ChargeFactory.create(statute="819.300", level="Felony Class C", disposition=Dispositions.DISMISSED)
 
     assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert charge.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
+    assert charge.type_eligibility.reason == "Dismissals are generally eligible under 137.225(1)(b)"
     assert charge.blocks_other_charges()
 
 

--- a/src/backend/tests/models/charge_types/test_type_analyzer_duii.py
+++ b/src/backend/tests/models/charge_types/test_type_analyzer_duii.py
@@ -21,7 +21,7 @@ def test_duii_dismissed():
     assert duii_type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert (
         duii_type_eligibility.reason
-        == "Dismissals are eligible under 137.225(1)(b) ⬥ 137.225(8)(b) - Diverted DUIIs are ineligible"
+        == "Dismissals are generally eligible under 137.225(1)(b) ⬥ 137.225(8)(b) - Diverted DUIIs are ineligible"
     )
 
 
@@ -32,7 +32,7 @@ def test_duii_diverted():
     assert duii_type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert (
         duii_type_eligibility.reason
-        == "Dismissals are eligible under 137.225(1)(b) ⬥ 137.225(8)(b) - Diverted DUIIs are ineligible"
+        == "Dismissals are generally eligible under 137.225(1)(b) ⬥ 137.225(8)(b) - Diverted DUIIs are ineligible"
     )
 
 

--- a/src/backend/tests/models/charge_types/test_unclassified.py
+++ b/src/backend/tests/models/charge_types/test_unclassified.py
@@ -1,3 +1,4 @@
+from expungeservice.models.charge_types.dismissed_charge import DismissedCharge
 from expungeservice.models.charge_types.unclassified_charge import UnclassifiedCharge
 from expungeservice.models.expungement_result import EligibilityStatus
 from tests.factories.charge_factory import ChargeFactory
@@ -12,9 +13,9 @@ def test_unclassified_charge():
         disposition=Dispositions.DISMISSED,
     )
 
-    assert isinstance(unclassified_dismissed, UnclassifiedCharge)
-    assert unclassified_dismissed.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert unclassified_dismissed.type_eligibility.reason == "Unrecognized Charge : Further Analysis Needed"
+    assert isinstance(unclassified_dismissed, DismissedCharge)
+    assert unclassified_dismissed.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert unclassified_dismissed.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
 
 
 def test_charge_that_falls_through():
@@ -25,9 +26,9 @@ def test_charge_that_falls_through():
         disposition=Dispositions.DISMISSED,
     )
 
-    assert isinstance(charge, UnclassifiedCharge)
-    assert charge.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert charge.type_eligibility.reason == "Unrecognized Charge : Further Analysis Needed"
+    assert isinstance(charge, DismissedCharge)
+    assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert charge.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
 
 
 def test_unrecognized_disposition():

--- a/src/backend/tests/models/charge_types/test_unclassified.py
+++ b/src/backend/tests/models/charge_types/test_unclassified.py
@@ -13,9 +13,9 @@ def test_unclassified_charge():
         disposition=Dispositions.DISMISSED,
     )
 
-    assert isinstance(unclassified_dismissed, DismissedCharge)
-    assert unclassified_dismissed.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert unclassified_dismissed.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
+    assert isinstance(unclassified_dismissed, UnclassifiedCharge)
+    assert unclassified_dismissed.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert unclassified_dismissed.type_eligibility.reason == "Unrecognized Charge : Further Analysis Needed"
 
 
 def test_charge_that_falls_through():
@@ -26,9 +26,9 @@ def test_charge_that_falls_through():
         disposition=Dispositions.DISMISSED,
     )
 
-    assert isinstance(charge, DismissedCharge)
-    assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert charge.type_eligibility.reason == "Dismissals are eligible under 137.225(1)(b)"
+    assert isinstance(charge, UnclassifiedCharge)
+    assert charge.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert charge.type_eligibility.reason == "Unrecognized Charge : Further Analysis Needed"
 
 
 def test_unrecognized_disposition():

--- a/src/backend/tests/models/test_record_summarizer_by_charge_type.py
+++ b/src/backend/tests/models/test_record_summarizer_by_charge_type.py
@@ -288,5 +288,5 @@ def test_violation_hidden_in_summary():
         violation_type=case.violation_type,
     )
 
-    assert isinstance(charge, DismissedCharge)
+    assert isinstance(charge, UnclassifiedCharge)
     assert charge.hidden_in_record_summary() == False

--- a/src/backend/tests/models/test_record_summarizer_by_charge_type.py
+++ b/src/backend/tests/models/test_record_summarizer_by_charge_type.py
@@ -1,6 +1,7 @@
 from datetime import date as date_class
 from expungeservice.models.charge_types.civil_offense import CivilOffense
 from expungeservice.models.charge_types.contempt_of_court import ContemptOfCourt
+from expungeservice.models.charge_types.dismissed_charge import DismissedCharge
 from expungeservice.models.charge_types.duii import Duii, DivertedDuii
 from expungeservice.models.charge_types.felony_class_a import FelonyClassA
 from expungeservice.models.charge_types.felony_class_b import FelonyClassB
@@ -48,7 +49,7 @@ def test_duii_hidden_in_summary():
         violation_type=case.violation_type,
     )
 
-    assert isinstance(charges[0], Duii)
+    assert isinstance(charges[0], DismissedCharge)
     assert charges[0].hidden_in_record_summary() == False
     assert isinstance(charges[1], DivertedDuii)
     assert charges[1].hidden_in_record_summary() == False
@@ -125,7 +126,7 @@ def test_marijuana_eligible_hidden_in_summary():
         level="Felony Class A",
         disposition=Dispositions.DISMISSED,
     )
-    assert isinstance(charge, MarijuanaEligible)
+    assert isinstance(charge, DismissedCharge)
     assert charge.hidden_in_record_summary() == False
 
 
@@ -287,5 +288,5 @@ def test_violation_hidden_in_summary():
         violation_type=case.violation_type,
     )
 
-    assert isinstance(charge, UnclassifiedCharge)
+    assert isinstance(charge, DismissedCharge)
     assert charge.hidden_in_record_summary() == False


### PR DESCRIPTION
We do not want to have to ask users questions for manu/del and subsection 6 if the charge is dismissed as they are type eligible. This will also boost performance as we will not have as many ambiguous records.

~~We assume that for unclassified charges that are dismissed we can just say they are eligible but this may be a dangerous assumption.~~

We remove ambiguity when Duii is a non-dismissal as they are known to be ineligible (or unknown).