### PR TITLE
Differentiate between charge id and ambiguous charge id

### DIFF
--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -21,7 +21,7 @@ class Expunger:
         """
         Evaluates the expungement eligibility of a record.
         """
-        charge_id_to_time_eligibility = {}
+        ambiguous_charge_id_to_time_eligibility = {}
         cases = self.record.cases
         for charge in self.analyzable_charges:
             eligibility_dates: List[Tuple[date, str]] = []
@@ -103,7 +103,7 @@ class Expunger:
                 time_eligibility = TimeEligibility(
                     status=EligibilityStatus.INELIGIBLE, reason=reason, date_will_be_eligible=date_will_be_eligible
                 )
-            charge_id_to_time_eligibility[charge.id] = time_eligibility
+            ambiguous_charge_id_to_time_eligibility[charge.ambiguous_charge_id] = time_eligibility
         for case in cases:
             non_violation_convictions_in_case = []
             violations_in_case = []
@@ -128,16 +128,18 @@ class Expunger:
                     if (
                         charge.type_eligibility.status != EligibilityStatus.INELIGIBLE
                         and charge.dismissed()
-                        and charge_id_to_time_eligibility[charge.id].date_will_be_eligible
-                        > charge_id_to_time_eligibility[attractor.id].date_will_be_eligible
+                        and ambiguous_charge_id_to_time_eligibility[charge.ambiguous_charge_id].date_will_be_eligible
+                        > ambiguous_charge_id_to_time_eligibility[attractor.ambiguous_charge_id].date_will_be_eligible
                     ):
                         time_eligibility = TimeEligibility(
-                            status=charge_id_to_time_eligibility[attractor.id].status,
+                            status=ambiguous_charge_id_to_time_eligibility[attractor.ambiguous_charge_id].status,
                             reason='Time eligibility of the arrest matches conviction on the same case (the "friendly" rule)',
-                            date_will_be_eligible=charge_id_to_time_eligibility[attractor.id].date_will_be_eligible,
+                            date_will_be_eligible=ambiguous_charge_id_to_time_eligibility[
+                                attractor.ambiguous_charge_id
+                            ].date_will_be_eligible,
                         )
-                        charge_id_to_time_eligibility[charge.id] = time_eligibility
-        return charge_id_to_time_eligibility
+                        ambiguous_charge_id_to_time_eligibility[charge.ambiguous_charge_id] = time_eligibility
+        return ambiguous_charge_id_to_time_eligibility
 
     @staticmethod
     def _categorize_charges(charges):

--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -16,6 +16,7 @@ from expungeservice.models.expungement_result import (
 @dataclass
 class Charge:
     id: str
+    ambiguous_charge_id: str
     name: str
     statute: str
     level: str

--- a/src/backend/expungeservice/models/helpers/charge_creator.py
+++ b/src/backend/expungeservice/models/helpers/charge_creator.py
@@ -1,8 +1,5 @@
 import re
-import weakref
 from datetime import datetime
-from typing import List
-
 from dacite import from_dict
 
 from expungeservice.models.ambiguous import AmbiguousCharge
@@ -27,8 +24,14 @@ class ChargeCreator:
         kwargs["_chapter"] = chapter
         kwargs["_section"] = section
         kwargs["statute"] = statute
-        kwargs["id"] = f"{case_number}-{charge_id}"
-        return [from_dict(data_class=classification, data=kwargs) for classification in classifications]
+        kwargs["ambiguous_charge_id"] = f"{case_number}-{charge_id}"
+        ambiguous_charge = []
+        for i, classification in enumerate(classifications):
+            uid = f"{case_number}-{charge_id}-{i}"
+            charge_dict = {**kwargs, "id": uid}
+            charge = from_dict(data_class=classification, data=charge_dict)
+            ambiguous_charge.append(charge)
+        return ambiguous_charge
 
     @staticmethod
     def __strip_non_alphanumeric_chars(statute):

--- a/src/backend/expungeservice/models/helpers/record_merger.py
+++ b/src/backend/expungeservice/models/helpers/record_merger.py
@@ -21,21 +21,22 @@ import collections
 class RecordMerger:
     @staticmethod
     def merge(
-        ambiguous_record: AmbiguousRecord, charge_id_to_time_eligibility_list: List[Dict[str, TimeEligibility]]
+        ambiguous_record: AmbiguousRecord,
+        ambiguous_charge_id_to_time_eligibility_list: List[Dict[str, TimeEligibility]],
     ) -> Record:
-        charge_id_to_time_eligibilities: Dict[str, List[TimeEligibility]] = collections.defaultdict(list)
-        for charge_id_to_time_eligibility in charge_id_to_time_eligibility_list:
+        ambiguous_charge_id_to_time_eligibilities: Dict[str, List[TimeEligibility]] = collections.defaultdict(list)
+        for charge_id_to_time_eligibility in ambiguous_charge_id_to_time_eligibility_list:
             for k, v in charge_id_to_time_eligibility.items():
-                if v not in charge_id_to_time_eligibilities[k]:
-                    charge_id_to_time_eligibilities[k].append(v)
+                if v not in ambiguous_charge_id_to_time_eligibilities[k]:
+                    ambiguous_charge_id_to_time_eligibilities[k].append(v)
         charges = list(flatten([record.charges for record in ambiguous_record]))
         record = ambiguous_record[0]
         new_case_list = []
         for case in record.cases:
             new_charges = []
             for charge in case.charges:
-                time_eligibilities = charge_id_to_time_eligibilities.get(charge.id)
-                same_charges = list(filter(lambda c: c.id == charge.id, charges))
+                time_eligibilities = ambiguous_charge_id_to_time_eligibilities.get(charge.ambiguous_charge_id)
+                same_charges = list(filter(lambda c: c.ambiguous_charge_id == charge.ambiguous_charge_id, charges))
                 merged_type_eligibility = RecordMerger.merge_type_eligibilities(same_charges)
                 merged_time_eligibility = RecordMerger.merge_time_eligibilities(time_eligibilities)
                 charge_eligibility = RecordMerger.compute_charge_eligibility(

--- a/src/backend/tests/test_crawler_expunger.py
+++ b/src/backend/tests/test_crawler_expunger.py
@@ -168,17 +168,17 @@ def test_expunger_runs_time_analyzer(record_with_specific_dates):
     expunger_result = expunger.run()
     assert len(expunger_result) == 9
 
-    assert expunger_result[record.cases[0].charges[0].id].status is EligibilityStatus.INELIGIBLE
-    assert expunger_result[record.cases[0].charges[1].id].status is EligibilityStatus.INELIGIBLE
-    assert expunger_result[record.cases[0].charges[2].id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[record.cases[0].charges[0].ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[record.cases[0].charges[1].ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[record.cases[0].charges[2].ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
 
-    assert expunger_result[record.cases[1].charges[0].id].status is EligibilityStatus.INELIGIBLE
-    assert expunger_result[record.cases[1].charges[1].id].status is EligibilityStatus.INELIGIBLE
-    assert expunger_result[record.cases[1].charges[2].id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[record.cases[1].charges[0].ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[record.cases[1].charges[1].ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[record.cases[1].charges[2].ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
 
-    assert expunger_result[record.cases[2].charges[0].id].status is EligibilityStatus.INELIGIBLE
-    assert expunger_result[record.cases[2].charges[1].id].status is EligibilityStatus.INELIGIBLE
-    assert expunger_result[record.cases[2].charges[2].id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[record.cases[2].charges[0].ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[record.cases[2].charges[1].ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[record.cases[2].charges[2].ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
 
 
 @pytest.fixture
@@ -197,4 +197,6 @@ def test_probation_revoked_affects_time_eligibility(record_with_revoked_probatio
     expunger = Expunger(record)
     expunger_result = expunger.run()
     assert len(expunger_result) == 6
-    assert expunger_result[record.cases[0].charges[0].id].date_will_be_eligible == date_class(2020, 11, 9)
+    assert expunger_result[record.cases[0].charges[0].ambiguous_charge_id].date_will_be_eligible == date_class(
+        2020, 11, 9
+    )

--- a/src/backend/tests/test_friendly_rule.py
+++ b/src/backend/tests/test_friendly_rule.py
@@ -23,16 +23,16 @@ def test_eligible_mrc_with_single_arrest():
     expunger = Expunger(record)
     expunger_result = expunger.run()
 
-    assert expunger_result[arrest.id].status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[arrest.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
     assert (
-        expunger_result[arrest.id].reason
+        expunger_result[arrest.ambiguous_charge_id].reason
         == 'Time eligibility of the arrest matches conviction on the same case (the "friendly" rule)'
     )
-    assert expunger_result[arrest.id].date_will_be_eligible == date.today()
+    assert expunger_result[arrest.ambiguous_charge_id].date_will_be_eligible == date.today()
 
-    assert expunger_result[three_yr_mrc.id].status is EligibilityStatus.ELIGIBLE
-    assert expunger_result[three_yr_mrc.id].reason == "Eligible now"
-    assert expunger_result[three_yr_mrc.id].date_will_be_eligible == date.today()
+    assert expunger_result[three_yr_mrc.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[three_yr_mrc.ambiguous_charge_id].reason == "Eligible now"
+    assert expunger_result[three_yr_mrc.ambiguous_charge_id].date_will_be_eligible == date.today()
 
     merged_record = RecordMerger.merge([record], [expunger_result])
     assert (
@@ -61,9 +61,9 @@ def test_arrest_is_unaffected_if_conviction_eligibility_is_older():
     expunger = Expunger(Record([case]))
     expunger_result = expunger.run()
 
-    assert expunger_result[arrest.id].status is EligibilityStatus.ELIGIBLE
-    assert expunger_result[arrest.id].date_will_be_eligible == arrest.date
-    assert expunger_result[arrest.id].reason == "Eligible now"
+    assert expunger_result[arrest.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[arrest.ambiguous_charge_id].date_will_be_eligible == arrest.date
+    assert expunger_result[arrest.ambiguous_charge_id].reason == "Eligible now"
 
 
 def test_eligible_mrc_with_violation():
@@ -88,20 +88,23 @@ def test_eligible_mrc_with_violation():
     expunger = Expunger(record)
 
     expunger_result = expunger.run()
-    assert expunger_result[three_yr_mrc.id].status is EligibilityStatus.ELIGIBLE
-    assert expunger_result[three_yr_mrc.id].reason == "Eligible now"
-    assert expunger_result[three_yr_mrc.id].date_will_be_eligible == date.today()
+    assert expunger_result[three_yr_mrc.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[three_yr_mrc.ambiguous_charge_id].reason == "Eligible now"
+    assert expunger_result[three_yr_mrc.ambiguous_charge_id].date_will_be_eligible == date.today()
 
-    assert expunger_result[arrest.id].status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[arrest.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
     assert (
-        expunger_result[arrest.id].reason
+        expunger_result[arrest.ambiguous_charge_id].reason
         == 'Time eligibility of the arrest matches conviction on the same case (the "friendly" rule)'
     )
-    assert expunger_result[arrest.id].date_will_be_eligible == date.today()
+    assert expunger_result[arrest.ambiguous_charge_id].date_will_be_eligible == date.today()
 
-    assert expunger_result[violation.id].status is EligibilityStatus.INELIGIBLE
-    assert expunger_result[violation.id].date_will_be_eligible == date.today() + relativedelta(years=7)
-    assert expunger_result[violation.id].reason == "Ten years from most recent other conviction (137.225(7)(b))"
+    assert expunger_result[violation.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[violation.ambiguous_charge_id].date_will_be_eligible == date.today() + relativedelta(years=7)
+    assert (
+        expunger_result[violation.ambiguous_charge_id].reason
+        == "Ten years from most recent other conviction (137.225(7)(b))"
+    )
 
 
 @pytest.mark.skip()
@@ -121,10 +124,10 @@ def test_needs_more_analysis_mrc_with_single_arrest():
     expunger_result = expunger.run()
 
     ten_years_from_mrc = three_yr_mrc.disposition.date + Time.TEN_YEARS
-    assert expunger_result[arrest.id].status is EligibilityStatus.INELIGIBLE
-    assert expunger_result[arrest.id].reason == "Ten years from most recent conviction (137.225(7)(b))"
-    assert expunger_result[arrest.id].date_will_be_eligible == date.today()
-    # assert expunger_result[arrest.id].date_eligible_without_friendly_rule == ten_years_from_mrc
+    assert expunger_result[arrest.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[arrest.ambiguous_charge_id].reason == "Ten years from most recent conviction (137.225(7)(b))"
+    assert expunger_result[arrest.ambiguous_charge_id].date_will_be_eligible == date.today()
+    # assert expunger_result[arrest.ambiguous_charge_id].date_eligible_without_friendly_rule == ten_years_from_mrc
     assert arrest.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.WILL_BE_ELIGIBLE
     assert (
         arrest.expungement_result.charge_eligibility.label
@@ -132,9 +135,9 @@ def test_needs_more_analysis_mrc_with_single_arrest():
     )
 
     assert three_yr_mrc.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert expunger_result[three_yr_mrc.id].status is EligibilityStatus.ELIGIBLE
-    assert expunger_result[three_yr_mrc.id].reason == "Eligible now"
-    assert expunger_result[three_yr_mrc.id].date_will_be_eligible == date.today()
+    assert expunger_result[three_yr_mrc.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[three_yr_mrc.ambiguous_charge_id].reason == "Eligible now"
+    assert expunger_result[three_yr_mrc.ambiguous_charge_id].date_will_be_eligible == date.today()
     assert three_yr_mrc.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.POSSIBLY_ELIGIBILE
     assert three_yr_mrc.expungement_result.charge_eligibility.label == "Possibly Eligible (review)"
 
@@ -156,15 +159,15 @@ def test_very_old_needs_more_analysis_mrc_with_single_arrest():
     expunger_result = expunger.run()
 
     three_years_from_mrc = mrc.disposition.date + Time.THREE_YEARS
-    assert expunger_result[arrest.id].status is EligibilityStatus.ELIGIBLE
-    assert expunger_result[arrest.id].date_will_be_eligible == three_years_from_mrc
-    # assert expunger_result[arrest.id].date_eligible_without_friendly_rule == Time.THREE_YEARS_AGO
+    assert expunger_result[arrest.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[arrest.ambiguous_charge_id].date_will_be_eligible == three_years_from_mrc
+    # assert expunger_result[arrest.ambiguous_charge_id].date_eligible_without_friendly_rule == Time.THREE_YEARS_AGO
     assert arrest.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.ELIGIBLE_NOW
     assert arrest.expungement_result.charge_eligibility.label == "Eligible"
 
     assert mrc.expungement_result.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert expunger_result[mrc.id].status is EligibilityStatus.ELIGIBLE
-    assert expunger_result[mrc.id].date_will_be_eligible == three_years_from_mrc
+    assert expunger_result[mrc.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[mrc.ambiguous_charge_id].date_will_be_eligible == three_years_from_mrc
     assert mrc.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.POSSIBLY_ELIGIBILE
     assert mrc.expungement_result.charge_eligibility.label == "Possibly Eligible (review)"
 
@@ -187,12 +190,15 @@ def test_arrest_time_eligibility_is_set_to_older_violation():
     expunger = Expunger(Record([case]))
     expunger_result = expunger.run()
 
-    assert expunger_result[arrest.id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[arrest.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
-        expunger_result[arrest.id].reason
+        expunger_result[arrest.ambiguous_charge_id].reason
         == 'Time eligibility of the arrest matches conviction on the same case (the "friendly" rule)'
     )
-    assert expunger_result[arrest.id].date_will_be_eligible == older_violation.disposition.date + Time.THREE_YEARS
+    assert (
+        expunger_result[arrest.ambiguous_charge_id].date_will_be_eligible
+        == older_violation.disposition.date + Time.THREE_YEARS
+    )
 
 
 def test_3_violations_are_time_restricted():
@@ -219,14 +225,14 @@ def test_3_violations_are_time_restricted():
     expunger_result = expunger.run()
 
     earliest_date_eligible = min(
-        expunger_result[violation_charge_1.id].date_will_be_eligible,
-        expunger_result[violation_charge_2.id].date_will_be_eligible,
-        expunger_result[violation_charge_3.id].date_will_be_eligible,
+        expunger_result[violation_charge_1.ambiguous_charge_id].date_will_be_eligible,
+        expunger_result[violation_charge_2.ambiguous_charge_id].date_will_be_eligible,
+        expunger_result[violation_charge_3.ambiguous_charge_id].date_will_be_eligible,
     )
 
-    assert expunger_result[arrest.id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[arrest.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
-        expunger_result[arrest.id].reason
+        expunger_result[arrest.ambiguous_charge_id].reason
         == 'Time eligibility of the arrest matches conviction on the same case (the "friendly" rule)'
     )
-    assert expunger_result[arrest.id].date_will_be_eligible == earliest_date_eligible
+    assert expunger_result[arrest.ambiguous_charge_id].date_will_be_eligible == earliest_date_eligible

--- a/src/backend/tests/test_time_analyzer.py
+++ b/src/backend/tests/test_time_analyzer.py
@@ -42,17 +42,19 @@ class TestSingleChargeDismissals(unittest.TestCase):
         expunger = Expunger(record)
 
         expunger_result = expunger.run()
-        assert expunger_result[three_yr_conviction.id].status is EligibilityStatus.INELIGIBLE
+        assert expunger_result[three_yr_conviction.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
-            expunger_result[three_yr_conviction.id].reason
+            expunger_result[three_yr_conviction.ambiguous_charge_id].reason
             == "Ten years from most recent other conviction (137.225(7)(b))"
         )
-        assert expunger_result[three_yr_conviction.id].date_will_be_eligible == date.today() + relativedelta(
-            years=7, days=1
-        )
+        assert expunger_result[
+            three_yr_conviction.ambiguous_charge_id
+        ].date_will_be_eligible == date.today() + relativedelta(years=7, days=1)
 
-        assert expunger_result[arrest.id].status is EligibilityStatus.INELIGIBLE
-        assert expunger_result[arrest.id].date_will_be_eligible == date.today() + relativedelta(years=7)
+        assert expunger_result[arrest.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
+        assert expunger_result[arrest.ambiguous_charge_id].date_will_be_eligible == date.today() + relativedelta(
+            years=7
+        )
 
     def test_ineligible_mrc_with_arrest_on_single_case(self):
         # In this case, the friendly rule doesn't apply because the conviction doesn't become eligible
@@ -75,11 +77,17 @@ class TestSingleChargeDismissals(unittest.TestCase):
         expunger = Expunger(record)
 
         expunger_result = expunger.run()
-        assert expunger_result[arrest.id].status is EligibilityStatus.INELIGIBLE
-        assert expunger_result[arrest.id].reason == "Ten years from most recent conviction (137.225(7)(b))"
-        assert expunger_result[mrc.id].status is EligibilityStatus.INELIGIBLE
-        assert expunger_result[mrc.id].reason == "Never. Type ineligible charges are always time ineligible."
-        assert expunger_result[mrc.id].date_will_be_eligible == date.max
+        assert expunger_result[arrest.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
+        assert (
+            expunger_result[arrest.ambiguous_charge_id].reason
+            == "Ten years from most recent conviction (137.225(7)(b))"
+        )
+        assert expunger_result[mrc.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
+        assert (
+            expunger_result[mrc.ambiguous_charge_id].reason
+            == "Never. Type ineligible charges are always time ineligible."
+        )
+        assert expunger_result[mrc.ambiguous_charge_id].date_will_be_eligible == date.max
 
     def test_more_than_ten_year_old_conviction(self):
         case = CaseFactory.create()
@@ -90,9 +98,11 @@ class TestSingleChargeDismissals(unittest.TestCase):
         expunger = Expunger(record)
         expunger_result = expunger.run()
 
-        assert expunger_result[charge.id].status is EligibilityStatus.ELIGIBLE
-        assert expunger_result[charge.id].reason == "Eligible now"
-        assert expunger_result[charge.id].date_will_be_eligible == charge.disposition.date + relativedelta(years=+3)
+        assert expunger_result[charge.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
+        assert expunger_result[charge.ambiguous_charge_id].reason == "Eligible now"
+        assert expunger_result[
+            charge.ambiguous_charge_id
+        ].date_will_be_eligible == charge.disposition.date + relativedelta(years=+3)
 
     def test_10_yr_old_conviction_with_3_yr_old_mrc(self):
         case = CaseFactory.create()
@@ -104,13 +114,22 @@ class TestSingleChargeDismissals(unittest.TestCase):
         expunger = Expunger(record)
         expunger_result = expunger.run()
 
-        assert expunger_result[ten_yr_charge.id].status is EligibilityStatus.INELIGIBLE
-        assert expunger_result[ten_yr_charge.id].reason == "Ten years from most recent other conviction (137.225(7)(b))"
-        assert expunger_result[ten_yr_charge.id].date_will_be_eligible == three_yr_mrc.disposition.date + Time.TEN_YEARS
+        assert expunger_result[ten_yr_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
+        assert (
+            expunger_result[ten_yr_charge.ambiguous_charge_id].reason
+            == "Ten years from most recent other conviction (137.225(7)(b))"
+        )
+        assert (
+            expunger_result[ten_yr_charge.ambiguous_charge_id].date_will_be_eligible
+            == three_yr_mrc.disposition.date + Time.TEN_YEARS
+        )
 
-        assert expunger_result[three_yr_mrc.id].status is EligibilityStatus.ELIGIBLE
-        assert expunger_result[three_yr_mrc.id].reason == "Eligible now"
-        assert expunger_result[three_yr_mrc.id].date_will_be_eligible == ten_yr_charge.disposition.date + Time.TEN_YEARS
+        assert expunger_result[three_yr_mrc.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
+        assert expunger_result[three_yr_mrc.ambiguous_charge_id].reason == "Eligible now"
+        assert (
+            expunger_result[three_yr_mrc.ambiguous_charge_id].date_will_be_eligible
+            == ten_yr_charge.disposition.date + Time.TEN_YEARS
+        )
 
     def test_10_yr_old_conviction_with_less_than_3_yr_old_mrc(self):
         case = CaseFactory.create()
@@ -124,18 +143,24 @@ class TestSingleChargeDismissals(unittest.TestCase):
         expunger = Expunger(record)
         expunger_result = expunger.run()
 
-        assert expunger_result[ten_yr_charge.id].status is EligibilityStatus.INELIGIBLE
-        assert expunger_result[ten_yr_charge.id].reason == "Ten years from most recent other conviction (137.225(7)(b))"
+        assert expunger_result[ten_yr_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
-            expunger_result[ten_yr_charge.id].date_will_be_eligible
+            expunger_result[ten_yr_charge.ambiguous_charge_id].reason
+            == "Ten years from most recent other conviction (137.225(7)(b))"
+        )
+        assert (
+            expunger_result[ten_yr_charge.ambiguous_charge_id].date_will_be_eligible
             == less_than_three_yr_mrc.disposition.date + Time.TEN_YEARS
         )
 
-        assert expunger_result[less_than_three_yr_mrc.id].status is EligibilityStatus.INELIGIBLE
+        assert expunger_result[less_than_three_yr_mrc.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
-            expunger_result[less_than_three_yr_mrc.id].reason == "Three years from date of conviction (137.225(1)(a))"
+            expunger_result[less_than_three_yr_mrc.ambiguous_charge_id].reason
+            == "Three years from date of conviction (137.225(1)(a))"
         )
-        assert expunger_result[less_than_three_yr_mrc.id].date_will_be_eligible == date.today() + relativedelta(days=+1)
+        assert expunger_result[
+            less_than_three_yr_mrc.ambiguous_charge_id
+        ].date_will_be_eligible == date.today() + relativedelta(days=+1)
 
     def test_more_than_three_year_rule_conviction(self):
         case = CaseFactory.create()
@@ -146,9 +171,9 @@ class TestSingleChargeDismissals(unittest.TestCase):
         expunger = Expunger(record)
         expunger_result = expunger.run()
 
-        assert expunger_result[charge.id].status is EligibilityStatus.ELIGIBLE
-        assert expunger_result[charge.id].reason == "Eligible now"
-        assert expunger_result[charge.id].date_will_be_eligible == date.today()
+        assert expunger_result[charge.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
+        assert expunger_result[charge.ambiguous_charge_id].reason == "Eligible now"
+        assert expunger_result[charge.ambiguous_charge_id].date_will_be_eligible == date.today()
 
     def test_less_than_three_year_rule_conviction(self):
         case = CaseFactory.create()
@@ -159,9 +184,13 @@ class TestSingleChargeDismissals(unittest.TestCase):
         expunger = Expunger(record)
         expunger_result = expunger.run()
 
-        assert expunger_result[charge.id].status is EligibilityStatus.INELIGIBLE
-        assert expunger_result[charge.id].reason == "Three years from date of conviction (137.225(1)(a))"
-        assert expunger_result[charge.id].date_will_be_eligible == date.today() + relativedelta(days=+1)
+        assert expunger_result[charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
+        assert (
+            expunger_result[charge.ambiguous_charge_id].reason == "Three years from date of conviction (137.225(1)(a))"
+        )
+        assert expunger_result[charge.ambiguous_charge_id].date_will_be_eligible == date.today() + relativedelta(
+            days=+1
+        )
 
     def test_time_eligibility_date_is_none_when_type_ineligible(self):
         case = CaseFactory.create()
@@ -178,9 +207,12 @@ class TestSingleChargeDismissals(unittest.TestCase):
         expunger = Expunger(record)
         expunger_result = expunger.run()
 
-        assert expunger_result[charge.id].status is EligibilityStatus.INELIGIBLE
-        assert expunger_result[charge.id].reason == "Never. Type ineligible charges are always time ineligible."
-        assert expunger_result[charge.id].date_will_be_eligible is date.max
+        assert expunger_result[charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
+        assert (
+            expunger_result[charge.ambiguous_charge_id].reason
+            == "Never. Type ineligible charges are always time ineligible."
+        )
+        assert expunger_result[charge.ambiguous_charge_id].date_will_be_eligible is date.max
 
 
 class TestDismissalBlock(unittest.TestCase):
@@ -198,9 +230,9 @@ class TestDismissalBlock(unittest.TestCase):
         expunger = Expunger(record)
         expunger_result = expunger.run()
 
-        assert expunger_result[self.recent_dismissal.id].status is EligibilityStatus.ELIGIBLE
-        assert expunger_result[self.recent_dismissal.id].reason == "Eligible now"
-        assert expunger_result[self.recent_dismissal.id].date_will_be_eligible == Time.TWO_YEARS_AGO
+        assert expunger_result[self.recent_dismissal.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
+        assert expunger_result[self.recent_dismissal.ambiguous_charge_id].reason == "Eligible now"
+        assert expunger_result[self.recent_dismissal.ambiguous_charge_id].date_will_be_eligible == Time.TWO_YEARS_AGO
 
     def test_all_mrd_case_related_dismissals_are_expungeable(self):
         case_related_dismissal = ChargeFactory.create_dismissed_charge(
@@ -212,13 +244,13 @@ class TestDismissalBlock(unittest.TestCase):
         expunger = Expunger(record)
         expunger_result = expunger.run()
 
-        assert expunger_result[self.recent_dismissal.id].status is EligibilityStatus.ELIGIBLE
-        assert expunger_result[self.recent_dismissal.id].reason == "Eligible now"
-        assert expunger_result[self.recent_dismissal.id].date_will_be_eligible == Time.TWO_YEARS_AGO
+        assert expunger_result[self.recent_dismissal.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
+        assert expunger_result[self.recent_dismissal.ambiguous_charge_id].reason == "Eligible now"
+        assert expunger_result[self.recent_dismissal.ambiguous_charge_id].date_will_be_eligible == Time.TWO_YEARS_AGO
 
-        assert expunger_result[case_related_dismissal.id].status is EligibilityStatus.ELIGIBLE
-        assert expunger_result[case_related_dismissal.id].reason == "Eligible now"
-        assert expunger_result[case_related_dismissal.id].date_will_be_eligible == Time.TWO_YEARS_AGO
+        assert expunger_result[case_related_dismissal.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
+        assert expunger_result[case_related_dismissal.ambiguous_charge_id].reason == "Eligible now"
+        assert expunger_result[case_related_dismissal.ambiguous_charge_id].date_will_be_eligible == Time.TWO_YEARS_AGO
 
     def test_mrd_blocks_dismissals_in_unrelated_cases(self):
         unrelated_dismissal = ChargeFactory.create_dismissed_charge(
@@ -230,12 +262,12 @@ class TestDismissalBlock(unittest.TestCase):
         expunger = Expunger(record)
         expunger_result = expunger.run()
 
-        assert expunger_result[unrelated_dismissal.id].status is EligibilityStatus.INELIGIBLE
+        assert expunger_result[unrelated_dismissal.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
-            expunger_result[unrelated_dismissal.id].reason
+            expunger_result[unrelated_dismissal.ambiguous_charge_id].reason
             == "Three years from most recent other arrest (137.225(8)(a))"
         )
-        assert expunger_result[unrelated_dismissal.id].date_will_be_eligible == Time.ONE_YEARS_FROM_NOW
+        assert expunger_result[unrelated_dismissal.ambiguous_charge_id].date_will_be_eligible == Time.ONE_YEARS_FROM_NOW
 
     def test_mrd_does_not_block_convictions(self):
         case = CaseFactory.create()
@@ -251,10 +283,10 @@ class TestDismissalBlock(unittest.TestCase):
         expunger = Expunger(record)
         expunger_result = expunger.run()
 
-        assert expunger_result[convicted_charge.id].status is EligibilityStatus.ELIGIBLE
-        assert expunger_result[convicted_charge.id].reason == "Eligible now"
+        assert expunger_result[convicted_charge.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
+        assert expunger_result[convicted_charge.ambiguous_charge_id].reason == "Eligible now"
         assert expunger_result[
-            convicted_charge.id
+            convicted_charge.ambiguous_charge_id
         ].date_will_be_eligible == convicted_charge.disposition.date + relativedelta(years=+3)
 
 
@@ -276,23 +308,23 @@ class TestSecondMRCLogic(unittest.TestCase):
 
         expunger_result = self.run_expunger(two_years_ago_charge, three_years_ago_charge)
 
-        assert expunger_result[three_years_ago_charge.id].status is EligibilityStatus.INELIGIBLE
+        assert expunger_result[three_years_ago_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
-            expunger_result[three_years_ago_charge.id].reason
+            expunger_result[three_years_ago_charge.ambiguous_charge_id].reason
             == "Ten years from most recent other conviction (137.225(7)(b))"
         )
         assert (
-            expunger_result[three_years_ago_charge.id].date_will_be_eligible
+            expunger_result[three_years_ago_charge.ambiguous_charge_id].date_will_be_eligible
             == two_years_ago_charge.disposition.date + Time.TEN_YEARS
         )
 
-        assert expunger_result[two_years_ago_charge.id].status is EligibilityStatus.INELIGIBLE
+        assert expunger_result[two_years_ago_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
-            expunger_result[two_years_ago_charge.id].reason
+            expunger_result[two_years_ago_charge.ambiguous_charge_id].reason
             == "Ten years from most recent other conviction (137.225(7)(b))"
         )
         assert (
-            expunger_result[two_years_ago_charge.id].date_will_be_eligible
+            expunger_result[two_years_ago_charge.ambiguous_charge_id].date_will_be_eligible
             == three_years_ago_charge.disposition.date + Time.TEN_YEARS
         )
 
@@ -306,23 +338,23 @@ class TestSecondMRCLogic(unittest.TestCase):
 
         expunger_result = self.run_expunger(five_year_ago_charge, seven_year_ago_charge)
 
-        assert expunger_result[seven_year_ago_charge.id].status is EligibilityStatus.INELIGIBLE
+        assert expunger_result[seven_year_ago_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
-            expunger_result[seven_year_ago_charge.id].reason
+            expunger_result[seven_year_ago_charge.ambiguous_charge_id].reason
             == "Ten years from most recent other conviction (137.225(7)(b))"
         )
         assert (
-            expunger_result[seven_year_ago_charge.id].date_will_be_eligible
+            expunger_result[seven_year_ago_charge.ambiguous_charge_id].date_will_be_eligible
             == five_year_ago_charge.disposition.date + Time.TEN_YEARS
         )
 
-        assert expunger_result[five_year_ago_charge.id].status is EligibilityStatus.INELIGIBLE
+        assert expunger_result[five_year_ago_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
-            expunger_result[five_year_ago_charge.id].reason
+            expunger_result[five_year_ago_charge.ambiguous_charge_id].reason
             == "Ten years from most recent other conviction (137.225(7)(b))"
         )
         assert (
-            expunger_result[five_year_ago_charge.id].date_will_be_eligible
+            expunger_result[five_year_ago_charge.ambiguous_charge_id].date_will_be_eligible
             == seven_year_ago_charge.disposition.date + Time.TEN_YEARS
         )
 
@@ -337,7 +369,7 @@ class TestSecondMRCLogic(unittest.TestCase):
 
         expunger_result = self.run_expunger(one_year_old_conviction, nine_year_old_conviction)
 
-        assert expunger_result[one_year_old_conviction.id].date_will_be_eligible == eligibility_date
+        assert expunger_result[one_year_old_conviction.ambiguous_charge_id].date_will_be_eligible == eligibility_date
 
 
 def create_class_b_felony_charge(case, date, ruling="Convicted"):
@@ -359,9 +391,9 @@ def test_felony_class_b_greater_than_20yrs():
     expunger = Expunger(Record([case]))
     expunger_result = expunger.run()
 
-    assert expunger_result[charge.id].status is EligibilityStatus.ELIGIBLE
-    assert expunger_result[charge.id].reason == "Eligible now"
-    assert expunger_result[charge.id].date_will_be_eligible == date.today()
+    assert expunger_result[charge.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[charge.ambiguous_charge_id].reason == "Eligible now"
+    assert expunger_result[charge.ambiguous_charge_id].date_will_be_eligible == date.today()
 
 
 def test_felony_class_b_less_than_20yrs():
@@ -371,11 +403,12 @@ def test_felony_class_b_less_than_20yrs():
     expunger = Expunger(Record([case]))
     expunger_result = expunger.run()
 
-    assert expunger_result[charge.id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
-        expunger_result[charge.id].reason == "Twenty years from date of class B felony conviction (137.225(5)(a)(A)(i))"
+        expunger_result[charge.ambiguous_charge_id].reason
+        == "Twenty years from date of class B felony conviction (137.225(5)(a)(A)(i))"
     )
-    assert expunger_result[charge.id].date_will_be_eligible == Time.TOMORROW
+    assert expunger_result[charge.ambiguous_charge_id].date_will_be_eligible == Time.TOMORROW
 
 
 def test_felony_class_b_with_subsequent_conviction():
@@ -389,15 +422,15 @@ def test_felony_class_b_with_subsequent_conviction():
     expunger = Expunger(Record([case_1, case_2]))
     expunger_result = expunger.run()
 
-    assert expunger_result[b_felony_charge.id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[b_felony_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
-        expunger_result[b_felony_charge.id].reason
+        expunger_result[b_felony_charge.ambiguous_charge_id].reason
         == "Never. Class B felony can have no subsequent arrests or convictions (137.225(5)(a)(A)(ii))"
     )
-    assert expunger_result[b_felony_charge.id].date_will_be_eligible == date.max
+    assert expunger_result[b_felony_charge.ambiguous_charge_id].date_will_be_eligible == date.max
 
     # The Class B felony does not affect eligibility of another charge that is otherwise eligible
-    assert expunger_result[subsequent_charge.id].status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[subsequent_charge.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
     assert subsequent_charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
 
 
@@ -419,8 +452,8 @@ def test_felony_class_b_with_prior_conviction():
         b_felony_charge.type_eligibility.reason
         == "Convictions that fulfill the conditions of 137.225(5)(a) are eligible"
     )
-    assert expunger_result[b_felony_charge.id].status is EligibilityStatus.ELIGIBLE
-    assert expunger_result[b_felony_charge.id].reason == "Eligible now"
+    assert expunger_result[b_felony_charge.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[b_felony_charge.ambiguous_charge_id].reason == "Eligible now"
 
 
 def test_dismissed_felony_class_b_with_subsequent_conviction():
@@ -439,7 +472,7 @@ def test_dismissed_felony_class_b_with_subsequent_conviction():
     expunger_result = expunger.run()
 
     assert b_felony_charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert expunger_result[b_felony_charge.id].status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[b_felony_charge.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
 
 
 def test_doubly_eligible_b_felony_gets_normal_eligibility_rule():
@@ -472,8 +505,8 @@ def test_doubly_eligible_b_felony_gets_normal_eligibility_rule():
     expunger_result_2 = expunger.run()
 
     assert manudel_type_eligilibility.status is EligibilityStatus.ELIGIBLE
-    assert expunger_result_1[manudel_charges[0].id].status is EligibilityStatus.ELIGIBLE
-    assert expunger_result_2[manudel_charges[1].id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result_1[manudel_charges[0].ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
+    assert expunger_result_2[manudel_charges[1].ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
 
 
 def test_single_violation_is_time_restricted():
@@ -489,9 +522,14 @@ def test_single_violation_is_time_restricted():
     expunger = Expunger(Record([case]))
     expunger_result = expunger.run()
 
-    assert expunger_result[violation_charge.id].status is EligibilityStatus.INELIGIBLE
-    assert expunger_result[violation_charge.id].reason == "Three years from date of conviction (137.225(1)(a))"
-    assert expunger_result[violation_charge.id].date_will_be_eligible == date.today() + relativedelta(days=+1)
+    assert expunger_result[violation_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
+    assert (
+        expunger_result[violation_charge.ambiguous_charge_id].reason
+        == "Three years from date of conviction (137.225(1)(a))"
+    )
+    assert expunger_result[violation_charge.ambiguous_charge_id].date_will_be_eligible == date.today() + relativedelta(
+        days=+1
+    )
 
 
 def test_2_violations_are_time_restricted():
@@ -511,17 +549,23 @@ def test_2_violations_are_time_restricted():
     expunger = Expunger(Record([case]))
     expunger_result = expunger.run()
 
-    assert expunger_result[violation_charge_1.id].status is EligibilityStatus.INELIGIBLE
-    assert expunger_result[violation_charge_1.id].reason == "Three years from date of conviction (137.225(1)(a))"
+    assert expunger_result[violation_charge_1.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
-        expunger_result[violation_charge_1.id].date_will_be_eligible
+        expunger_result[violation_charge_1.ambiguous_charge_id].reason
+        == "Three years from date of conviction (137.225(1)(a))"
+    )
+    assert (
+        expunger_result[violation_charge_1.ambiguous_charge_id].date_will_be_eligible
         == violation_charge_1.disposition.date + Time.THREE_YEARS
     )
 
-    assert expunger_result[violation_charge_2.id].status is EligibilityStatus.INELIGIBLE
-    assert expunger_result[violation_charge_2.id].reason == "Three years from date of conviction (137.225(1)(a))"
+    assert expunger_result[violation_charge_2.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
-        expunger_result[violation_charge_2.id].date_will_be_eligible
+        expunger_result[violation_charge_2.ambiguous_charge_id].reason
+        == "Three years from date of conviction (137.225(1)(a))"
+    )
+    assert (
+        expunger_result[violation_charge_2.ambiguous_charge_id].date_will_be_eligible
         == violation_charge_2.disposition.date + Time.THREE_YEARS
     )
 
@@ -548,30 +592,33 @@ def test_3_violations_are_time_restricted():
     expunger = Expunger(Record([case]))
     expunger_result = expunger.run()
 
-    assert expunger_result[violation_charge_1.id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[violation_charge_1.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
-        expunger_result[violation_charge_1.id].reason == "Ten years from most recent other conviction (137.225(7)(b))"
+        expunger_result[violation_charge_1.ambiguous_charge_id].reason
+        == "Ten years from most recent other conviction (137.225(7)(b))"
     )
     assert (
-        expunger_result[violation_charge_1.id].date_will_be_eligible
+        expunger_result[violation_charge_1.ambiguous_charge_id].date_will_be_eligible
         == violation_charge_2.disposition.date + Time.TEN_YEARS
     )
 
-    assert expunger_result[violation_charge_2.id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[violation_charge_2.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
-        expunger_result[violation_charge_2.id].reason == "Ten years from most recent other conviction (137.225(7)(b))"
+        expunger_result[violation_charge_2.ambiguous_charge_id].reason
+        == "Ten years from most recent other conviction (137.225(7)(b))"
     )
     assert (
-        expunger_result[violation_charge_2.id].date_will_be_eligible
+        expunger_result[violation_charge_2.ambiguous_charge_id].date_will_be_eligible
         == violation_charge_1.disposition.date + Time.TEN_YEARS
     )
 
-    assert expunger_result[violation_charge_3.id].status is EligibilityStatus.INELIGIBLE
+    assert expunger_result[violation_charge_3.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
-        expunger_result[violation_charge_3.id].reason == "Ten years from most recent other conviction (137.225(7)(b))"
+        expunger_result[violation_charge_3.ambiguous_charge_id].reason
+        == "Ten years from most recent other conviction (137.225(7)(b))"
     )
     assert (
-        expunger_result[violation_charge_3.id].date_will_be_eligible
+        expunger_result[violation_charge_3.ambiguous_charge_id].date_will_be_eligible
         == violation_charge_1.disposition.date + Time.TEN_YEARS
     )
 
@@ -592,8 +639,11 @@ def test_nonblocking_charge_is_not_skipped_and_does_not_block():
     expunger = Expunger(Record([case]))
     expunger_result = expunger.run()
 
-    assert expunger_result[civil_offense.id].status is EligibilityStatus.INELIGIBLE
-    assert expunger_result[civil_offense.id].reason == "Never. Type ineligible charges are always time ineligible."
-    assert expunger_result[civil_offense.id].date_will_be_eligible == date.max
+    assert expunger_result[civil_offense.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
+    assert (
+        expunger_result[civil_offense.ambiguous_charge_id].reason
+        == "Never. Type ineligible charges are always time ineligible."
+    )
+    assert expunger_result[civil_offense.ambiguous_charge_id].date_will_be_eligible == date.max
 
-    assert expunger_result[violation_charge.id].status is EligibilityStatus.ELIGIBLE
+    assert expunger_result[violation_charge.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE


### PR DESCRIPTION
Relative to #963 

If a charge in OECI can have multiple potential (ambiguous) charge types, we need a way to identify the specific charge type versus the ambiguous charge as a group.

