### PR TITLE
Roll back reach-scripts version

### DIFF
--- a/src/frontend/Dockerfile.dev
+++ b/src/frontend/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:latest as build
+FROM node:13.11 as build
 RUN mkdir /usr/src/app
 ENV PATH /usr/src/app/node_modules/.bin:$PATH
 COPY package.json /usr/src/app/package.json

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -26,7 +26,7 @@
     "react-dom": "^16.12.0",
     "react-redux": "^7.1.3",
     "react-router-dom": "^5.1.2",
-    "react-scripts": "^3.4.0",
+    "react-scripts": "3.2.0",
     "react-test-renderer": "^16.11.0",
     "redux": "^4.0.5",
     "redux-mock-store": "^1.5.4",


### PR DESCRIPTION
The react-scripts version bump from 3.2 to 3.4 apparently breaks our dev frontend unless the latest version of node is running.

In dev, we're using the latest node image available on dockerhub, which is 13.11. But the latest actual version of node is 13.12, and is not supported yet on dockerhub

For now, fix this error by rolling back the react-scripts version. We could also make our own custom Dockerfile for node to use the latest version.

Also we're starting to specify our node version in the Dockerfile, because this should be explicit.