### PR TITLE
Add disambiguating question for R&J exception

### DIFF
--- a/src/backend/expungeservice/charge_classifier.py
+++ b/src/backend/expungeservice/charge_classifier.py
@@ -236,11 +236,16 @@ class ChargeClassifier:
         if statute in SexCrime.statutes:
             return AmbiguousChargeTypeWithQuestion([SexCrime])
         elif statute in SexCrime.romeo_and_juliet_exceptions:
-            question_string = "TODO: FIXME: Is this charge eligible?"
-            options = ["TODO 1", "TODO 2"]
+            question_string = """
+            Select "Yes" if ALL of the following are true:
+            1. The victim's lack of consent was solely due to age (statutory rape) AND
+            2. The victim was at least twelve years old at the time of the act AND
+            3. You were no more than nineteen years old at the time of the act
+            """
+            options = ["Yes", "No"]
             charge_type_by_level = ChargeClassifier._classification_by_level(level, statute).ambiguous_charge_type
             return AmbiguousChargeTypeWithQuestion(
-                [RomeoAndJulietIneligibleSexCrime] + charge_type_by_level, question_string, options
+                charge_type_by_level + [RomeoAndJulietIneligibleSexCrime], question_string, options
             )
 
     # TODO: Deduplicate with charge.dismissed()

--- a/src/backend/tests/models/charge_types/test_sex_crimes.py
+++ b/src/backend/tests/models/charge_types/test_sex_crimes.py
@@ -23,7 +23,7 @@ def test_sex_crimes_with_romeo_and_juliet_exception(sex_crimes_statute):
         name="Generic", statute=sex_crimes_statute, level="Misdemeanor Class A", disposition=Dispositions.CONVICTED
     )
     type_eligibility = RecordMerger.merge_type_eligibilities(charges)
-    assert isinstance(charges[0], RomeoAndJulietIneligibleSexCrime)
-    assert isinstance(charges[1], Misdemeanor)
+    assert isinstance(charges[0], Misdemeanor)
+    assert isinstance(charges[1], RomeoAndJulietIneligibleSexCrime)
     assert type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert type_eligibility.reason == "Failure to meet requirements under 163A.140(1) ⬥ Eligible under 137.225(5)(b)"
+    assert type_eligibility.reason == "Eligible under 137.225(5)(b) ⬥ Failure to meet requirements under 163A.140(1)"


### PR DESCRIPTION
Potentially resolves https://github.com/codeforpdx/recordexpungPDX/issues/987

For now, when conditions under 163A.140(1) are fulfilled, then we follow "normal" classification by level rules.