### PR TITLE
Assume unclassified charges do not block

### DIFF
--- a/src/backend/expungeservice/models/charge_types/unclassified_charge.py
+++ b/src/backend/expungeservice/models/charge_types/unclassified_charge.py
@@ -7,8 +7,14 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 @dataclass
 class UnclassifiedCharge(Charge):
     type_name: str = "Unclassified"
+    expungement_rules: str = (
+        """RecordSponge was not able to read this charge based on the information provided in the online records, and is therefore unable to determine its eligibility for expungement. Furthermore, if the conviction date was within the last ten years, your expungement analysis for your other cases may not be correct."""
+    )
 
     def _type_eligibility(self):
         return TypeEligibility(
             EligibilityStatus.NEEDS_MORE_ANALYSIS, reason="Unrecognized Charge : Further Analysis Needed"
         )
+
+    def blocks_other_charges(self):
+        return False

--- a/src/backend/tests/models/charge_types/test_unclassified.py
+++ b/src/backend/tests/models/charge_types/test_unclassified.py
@@ -1,4 +1,3 @@
-from expungeservice.models.charge_types.dismissed_charge import DismissedCharge
 from expungeservice.models.charge_types.unclassified_charge import UnclassifiedCharge
 from expungeservice.models.expungement_result import EligibilityStatus
 from tests.factories.charge_factory import ChargeFactory
@@ -16,6 +15,7 @@ def test_unclassified_charge():
     assert isinstance(unclassified_dismissed, UnclassifiedCharge)
     assert unclassified_dismissed.type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert unclassified_dismissed.type_eligibility.reason == "Unrecognized Charge : Further Analysis Needed"
+    assert not unclassified_dismissed.blocks_other_charges()
 
 
 def test_charge_that_falls_through():


### PR DESCRIPTION
Resolves https://github.com/codeforpdx/recordexpungPDX/issues/978

While this may rarely not be true, for the most part unclassified charges are from irregular low level charges (or really severe charges, in which case an expungement probably will not be attempted).