### PR TITLE
Coerce label for R&J exception to be possibly eligible

### DIFF
--- a/src/backend/expungeservice/models/charge_types/sex_crimes.py
+++ b/src/backend/expungeservice/models/charge_types/sex_crimes.py
@@ -60,14 +60,27 @@ class SexCrime(Charge):
 
 
 @dataclass
-class RomeoAndJulietIneligibleSexCrime(Charge):
-    type_name: str = "Romeo And Juliet Ineligible Sex Crime"
-    expungement_rules: str = ("""TODO""")
+class RomeoAndJulietNMASexCrime(Charge):
+    type_name: str = "163A.140(1) related sex crime"
+    expungement_rules: str = ("""Please contact michael@qiu-qiulaw.com for manual analysis.""")
 
     def _type_eligibility(self):
         if self.dismissed():
             raise ValueError("Dismissed criminal charges should have been caught by another class.")
         elif self.convicted():
             return TypeEligibility(
-                EligibilityStatus.INELIGIBLE, reason="Failure to meet requirements under 163A.140(1)"
+                EligibilityStatus.INELIGIBLE,
+                reason="Possibly meets requirements under 163A.140(1) - please contact michael@qiu-qiulaw.com for manual analysis",
             )
+
+
+@dataclass
+class RomeoAndJulietIneligibleSexCrime(Charge):
+    type_name: str = "163A.140(1) related sex crime"
+    expungement_rules: str = ("""TODO""")
+
+    def _type_eligibility(self):
+        if self.dismissed():
+            raise ValueError("Dismissed criminal charges should have been caught by another class.")
+        elif self.convicted():
+            return TypeEligibility(EligibilityStatus.INELIGIBLE, reason="Fails to meet requirements under 163A.140(1)")

--- a/src/backend/expungeservice/models/charge_types/sex_crimes.py
+++ b/src/backend/expungeservice/models/charge_types/sex_crimes.py
@@ -61,7 +61,7 @@ class SexCrime(Charge):
 
 @dataclass
 class RomeoAndJulietNMASexCrime(Charge):
-    type_name: str = "163A.140(1) related sex crime"
+    type_name: str = "137.225(6)(f) related sex crime"
     expungement_rules: str = ("""Please contact michael@qiu-qiulaw.com for manual analysis.""")
 
     def _type_eligibility(self):
@@ -70,17 +70,19 @@ class RomeoAndJulietNMASexCrime(Charge):
         elif self.convicted():
             return TypeEligibility(
                 EligibilityStatus.INELIGIBLE,
-                reason="Possibly meets requirements under 163A.140(1) - please contact michael@qiu-qiulaw.com for manual analysis",
+                reason="Possibly meets requirements under 137.225(6)(f) - Contact email michael@qiu-qiulaw.com with subject line '6F' for free and confidential further analysis",
             )
 
 
 @dataclass
 class RomeoAndJulietIneligibleSexCrime(Charge):
-    type_name: str = "163A.140(1) related sex crime"
+    type_name: str = "137.225(6)(f) related sex crime"
     expungement_rules: str = ("""TODO""")
 
     def _type_eligibility(self):
         if self.dismissed():
             raise ValueError("Dismissed criminal charges should have been caught by another class.")
         elif self.convicted():
-            return TypeEligibility(EligibilityStatus.INELIGIBLE, reason="Fails to meet requirements under 163A.140(1)")
+            return TypeEligibility(
+                EligibilityStatus.INELIGIBLE, reason="Fails to meet requirements under 137.225(6)(f)"
+            )

--- a/src/backend/expungeservice/models/charge_types/sex_crimes.py
+++ b/src/backend/expungeservice/models/charge_types/sex_crimes.py
@@ -70,7 +70,7 @@ class RomeoAndJulietNMASexCrime(Charge):
         elif self.convicted():
             return TypeEligibility(
                 EligibilityStatus.INELIGIBLE,
-                reason="Possibly meets requirements under 137.225(6)(f) - Contact email michael@qiu-qiulaw.com with subject line '6F' for free and confidential further analysis",
+                reason="Possibly meets requirements under 137.225(6)(f) - Email michael@qiu-qiulaw.com with subject line '6F' for free and confidential further analysis",
             )
 
 

--- a/src/backend/tests/models/charge_types/test_sex_crimes.py
+++ b/src/backend/tests/models/charge_types/test_sex_crimes.py
@@ -31,5 +31,5 @@ def test_sex_crimes_with_romeo_and_juliet_exception(sex_crimes_statute):
     assert type_eligibility.status is EligibilityStatus.INELIGIBLE
     assert (
         type_eligibility.reason
-        == "Possibly meets requirements under 137.225(6)(f) - Contact email michael@qiu-qiulaw.com with subject line '6F' for free and confidential further analysis ⬥ Fails to meet requirements under 137.225(6)(f)"
+        == "Possibly meets requirements under 137.225(6)(f) - Email michael@qiu-qiulaw.com with subject line '6F' for free and confidential further analysis ⬥ Fails to meet requirements under 137.225(6)(f)"
     )

--- a/src/backend/tests/models/charge_types/test_sex_crimes.py
+++ b/src/backend/tests/models/charge_types/test_sex_crimes.py
@@ -31,5 +31,5 @@ def test_sex_crimes_with_romeo_and_juliet_exception(sex_crimes_statute):
     assert type_eligibility.status is EligibilityStatus.INELIGIBLE
     assert (
         type_eligibility.reason
-        == "Possibly meets requirements under 163A.140(1) - please contact michael@qiu-qiulaw.com for manual analysis ⬥ Fails to meet requirements under 163A.140(1)"
+        == "Possibly meets requirements under 137.225(6)(f) - Contact email michael@qiu-qiulaw.com with subject line '6F' for free and confidential further analysis ⬥ Fails to meet requirements under 137.225(6)(f)"
     )

--- a/src/backend/tests/models/charge_types/test_sex_crimes.py
+++ b/src/backend/tests/models/charge_types/test_sex_crimes.py
@@ -1,6 +1,9 @@
-from expungeservice.models.charge_types.misdemeanor import Misdemeanor
 from expungeservice.models.expungement_result import EligibilityStatus
-from expungeservice.models.charge_types.sex_crimes import SexCrime, RomeoAndJulietIneligibleSexCrime
+from expungeservice.models.charge_types.sex_crimes import (
+    SexCrime,
+    RomeoAndJulietIneligibleSexCrime,
+    RomeoAndJulietNMASexCrime,
+)
 from expungeservice.record_merger import RecordMerger
 from tests.factories.charge_factory import ChargeFactory
 from tests.models.test_charge import Dispositions
@@ -23,7 +26,10 @@ def test_sex_crimes_with_romeo_and_juliet_exception(sex_crimes_statute):
         name="Generic", statute=sex_crimes_statute, level="Misdemeanor Class A", disposition=Dispositions.CONVICTED
     )
     type_eligibility = RecordMerger.merge_type_eligibilities(charges)
-    assert isinstance(charges[0], Misdemeanor)
+    assert isinstance(charges[0], RomeoAndJulietNMASexCrime)
     assert isinstance(charges[1], RomeoAndJulietIneligibleSexCrime)
-    assert type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert type_eligibility.reason == "Eligible under 137.225(5)(b) ⬥ Failure to meet requirements under 163A.140(1)"
+    assert type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert (
+        type_eligibility.reason
+        == "Possibly meets requirements under 163A.140(1) - please contact michael@qiu-qiulaw.com for manual analysis ⬥ Fails to meet requirements under 163A.140(1)"
+    )


### PR DESCRIPTION
Resolves https://github.com/codeforpdx/recordexpungPDX/issues/1004

Before question is asked:
![Screen Shot 2020-04-07 at 11 19 40 AM](https://user-images.githubusercontent.com/6329898/78705122-da04f280-78c1-11ea-91da-664d20878796.png)

After "Yes" is selected:
![Screen Shot 2020-04-07 at 11 21 50 AM](https://user-images.githubusercontent.com/6329898/78705219-03be1980-78c2-11ea-829f-e723f3e92e33.png)

After "No" is selected:
![Screen Shot 2020-04-07 at 11 22 36 AM](https://user-images.githubusercontent.com/6329898/78705278-1b959d80-78c2-11ea-98db-4f41049ebc17.png)

