### PR TITLE
Change Disposition to a frozen class

### DIFF
--- a/src/backend/expungeservice/crawler/crawler.py
+++ b/src/backend/expungeservice/crawler/crawler.py
@@ -7,7 +7,7 @@ import requests
 from datetime import datetime
 
 from expungeservice.charge_creator import ChargeCreator
-from expungeservice.models.disposition import Disposition
+from expungeservice.models.disposition import Disposition, DispositionCreator
 from expungeservice.crawler.parsers.param_parser import ParamParser
 from expungeservice.crawler.parsers.node_parser import NodeParser
 from expungeservice.crawler.parsers.record_parser import RecordParser
@@ -105,5 +105,7 @@ class Crawler:
                 datetime.strptime(disposition_data.get("date"), "%m/%d/%Y")
             )  # TODO: Log error if format is not correct
             ruling = disposition_data.get("ruling")
-            charge["disposition"] = Disposition(date, ruling, "amended" in disposition_data["event"].lower())
+            charge["disposition"] = DispositionCreator.create(
+                date, ruling, "amended" in disposition_data["event"].lower()
+            )
         return ChargeCreator.create(charge_id, **charge)

--- a/src/backend/expungeservice/models/disposition.py
+++ b/src/backend/expungeservice/models/disposition.py
@@ -1,6 +1,5 @@
-from dataclasses import dataclass, field
-from datetime import date, datetime
-from typing import Optional
+from dataclasses import dataclass
+from datetime import date
 from enum import Enum
 
 
@@ -12,18 +11,23 @@ class DispositionStatus(str, Enum):
     UNRECOGNIZED = "Unrecognized"
 
 
-@dataclass(eq=False)
+@dataclass(frozen=True)
 class Disposition:
     date: date
     ruling: str
+    status: DispositionStatus
     amended: bool = False
-    status: DispositionStatus = field(init=False)
 
-    def __post_init__(self):
-        self.status = self.__set_status()
 
-    def __set_status(self):
-        ruling = self.ruling.lower()
+class DispositionCreator:
+    @staticmethod
+    def create(date: date, ruling: str, amended: bool = False) -> Disposition:
+        status = DispositionCreator.__build_status(ruling)
+        return Disposition(date, ruling, status, amended)
+
+    @staticmethod
+    def __build_status(ruling_string):
+        ruling = ruling_string.lower()
         conviction_rulings = ["convicted", "conviction", "reduced", "finding - guilty", "conversion", "converted"]
         dismissal_rulings = [
             "acquitted",

--- a/src/backend/tests/factories/charge_factory.py
+++ b/src/backend/tests/factories/charge_factory.py
@@ -3,7 +3,7 @@ from datetime import date as date_class
 from expungeservice.models.ambiguous import AmbiguousCharge
 from expungeservice.models.charge import Charge
 from expungeservice.charge_creator import ChargeCreator
-from expungeservice.models.disposition import Disposition
+from expungeservice.models.disposition import Disposition, DispositionCreator
 
 
 class ChargeFactory:
@@ -69,7 +69,7 @@ class ChargeFactory:
         violation_type="Offense Misdemeanor",
     ) -> Charge:
         cls.charge_count += 1
-        disposition = Disposition(date=date_class.today(), ruling="Dismissed")
+        disposition = DispositionCreator.create(date=date_class.today(), ruling="Dismissed")
         kwargs = {
             "case_number": case_number,
             "name": name,

--- a/src/backend/tests/models/charge_types/test_type_analyzer_duii.py
+++ b/src/backend/tests/models/charge_types/test_type_analyzer_duii.py
@@ -1,16 +1,16 @@
 from datetime import datetime, timedelta
 
+from expungeservice.models.disposition import DispositionCreator
 from expungeservice.models.expungement_result import EligibilityStatus
 from expungeservice.record_merger import RecordMerger
 
 from tests.factories.charge_factory import ChargeFactory
-from expungeservice.models.disposition import Disposition
 
 
 def build_charges(statute, disposition_ruling):
     last_week = datetime.today() - timedelta(days=7)
     return ChargeFactory.create_ambiguous_charge(
-        statute=statute, disposition=Disposition(ruling=disposition_ruling, date=last_week)
+        statute=statute, disposition=DispositionCreator.create(ruling=disposition_ruling, date=last_week)
     )
 
 

--- a/src/backend/tests/models/test_charge.py
+++ b/src/backend/tests/models/test_charge.py
@@ -2,17 +2,18 @@ import unittest
 
 from datetime import date, datetime, timedelta
 from dateutil.relativedelta import relativedelta
-from expungeservice.models.disposition import Disposition
+
+from expungeservice.models.disposition import DispositionCreator
 from tests.factories.charge_factory import ChargeFactory
 from tests.factories.case_factory import CaseFactory
 
 
 class Dispositions:
     LAST_WEEK = datetime.today() - timedelta(days=7)
-    CONVICTED = Disposition(ruling="Convicted", date=LAST_WEEK)
-    DISMISSED = Disposition(ruling="Dismissed", date=LAST_WEEK)
-    UNRECOGNIZED_DISPOSITION = Disposition(ruling="Something unrecognized", date=LAST_WEEK)
-    NO_COMPLAINT = Disposition(ruling="No Complaint", date=LAST_WEEK)
+    CONVICTED = DispositionCreator.create(ruling="Convicted", date=LAST_WEEK)
+    DISMISSED = DispositionCreator.create(ruling="Dismissed", date=LAST_WEEK)
+    UNRECOGNIZED_DISPOSITION = DispositionCreator.create(ruling="Something unrecognized", date=LAST_WEEK)
+    NO_COMPLAINT = DispositionCreator.create(ruling="No Complaint", date=LAST_WEEK)
 
 
 class TestChargeClass(unittest.TestCase):
@@ -45,37 +46,37 @@ class TestChargeClass(unittest.TestCase):
 
     def test_it_knows_if_it_has_a_recent_conviction_happy_path(self):
         charge = ChargeFactory.create()
-        charge.disposition = Disposition(self.LESS_THAN_TEN_YEARS_AGO, "Convicted")
+        charge.disposition = DispositionCreator.create(self.LESS_THAN_TEN_YEARS_AGO, "Convicted")
 
         assert charge.recent_conviction() is True
 
     def test_it_knows_if_it_has_a_recent_conviction_sad_path(self):
         charge = ChargeFactory.create()
-        charge.disposition = Disposition(self.TEN_YEARS_AGO, "Convicted")
+        charge.disposition = DispositionCreator.create(self.TEN_YEARS_AGO, "Convicted")
 
         assert charge.recent_conviction() is False
 
     def test_dismissed_charge_is_not_a_recent_conviction(self):
         charge = ChargeFactory.create()
-        charge.disposition = Disposition(self.LESS_THAN_TEN_YEARS_AGO, "Dismissed")
+        charge.disposition = DispositionCreator.create(self.LESS_THAN_TEN_YEARS_AGO, "Dismissed")
 
         assert charge.recent_conviction() is False
 
     def test_most_recent_dismissal_happy_path(self):
         charge = ChargeFactory.create(date=self.LESS_THAN_THREE_YEARS_AGO)
-        charge.disposition = Disposition(date=self.LESS_THAN_THREE_YEARS_AGO, ruling="Dismissed")
+        charge.disposition = DispositionCreator.create(date=self.LESS_THAN_THREE_YEARS_AGO, ruling="Dismissed")
 
         assert charge.recent_dismissal() is True
 
     def test_most_recent_dismissal_sad_path(self):
         charge = ChargeFactory.create(date=self.THREE_YEARS_AGO)
-        charge.disposition = Disposition(date=self.THREE_YEARS_AGO, ruling="Dismissed")
+        charge.disposition = DispositionCreator.create(date=self.THREE_YEARS_AGO, ruling="Dismissed")
 
         assert charge.recent_dismissal() is False
 
     def test_convicted_charge_is_not_a_recent_dismissal(self):
         charge = ChargeFactory.create(date=self.LESS_THAN_THREE_YEARS_AGO)
-        charge.disposition = Disposition(date=self.LESS_THAN_THREE_YEARS_AGO, ruling="Convicted")
+        charge.disposition = DispositionCreator.create(date=self.LESS_THAN_THREE_YEARS_AGO, ruling="Convicted")
 
         assert charge.recent_dismissal() is False
 

--- a/src/backend/tests/models/test_disposition_status.py
+++ b/src/backend/tests/models/test_disposition_status.py
@@ -1,6 +1,6 @@
 from datetime import date
 
-from expungeservice.models.disposition import Disposition, DispositionStatus
+from expungeservice.models.disposition import DispositionStatus, DispositionCreator
 from expungeservice.models.expungement_result import EligibilityStatus
 
 from tests.factories.charge_factory import ChargeFactory
@@ -8,16 +8,16 @@ from tests.factories.charge_factory import ChargeFactory
 
 def test_disposition_status_values():
     today = date.today()
-    assert Disposition(today, "Dismissed").status == DispositionStatus.DISMISSED
-    assert Disposition(today, "Dismissal").status == DispositionStatus.DISMISSED
-    assert Disposition(today, "Acquitted").status == DispositionStatus.DISMISSED
-    assert Disposition(today, "Acquittal").status == DispositionStatus.DISMISSED
-    assert Disposition(today, "Convicted").status == DispositionStatus.CONVICTED
-    assert Disposition(today, "Reduced to a lesser charge").status == DispositionStatus.CONVICTED
-    assert Disposition(today, "Conversion - Disposition Types").status == DispositionStatus.CONVICTED
-    assert Disposition(today, "Diverted").status == DispositionStatus.DIVERTED
-    assert Disposition(today, "No complaint").status == DispositionStatus.NO_COMPLAINT
-    assert Disposition(today, "What is this?").status == DispositionStatus.UNRECOGNIZED
+    assert DispositionCreator.create(today, "Dismissed").status == DispositionStatus.DISMISSED
+    assert DispositionCreator.create(today, "Dismissal").status == DispositionStatus.DISMISSED
+    assert DispositionCreator.create(today, "Acquitted").status == DispositionStatus.DISMISSED
+    assert DispositionCreator.create(today, "Acquittal").status == DispositionStatus.DISMISSED
+    assert DispositionCreator.create(today, "Convicted").status == DispositionStatus.CONVICTED
+    assert DispositionCreator.create(today, "Reduced to a lesser charge").status == DispositionStatus.CONVICTED
+    assert DispositionCreator.create(today, "Conversion - Disposition Types").status == DispositionStatus.CONVICTED
+    assert DispositionCreator.create(today, "Diverted").status == DispositionStatus.DIVERTED
+    assert DispositionCreator.create(today, "No complaint").status == DispositionStatus.NO_COMPLAINT
+    assert DispositionCreator.create(today, "What is this?").status == DispositionStatus.UNRECOGNIZED
 
 
 def test_all_disposition_statuses_are_either_convicted_or_dismissed():
@@ -26,7 +26,7 @@ def test_all_disposition_statuses_are_either_convicted_or_dismissed():
     for status in DispositionStatus:
         # Use the status.value to create the disposition,
         # which happens to always be a valid string for that dispo status.
-        charge.disposition = Disposition(today, status.value)
+        charge.disposition = DispositionCreator.create(today, status.value)
 
         if status == DispositionStatus.UNRECOGNIZED:
             assert not charge.convicted()
@@ -48,7 +48,7 @@ def test_dispositionless_charge_is_not_convicted_nor_dismissed():
 
 def test_charge_with_unrecognized_disposition_eligibility():
     charge = ChargeFactory.create(
-        level="Felony Class B", disposition=Disposition(ruling="What am I", date=date(2001, 1, 1))
+        level="Felony Class B", disposition=DispositionCreator.create(ruling="What am I", date=date(2001, 1, 1))
     )
     assert not charge.convicted()
     assert not charge.dismissed()

--- a/src/backend/tests/models/test_record_summarizer.py
+++ b/src/backend/tests/models/test_record_summarizer.py
@@ -1,4 +1,4 @@
-from expungeservice.models.disposition import Disposition
+from expungeservice.models.disposition import DispositionCreator
 from expungeservice.record_merger import RecordMerger
 from expungeservice.record_summarizer import RecordSummarizer
 from expungeservice.expunger import Expunger
@@ -14,7 +14,7 @@ def test_record_summarizer_multiple_cases():
         ChargeFactory.create(
             case_number=case_all_eligible.case_number,
             name="Theft of dignity",
-            disposition=Disposition(ruling="Convicted", date=Time.TEN_YEARS_AGO),
+            disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO),
         )
     ]
 
@@ -24,12 +24,12 @@ def test_record_summarizer_multiple_cases():
     case_partially_eligible.charges = [
         ChargeFactory.create(
             case_number=case_partially_eligible.case_number,
-            disposition=Disposition(ruling="Convicted", date=Time.TEN_YEARS_AGO),
+            disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO),
         ),
         ChargeFactory.create(
             case_number=case_partially_eligible.case_number,
             level="Felony Class A",
-            disposition=Disposition(ruling="Convicted", date=Time.TEN_YEARS_AGO),
+            disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO),
         ),
     ]
 
@@ -38,7 +38,7 @@ def test_record_summarizer_multiple_cases():
         ChargeFactory.create(
             case_number=case_possibly_eligible.case_number,
             level="Felony Class B",
-            disposition=Disposition(ruling="Convicted", date=Time.TEN_YEARS_AGO),
+            disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO),
         )
     ]
 
@@ -47,7 +47,7 @@ def test_record_summarizer_multiple_cases():
         ChargeFactory.create(
             case_number=case_all_ineligible.case_number,
             level="Felony Class A",
-            disposition=Disposition(ruling="Convicted", date=Time.TEN_YEARS_AGO),
+            disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO),
         )
     ]
 
@@ -56,7 +56,7 @@ def test_record_summarizer_multiple_cases():
         ChargeFactory.create(
             case_number=case_all_ineligible_2.case_number,
             level="Felony Class A",
-            disposition=Disposition(ruling="Convicted", date=Time.TEN_YEARS_AGO),
+            disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO),
         )
     ]
     record = Record(

--- a/src/backend/tests/test_friendly_rule.py
+++ b/src/backend/tests/test_friendly_rule.py
@@ -2,7 +2,7 @@ import pytest
 from dateutil.relativedelta import relativedelta
 
 from expungeservice.expunger import Expunger
-from expungeservice.models.disposition import Disposition
+from expungeservice.models.disposition import DispositionCreator
 from expungeservice.models.expungement_result import EligibilityStatus, ChargeEligibilityStatus
 from expungeservice.record_merger import RecordMerger
 from expungeservice.models.record import Record
@@ -13,9 +13,11 @@ from datetime import date
 
 
 def test_eligible_mrc_with_single_arrest():
-    three_yr_mrc = ChargeFactory.create(disposition=Disposition(ruling="Convicted", date=Time.THREE_YEARS_AGO))
+    three_yr_mrc = ChargeFactory.create(
+        disposition=DispositionCreator.create(ruling="Convicted", date=Time.THREE_YEARS_AGO)
+    )
 
-    arrest = ChargeFactory.create(disposition=Disposition(ruling="Dismissed", date=Time.THREE_YEARS_AGO))
+    arrest = ChargeFactory.create(disposition=DispositionCreator.create(ruling="Dismissed", date=Time.THREE_YEARS_AGO))
 
     case = CaseFactory.create()
     case.charges = [three_yr_mrc, arrest]
@@ -52,9 +54,9 @@ def test_arrest_is_unaffected_if_conviction_eligibility_is_older():
     violation_charge = ChargeFactory.create(
         level="Class A Violation",
         date=Time.TEN_YEARS_AGO,
-        disposition=Disposition(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO),
+        disposition=DispositionCreator.create(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO),
     )
-    arrest = ChargeFactory.create(disposition=Disposition(ruling="Dismissed", date=Time.ONE_YEAR_AGO))
+    arrest = ChargeFactory.create(disposition=DispositionCreator.create(ruling="Dismissed", date=Time.ONE_YEAR_AGO))
 
     case = CaseFactory.create()
     case.charges = [violation_charge, arrest]
@@ -70,17 +72,19 @@ def test_eligible_mrc_with_violation():
     case = CaseFactory.create()
 
     three_yr_mrc = ChargeFactory.create(
-        case_number=case.case_number, disposition=Disposition(ruling="Convicted", date=Time.THREE_YEARS_AGO)
+        case_number=case.case_number,
+        disposition=DispositionCreator.create(ruling="Convicted", date=Time.THREE_YEARS_AGO),
     )
 
     arrest = ChargeFactory.create(
-        case_number=case.case_number, disposition=Disposition(ruling="Dismissed", date=Time.THREE_YEARS_AGO)
+        case_number=case.case_number,
+        disposition=DispositionCreator.create(ruling="Dismissed", date=Time.THREE_YEARS_AGO),
     )
 
     violation = ChargeFactory.create(
         level="Violation",
         case_number=case.case_number,
-        disposition=Disposition(ruling="Convicted", date=Time.THREE_YEARS_AGO),
+        disposition=DispositionCreator.create(ruling="Convicted", date=Time.THREE_YEARS_AGO),
     )
 
     case.charges = [three_yr_mrc, arrest, violation]
@@ -113,9 +117,9 @@ def test_needs_more_analysis_mrc_with_single_arrest():
         name="Assault in the third degree",
         statute="163.165",
         level="Felony Class C",
-        disposition=Disposition(ruling="Convicted", date=Time.THREE_YEARS_AGO),
+        disposition=DispositionCreator.create(ruling="Convicted", date=Time.THREE_YEARS_AGO),
     )
-    arrest = ChargeFactory.create(disposition=Disposition(ruling="Dismissed", date=Time.THREE_YEARS_AGO))
+    arrest = ChargeFactory.create(disposition=DispositionCreator.create(ruling="Dismissed", date=Time.THREE_YEARS_AGO))
 
     case = CaseFactory.create()
     case.charges = [three_yr_mrc, arrest]
@@ -148,9 +152,9 @@ def test_very_old_needs_more_analysis_mrc_with_single_arrest():
         name="Assault in the third degree",
         statute="163.165",
         level="Felony Class C",
-        disposition=Disposition(ruling="Convicted", date=Time.TWENTY_YEARS_AGO),
+        disposition=DispositionCreator.create(ruling="Convicted", date=Time.TWENTY_YEARS_AGO),
     )
-    arrest = ChargeFactory.create(disposition=Disposition(ruling="Dismissed", date=Time.THREE_YEARS_AGO))
+    arrest = ChargeFactory.create(disposition=DispositionCreator.create(ruling="Dismissed", date=Time.THREE_YEARS_AGO))
 
     case = CaseFactory.create()
     case.charges = [mrc, arrest]
@@ -176,14 +180,14 @@ def test_arrest_time_eligibility_is_set_to_older_violation():
     older_violation = ChargeFactory.create(
         level="Class A Violation",
         date=Time.LESS_THAN_THREE_YEARS_AGO,
-        disposition=Disposition(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO),
+        disposition=DispositionCreator.create(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO),
     )
     newer_violation = ChargeFactory.create(
         level="Class A Violation",
         date=Time.TWO_YEARS_AGO,
-        disposition=Disposition(ruling="Convicted", date=Time.TWO_YEARS_AGO),
+        disposition=DispositionCreator.create(ruling="Convicted", date=Time.TWO_YEARS_AGO),
     )
-    arrest = ChargeFactory.create(disposition=Disposition(ruling="Dismissed", date=Time.ONE_YEAR_AGO))
+    arrest = ChargeFactory.create(disposition=DispositionCreator.create(ruling="Dismissed", date=Time.ONE_YEAR_AGO))
 
     case = CaseFactory.create()
     case.charges = [older_violation, newer_violation, arrest]
@@ -205,19 +209,19 @@ def test_3_violations_are_time_restricted():
     violation_charge_1 = ChargeFactory.create(
         level="Class A Violation",
         date=Time.LESS_THAN_THREE_YEARS_AGO,
-        disposition=Disposition(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO),
+        disposition=DispositionCreator.create(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO),
     )
     violation_charge_2 = ChargeFactory.create(
         level="Class A Violation",
         date=Time.TWO_YEARS_AGO,
-        disposition=Disposition(ruling="Convicted", date=Time.TWO_YEARS_AGO),
+        disposition=DispositionCreator.create(ruling="Convicted", date=Time.TWO_YEARS_AGO),
     )
     violation_charge_3 = ChargeFactory.create(
         level="Class A Violation",
         date=Time.ONE_YEAR_AGO,
-        disposition=Disposition(ruling="Convicted", date=Time.ONE_YEAR_AGO),
+        disposition=DispositionCreator.create(ruling="Convicted", date=Time.ONE_YEAR_AGO),
     )
-    arrest = ChargeFactory.create(disposition=Disposition(ruling="Dismissed", date=Time.ONE_YEAR_AGO))
+    arrest = ChargeFactory.create(disposition=DispositionCreator.create(ruling="Dismissed", date=Time.ONE_YEAR_AGO))
 
     case = CaseFactory.create()
     case.charges = [violation_charge_3, violation_charge_2, violation_charge_1, arrest]

--- a/src/backend/tests/test_time_analyzer.py
+++ b/src/backend/tests/test_time_analyzer.py
@@ -4,7 +4,7 @@ from datetime import date
 
 from dateutil.relativedelta import relativedelta
 from expungeservice.expunger import Expunger
-from expungeservice.models.disposition import Disposition
+from expungeservice.models.disposition import DispositionCreator
 from expungeservice.models.expungement_result import EligibilityStatus
 from expungeservice.record_merger import RecordMerger
 from expungeservice.models.record import Record
@@ -18,23 +18,25 @@ class TestSingleChargeDismissals(unittest.TestCase):
         case = CaseFactory.create()
 
         three_yr_conviction = ChargeFactory.create(
-            case_number=case.case_number, disposition=Disposition(ruling="Convicted", date=Time.THREE_YEARS_AGO)
+            case_number=case.case_number,
+            disposition=DispositionCreator.create(ruling="Convicted", date=Time.THREE_YEARS_AGO),
         )
 
         arrest = ChargeFactory.create(
-            case_number=case.case_number, disposition=Disposition(ruling="Dismissed", date=Time.THREE_YEARS_AGO)
+            case_number=case.case_number,
+            disposition=DispositionCreator.create(ruling="Dismissed", date=Time.THREE_YEARS_AGO),
         )
 
         violation = ChargeFactory.create(
             level="Violation",
             case_number=case.case_number,
-            disposition=Disposition(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO),
+            disposition=DispositionCreator.create(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO),
         )
 
         violation_2 = ChargeFactory.create(
             level="Violation",
             case_number=case.case_number,
-            disposition=Disposition(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO),
+            disposition=DispositionCreator.create(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO),
         )
 
         case.charges = [three_yr_conviction, arrest, violation, violation_2]
@@ -62,14 +64,14 @@ class TestSingleChargeDismissals(unittest.TestCase):
 
         mrc = ChargeFactory.create(
             case_number=case.case_number,
-            disposition=Disposition(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO),
+            disposition=DispositionCreator.create(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO),
             statute="666.666",
             level="Felony Class A",
         )
 
         arrest = ChargeFactory.create(
             case_number=case.case_number,
-            disposition=Disposition(ruling="Dismissed", date=Time.LESS_THAN_THREE_YEARS_AGO),
+            disposition=DispositionCreator.create(ruling="Dismissed", date=Time.LESS_THAN_THREE_YEARS_AGO),
         )
 
         case.charges = [mrc, arrest]
@@ -91,7 +93,9 @@ class TestSingleChargeDismissals(unittest.TestCase):
 
     def test_more_than_ten_year_old_conviction(self):
         case = CaseFactory.create()
-        charge = ChargeFactory.create(disposition=Disposition(ruling="Convicted", date=Time.TEN_YEARS_AGO))
+        charge = ChargeFactory.create(
+            disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO)
+        )
 
         case.charges = [charge]
         record = Record([case])
@@ -106,8 +110,12 @@ class TestSingleChargeDismissals(unittest.TestCase):
 
     def test_10_yr_old_conviction_with_3_yr_old_mrc(self):
         case = CaseFactory.create()
-        ten_yr_charge = ChargeFactory.create(disposition=Disposition(ruling="Convicted", date=Time.TEN_YEARS_AGO))
-        three_yr_mrc = ChargeFactory.create(disposition=Disposition(ruling="Convicted", date=Time.THREE_YEARS_AGO))
+        ten_yr_charge = ChargeFactory.create(
+            disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO)
+        )
+        three_yr_mrc = ChargeFactory.create(
+            disposition=DispositionCreator.create(ruling="Convicted", date=Time.THREE_YEARS_AGO)
+        )
 
         case.charges = [ten_yr_charge, three_yr_mrc]
         record = Record([case])
@@ -133,9 +141,11 @@ class TestSingleChargeDismissals(unittest.TestCase):
 
     def test_10_yr_old_conviction_with_less_than_3_yr_old_mrc(self):
         case = CaseFactory.create()
-        ten_yr_charge = ChargeFactory.create(disposition=Disposition(ruling="Convicted", date=Time.TEN_YEARS_AGO))
+        ten_yr_charge = ChargeFactory.create(
+            disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO)
+        )
         less_than_three_yr_mrc = ChargeFactory.create(
-            disposition=Disposition(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO)
+            disposition=DispositionCreator.create(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO)
         )
 
         case.charges = [ten_yr_charge, less_than_three_yr_mrc]
@@ -164,7 +174,9 @@ class TestSingleChargeDismissals(unittest.TestCase):
 
     def test_more_than_three_year_rule_conviction(self):
         case = CaseFactory.create()
-        charge = ChargeFactory.create(disposition=Disposition(ruling="Convicted", date=Time.THREE_YEARS_AGO))
+        charge = ChargeFactory.create(
+            disposition=DispositionCreator.create(ruling="Convicted", date=Time.THREE_YEARS_AGO)
+        )
 
         case.charges = [charge]
         record = Record([case])
@@ -177,7 +189,9 @@ class TestSingleChargeDismissals(unittest.TestCase):
 
     def test_less_than_three_year_rule_conviction(self):
         case = CaseFactory.create()
-        charge = ChargeFactory.create(disposition=Disposition(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO))
+        charge = ChargeFactory.create(
+            disposition=DispositionCreator.create(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO)
+        )
 
         case.charges = [charge]
         record = Record([case])
@@ -199,7 +213,7 @@ class TestSingleChargeDismissals(unittest.TestCase):
             statute="163.185",
             level="Felony Class A",
             date=Time.ONE_YEAR_AGO,
-            disposition=Disposition(ruling="Convicted", date=Time.ONE_YEAR_AGO),
+            disposition=DispositionCreator.create(ruling="Convicted", date=Time.ONE_YEAR_AGO),
         )
 
         case.charges = [charge]
@@ -274,7 +288,7 @@ class TestDismissalBlock(unittest.TestCase):
         convicted_charge = ChargeFactory.create(
             case_number=case.case_number,
             date=Time.TWENTY_YEARS_AGO,
-            disposition=Disposition(ruling="Convicted", date=Time.TWENTY_YEARS_AGO),
+            disposition=DispositionCreator.create(ruling="Convicted", date=Time.TWENTY_YEARS_AGO),
             violation_type=case.violation_type,
         )
         case.charges = [convicted_charge]
@@ -300,10 +314,10 @@ class TestSecondMRCLogic(unittest.TestCase):
 
     def test_3_yr_old_conviction_2_yr_old_mrc(self):
         three_years_ago_charge = ChargeFactory.create(
-            disposition=Disposition(ruling="Convicted", date=Time.THREE_YEARS_AGO)
+            disposition=DispositionCreator.create(ruling="Convicted", date=Time.THREE_YEARS_AGO)
         )
         two_years_ago_charge = ChargeFactory.create(
-            disposition=Disposition(ruling="Convicted", date=Time.TWO_YEARS_AGO)
+            disposition=DispositionCreator.create(ruling="Convicted", date=Time.TWO_YEARS_AGO)
         )
 
         expunger_result = self.run_expunger(two_years_ago_charge, three_years_ago_charge)
@@ -330,10 +344,10 @@ class TestSecondMRCLogic(unittest.TestCase):
 
     def test_7_yr_old_conviction_5_yr_old_mrc(self):
         seven_year_ago_charge = ChargeFactory.create(
-            disposition=Disposition(ruling="Convicted", date=Time.SEVEN_YEARS_AGO)
+            disposition=DispositionCreator.create(ruling="Convicted", date=Time.SEVEN_YEARS_AGO)
         )
         five_year_ago_charge = ChargeFactory.create(
-            disposition=Disposition(ruling="Convicted", date=Time.FIVE_YEARS_AGO)
+            disposition=DispositionCreator.create(ruling="Convicted", date=Time.FIVE_YEARS_AGO)
         )
 
         expunger_result = self.run_expunger(five_year_ago_charge, seven_year_ago_charge)
@@ -360,10 +374,10 @@ class TestSecondMRCLogic(unittest.TestCase):
 
     def test_mrc_is_eligible_in_two_years(self):
         nine_year_old_conviction = ChargeFactory.create(
-            disposition=Disposition(ruling="Convicted", date=Time.NINE_YEARS_AGO)
+            disposition=DispositionCreator.create(ruling="Convicted", date=Time.NINE_YEARS_AGO)
         )
         one_year_old_conviction = ChargeFactory.create(
-            disposition=Disposition(ruling="Convicted", date=Time.ONE_YEAR_AGO)
+            disposition=DispositionCreator.create(ruling="Convicted", date=Time.ONE_YEAR_AGO)
         )
         eligibility_date = one_year_old_conviction.disposition.date + Time.THREE_YEARS
 
@@ -379,7 +393,7 @@ def create_class_b_felony_charge(case, date, ruling="Convicted"):
         statute="164.057",
         level="Felony Class B",
         date=date,
-        disposition=Disposition(ruling=ruling, date=date),
+        disposition=DispositionCreator.create(ruling=ruling, date=date),
         violation_type=case.violation_type,
     )
 
@@ -415,7 +429,9 @@ def test_felony_class_b_with_subsequent_conviction():
     case_1 = CaseFactory.create(case_number="1")
     b_felony_charge = create_class_b_felony_charge(case_1, Time.TWENTY_YEARS_AGO)
     case_1.charges = [b_felony_charge]
-    subsequent_charge = ChargeFactory.create(disposition=Disposition(ruling="Convicted", date=Time.TEN_YEARS_AGO))
+    subsequent_charge = ChargeFactory.create(
+        disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO)
+    )
     case_2 = CaseFactory.create(case_number="2")
     case_2.charges = [subsequent_charge]
 
@@ -439,7 +455,7 @@ def test_felony_class_b_with_prior_conviction():
     b_felony_charge = create_class_b_felony_charge(case_1, Time.TWENTY_YEARS_AGO)
     case_1.charges = [b_felony_charge]
     prior_charge = ChargeFactory.create(
-        disposition=Disposition(ruling="Convicted", date=Time.MORE_THAN_TWENTY_YEARS_AGO)
+        disposition=DispositionCreator.create(ruling="Convicted", date=Time.MORE_THAN_TWENTY_YEARS_AGO)
     )
     case_2 = CaseFactory.create(case_number="2")
     case_2.charges = [prior_charge]
@@ -463,7 +479,7 @@ def test_dismissed_felony_class_b_with_subsequent_conviction():
     case_2 = CaseFactory.create(case_number="2")
     subsequent_charge = ChargeFactory.create(
         case_number=case_2.case_number,
-        disposition=Disposition(ruling="Convicted", date=Time.TEN_YEARS_AGO),
+        disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO),
         violation_type=case_2.violation_type,
     )
     case_2.charges = [subsequent_charge]
@@ -483,7 +499,7 @@ def test_doubly_eligible_b_felony_gets_normal_eligibility_rule():
         statute="4759922b",
         level="Felony Class B",
         date=Time.LESS_THAN_TWENTY_YEARS_AGO,
-        disposition=Disposition(ruling="Convicted", date=Time.LESS_THAN_TWENTY_YEARS_AGO),
+        disposition=DispositionCreator.create(ruling="Convicted", date=Time.LESS_THAN_TWENTY_YEARS_AGO),
     )
     manudel_type_eligilibility = RecordMerger.merge_type_eligibilities(manudel_charges)
 
@@ -493,7 +509,8 @@ def test_doubly_eligible_b_felony_gets_normal_eligibility_rule():
     case_1b.charges = [manudel_charges[1]]
     case_2 = CaseFactory.create(case_number="2")
     subsequent_charge = ChargeFactory.create(
-        case_number=case_2.case_number, disposition=Disposition(ruling="Convicted", date=Time.TEN_YEARS_AGO)
+        case_number=case_2.case_number,
+        disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO),
     )
     case_2.charges = [subsequent_charge]
 
@@ -514,7 +531,7 @@ def test_single_violation_is_time_restricted():
     violation_charge = ChargeFactory.create(
         level="Class A Violation",
         date=Time.TEN_YEARS_AGO,
-        disposition=Disposition(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO),
+        disposition=DispositionCreator.create(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO),
     )
 
     case = CaseFactory.create()
@@ -536,12 +553,12 @@ def test_2_violations_are_time_restricted():
     violation_charge_1 = ChargeFactory.create(
         level="Class A Violation",
         date=Time.LESS_THAN_THREE_YEARS_AGO,
-        disposition=Disposition(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO),
+        disposition=DispositionCreator.create(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO),
     )
     violation_charge_2 = ChargeFactory.create(
         level="Class A Violation",
         date=Time.TWO_YEARS_AGO,
-        disposition=Disposition(ruling="Convicted", date=Time.TWO_YEARS_AGO),
+        disposition=DispositionCreator.create(ruling="Convicted", date=Time.TWO_YEARS_AGO),
     )
 
     case = CaseFactory.create()
@@ -574,17 +591,17 @@ def test_3_violations_are_time_restricted():
     violation_charge_1 = ChargeFactory.create(
         level="Class A Violation",
         date=Time.LESS_THAN_THREE_YEARS_AGO,
-        disposition=Disposition(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO),
+        disposition=DispositionCreator.create(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO),
     )
     violation_charge_2 = ChargeFactory.create(
         level="Class A Violation",
         date=Time.TWO_YEARS_AGO,
-        disposition=Disposition(ruling="Convicted", date=Time.TWO_YEARS_AGO),
+        disposition=DispositionCreator.create(ruling="Convicted", date=Time.TWO_YEARS_AGO),
     )
     violation_charge_3 = ChargeFactory.create(
         level="Class A Violation",
         date=Time.ONE_YEAR_AGO,
-        disposition=Disposition(ruling="Convicted", date=Time.ONE_YEAR_AGO),
+        disposition=DispositionCreator.create(ruling="Convicted", date=Time.ONE_YEAR_AGO),
     )
 
     case = CaseFactory.create()
@@ -625,13 +642,13 @@ def test_3_violations_are_time_restricted():
 
 def test_nonblocking_charge_is_not_skipped_and_does_not_block():
     civil_offense = ChargeFactory.create(
-        level="N/A", statute="1.000", disposition=Disposition(ruling="Convicted", date=Time.ONE_YEAR_AGO)
+        level="N/A", statute="1.000", disposition=DispositionCreator.create(ruling="Convicted", date=Time.ONE_YEAR_AGO)
     )
 
     violation_charge = ChargeFactory.create(
         level="Class A Violation",
         date=Time.TEN_YEARS_AGO,
-        disposition=Disposition(ruling="Convicted", date=Time.TEN_YEARS_AGO),
+        disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO),
     )
 
     case = CaseFactory.create()


### PR DESCRIPTION
Our ultimate goal is to make the Record object frozen so that we can cache results from the Expunger. Before this commit, since the status was dependent on the ruling string, almost all randomly generated ruling strings resolved to status unrecognized. Thus we adjust the generator such that only `DismissedCharge`s receive a disposition status of dismissed, no complaint, or diverted. Note this increases the test time for the generator slightly.