### PR TITLE
Convert Expunger.run into a static method

### DIFF
--- a/src/backend/expungeservice/crawler/crawler.py
+++ b/src/backend/expungeservice/crawler/crawler.py
@@ -73,7 +73,7 @@ class Crawler:
                 questions.append(question)
         ambiguous_case = []
         for charges in product(*ambiguous_charges):
-            possible_case = replace(updated_case, charges=list(charges))
+            possible_case = replace(updated_case, charges=tuple(charges))
             ambiguous_case.append(possible_case)
         return ambiguous_case, questions
 

--- a/src/backend/expungeservice/generator.py
+++ b/src/backend/expungeservice/generator.py
@@ -62,6 +62,4 @@ def build_record_strategy(min_cases_size=0, min_charges_size=0) -> SearchStrateg
 def build_record() -> Record:
     record_strategy = build_record_strategy(min_cases_size=10, min_charges_size=1)
     record = record_strategy.example()
-    expunger = Expunger(record)
-    expunger.run()
     return record

--- a/src/backend/expungeservice/models/case.py
+++ b/src/backend/expungeservice/models/case.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime, date as date_class
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from expungeservice.models.charge import Charge
 
@@ -15,7 +15,7 @@ class Case:
     date: date_class
     violation_type: str
     current_status: str
-    charges: List[Charge]
+    charges: Tuple[Charge, ...]
     case_detail_link: str
     balance_due_in_cents: int = 0
     probation_revoked: Optional[date_class] = None

--- a/src/backend/expungeservice/models/expungement_result.py
+++ b/src/backend/expungeservice/models/expungement_result.py
@@ -32,13 +32,13 @@ class TimeEligibility:
     date_will_be_eligible: date
 
 
-@dataclass
+@dataclass(frozen=True)
 class ChargeEligibility:
     status: ChargeEligibilityStatus
     label: str
 
 
-@dataclass
+@dataclass(frozen=True)
 class ExpungementResult:
     type_eligibility: TypeEligibility = TypeEligibility(
         status=EligibilityStatus.NEEDS_MORE_ANALYSIS, reason="Default value"

--- a/src/backend/expungeservice/models/record.py
+++ b/src/backend/expungeservice/models/record.py
@@ -13,7 +13,7 @@ class Question:
     answer: str = ""
 
 
-@dataclass
+@dataclass(frozen=True)
 class Record:
     cases: List[Case]
     errors: List[str] = field(default_factory=list)

--- a/src/backend/expungeservice/models/record.py
+++ b/src/backend/expungeservice/models/record.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List, Dict
+from typing import List, Dict, Tuple
 
 from expungeservice.models.case import Case
 from expungeservice.models.charge import Charge
@@ -15,8 +15,8 @@ class Question:
 
 @dataclass(frozen=True)
 class Record:
-    cases: List[Case]
-    errors: List[str] = field(default_factory=list)
+    cases: Tuple[Case, ...]
+    errors: Tuple[str, ...] = ()
 
     @property
     def charges(self):

--- a/src/backend/expungeservice/record_creator.py
+++ b/src/backend/expungeservice/record_creator.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from itertools import product, groupby
 from typing import List, Dict, Tuple
 
@@ -51,10 +52,11 @@ class RecordCreator:
     @staticmethod
     def analyze_ambiguous_record(ambiguous_record: AmbiguousRecord):
         charge_id_to_time_eligibilities = []
+        ambiguous_record_with_errors = []
         for record in ambiguous_record:
-            record.errors += ErrorChecker.check(record)  # TODO: Fix mutation
-            expunger = Expunger(record)
-            charge_id_to_time_eligibility = expunger.run()
+            record_with_errors = replace(record, errors=ErrorChecker.check(record))
+            charge_id_to_time_eligibility = Expunger.run(record_with_errors)
             charge_id_to_time_eligibilities.append(charge_id_to_time_eligibility)
-        record = RecordMerger.merge(ambiguous_record, charge_id_to_time_eligibilities)
+            ambiguous_record_with_errors.append(record_with_errors)
+        record = RecordMerger.merge(ambiguous_record_with_errors, charge_id_to_time_eligibilities)
         return record

--- a/src/backend/expungeservice/record_merger.py
+++ b/src/backend/expungeservice/record_merger.py
@@ -5,6 +5,7 @@ from typing import List, Dict, Set, Optional
 from more_itertools import flatten, unique_everseen
 
 from expungeservice.models.ambiguous import AmbiguousRecord
+from expungeservice.models.case import Case
 from expungeservice.models.charge import Charge
 from expungeservice.models.charge_types.sex_crimes import RomeoAndJulietNMASexCrime
 from expungeservice.models.expungement_result import (
@@ -32,7 +33,7 @@ class RecordMerger:
                     ambiguous_charge_id_to_time_eligibilities[k].append(v)
         charges = list(flatten([record.charges for record in ambiguous_record]))
         record = ambiguous_record[0]
-        new_case_list = []
+        new_case_list: List[Case] = []
         for case in record.cases:
             new_charges = []
             for charge in case.charges:
@@ -52,9 +53,9 @@ class RecordMerger:
                 merged_type_name = " ⬥ ".join(list(unique_everseen([charge.type_name for charge in same_charges])))
                 new_charge: Charge = replace(charge, type_name=merged_type_name, expungement_result=expungement_result)
                 new_charges.append(new_charge)
-            new_case = replace(case, charges=new_charges)
+            new_case = replace(case, charges=tuple(new_charges))
             new_case_list.append(new_case)
-        return replace(record, cases=new_case_list)
+        return replace(record, cases=tuple(new_case_list))
 
     @staticmethod
     def filter_ambiguous_record(ambiguous_record: AmbiguousRecord, questions: List[Question]) -> AmbiguousRecord:

--- a/src/backend/tests/models/test_record.py
+++ b/src/backend/tests/models/test_record.py
@@ -7,24 +7,24 @@ from tests.factories.charge_factory import ChargeFactory
 
 class TestRecordObject(unittest.TestCase):
     def test_print_balance_in_cents(self):
-        record = Record([CaseFactory.create(balance="123.00"), CaseFactory.create(balance="246.00")])
+        record = Record(tuple([CaseFactory.create(balance="123.00"), CaseFactory.create(balance="246.00")]))
         assert record.total_balance_due == 369.00
 
     def test_print_balance_in_cents_empty(self):
-        record = Record([CaseFactory.create()])
+        record = Record(tuple([CaseFactory.create()]))
         assert record.total_balance_due == 0.00
 
 
 class TestChargeMethod(unittest.TestCase):
     def setUp(self):
         self.charge_zero = ChargeFactory.create(case_number="1")
-        self.case_1 = CaseFactory.create(case_number="1", charges=[self.charge_zero])
+        self.case_1 = CaseFactory.create(case_number="1", charges=tuple([self.charge_zero]))
 
         self.charge_one = ChargeFactory.create(case_number="2")
         self.charge_two = ChargeFactory.create(case_number="2")
-        self.case_2 = CaseFactory.create(case_number="2", charges=[self.charge_one, self.charge_two])
+        self.case_2 = CaseFactory.create(case_number="2", charges=tuple([self.charge_one, self.charge_two]))
 
-        self.record = Record([self.case_1, self.case_2])
+        self.record = Record(tuple([self.case_1, self.case_2]))
 
     def test_num_cases(self):
         assert len(self.record.charges) == 3

--- a/src/backend/tests/models/test_record_summarizer.py
+++ b/src/backend/tests/models/test_record_summarizer.py
@@ -78,8 +78,8 @@ def test_record_summarizer_multiple_cases():
     record = Record(
         [case_all_eligible, case_partially_eligible, case_possibly_eligible, case_all_ineligible, case_all_ineligible_2]
     )
-    expunger = Expunger(record)
-    expunger_result = expunger.run()
+    expunger_result = Expunger.run(record)
+
     merged_record = RecordMerger.merge([record], [expunger_result])
     record_summary = RecordSummarizer.summarize(merged_record, {})
 

--- a/src/backend/tests/models/test_record_summarizer.py
+++ b/src/backend/tests/models/test_record_summarizer.py
@@ -13,70 +13,88 @@ def test_record_summarizer_multiple_cases():
         case_number="1",
         balance="100.00",
         date_location=["1/1/1995", "Multnomah"],
-        charges=[
-            ChargeFactory.create(
-                case_number="1",
-                name="Theft of dignity",
-                disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO),
-            )
-        ],
+        charges=tuple(
+            [
+                ChargeFactory.create(
+                    case_number="1",
+                    name="Theft of dignity",
+                    disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO),
+                )
+            ]
+        ),
     )
 
     case_partially_eligible = CaseFactory.create(
         case_number="2",
         balance="200.00",
         date_location=["1/1/1995", "Clackamas"],
-        charges=[
-            ChargeFactory.create(
-                case_number="2", disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO),
-            ),
-            ChargeFactory.create(
-                case_number="2",
-                level="Felony Class A",
-                disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO),
-            ),
-        ],
+        charges=tuple(
+            [
+                ChargeFactory.create(
+                    case_number="2", disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO),
+                ),
+                ChargeFactory.create(
+                    case_number="2",
+                    level="Felony Class A",
+                    disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO),
+                ),
+            ]
+        ),
     )
 
     case_possibly_eligible = CaseFactory.create(
         case_number="3",
         balance="300.00",
         date_location=["1/1/1995", "Baker"],
-        charges=[
-            ChargeFactory.create(
-                case_number="3",
-                level="Felony Class B",
-                disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO),
-            )
-        ],
+        charges=tuple(
+            [
+                ChargeFactory.create(
+                    case_number="3",
+                    level="Felony Class B",
+                    disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO),
+                )
+            ]
+        ),
     )
 
     case_all_ineligible = CaseFactory.create(
         case_number="4",
         balance="400.00",
         date_location=["1/1/1995", "Baker"],
-        charges=[
-            ChargeFactory.create(
-                case_number="4",
-                level="Felony Class A",
-                disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO),
-            )
-        ],
+        charges=tuple(
+            [
+                ChargeFactory.create(
+                    case_number="4",
+                    level="Felony Class A",
+                    disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO),
+                )
+            ]
+        ),
     )
 
     case_all_ineligible_2 = CaseFactory.create(
         case_number="5",
         date_location=["1/1/1995", "Baker"],
-        charges=[
-            ChargeFactory.create(
-                case_number="5",
-                level="Felony Class A",
-                disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO),
-            )
-        ],
+        charges=tuple(
+            [
+                ChargeFactory.create(
+                    case_number="5",
+                    level="Felony Class A",
+                    disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO),
+                )
+            ]
+        ),
     )
     record = Record(
-        [case_all_eligible, case_partially_eligible, case_possibly_eligible, case_all_ineligible, case_all_ineligible_2]
+        tuple(
+            [
+                case_all_eligible,
+                case_partially_eligible,
+                case_possibly_eligible,
+                case_all_ineligible,
+                case_all_ineligible_2,
+            ]
+        )
     )
     expunger_result = Expunger.run(record)
 
@@ -100,7 +118,7 @@ def test_record_summarizer_multiple_cases():
 
 
 def test_record_summarizer_no_cases():
-    record = Record([])
+    record = Record(tuple([]))
     record_summary = RecordSummarizer.summarize(record, {})
 
     assert record_summary.total_balance_due == 0.00

--- a/src/backend/tests/serializer/test_serializer.py
+++ b/src/backend/tests/serializer/test_serializer.py
@@ -30,6 +30,6 @@ def _record(request):
 
 
 def test_round_trip_various_records(_record):
-    expunger = Expunger(_record)
-    expunger_result = expunger.run()
+    expunger_result = Expunger.run(_record)
+
     json.loads(json.dumps(_record, cls=ExpungeModelEncoder))

--- a/src/backend/tests/serializer/test_serializer_generative.py
+++ b/src/backend/tests/serializer/test_serializer_generative.py
@@ -11,7 +11,6 @@ from expungeservice.serializer import ExpungeModelEncoder
 @settings(suppress_health_check=[HealthCheck.too_slow])
 @given(build_record_strategy())
 def test_round_trip_various_records(record):
-    expunger = Expunger(record)
-    expunger_result = expunger.run()
+    expunger_result = Expunger.run(record)
     updated_record = RecordMerger.merge([record], [expunger_result])
     json.loads(json.dumps(updated_record, cls=ExpungeModelEncoder))

--- a/src/backend/tests/test_crawler_expunger.py
+++ b/src/backend/tests/test_crawler_expunger.py
@@ -27,9 +27,9 @@ def record_with_open_case():
 
 def test_expunger_with_open_case(record_with_open_case):
     errors = record_with_open_case.errors
-    expunger = Expunger(record_with_open_case)
+    expunger_result = Expunger.run(record_with_open_case)
 
-    assert len(expunger.run()) == 4
+    assert len(expunger_result) == 4
     assert "All charges are ineligible because there is one or more open case" in errors[0]
 
 
@@ -39,8 +39,8 @@ def empty_record():
 
 
 def test_expunger_with_an_empty_record(empty_record):
-    expunger = Expunger(empty_record)
-    assert expunger.run() == {}
+    expunger_result = Expunger.run(empty_record)
+    assert expunger_result == {}
 
 
 @pytest.fixture
@@ -49,8 +49,8 @@ def partial_dispos_record():
 
 
 def test_partial_dispos(partial_dispos_record):
-    expunger = Expunger(partial_dispos_record)
-    assert len(expunger.run()) == 1
+    expunger_result = Expunger.run(partial_dispos_record)
+    assert len(expunger_result) == 1
 
 
 @pytest.fixture
@@ -60,9 +60,9 @@ def record_without_dispos():
 
 def test_case_without_dispos(record_without_dispos):
     errors = record_without_dispos.errors
-    expunger = Expunger(record_without_dispos)
+    expunger_result = Expunger.run(record_without_dispos)
     assert record_without_dispos.cases[0].closed()
-    assert expunger.run() == {}
+    assert expunger_result == {}
     assert errors[0] == (
         f"""Case [{record_without_dispos.cases[0].case_number}] has a charge with a missing disposition.
 This might be an error in the OECI database. Time analysis is ignoring this charge and may be inaccurate for other charges."""
@@ -82,8 +82,8 @@ def record_with_unrecognized_dispo():
 
 def test_case_with_unrecognized_dispo(record_with_unrecognized_dispo):
     errors = record_with_unrecognized_dispo.errors
-    expunger = Expunger(record_with_unrecognized_dispo)
-    assert len(expunger.run()) == 6
+    expunger_result = Expunger.run(record_with_unrecognized_dispo)
+    assert len(expunger_result) == 6
     assert "The following cases have charges with an unrecognized disposition" in errors[0]
 
 
@@ -164,8 +164,8 @@ def record_with_specific_dates():
 
 def test_expunger_runs_time_analyzer(record_with_specific_dates):
     record = record_with_specific_dates
-    expunger = Expunger(record)
-    expunger_result = expunger.run()
+    expunger_result = Expunger.run(record)
+
     assert len(expunger_result) == 9
 
     assert expunger_result[record.cases[0].charges[0].ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
@@ -194,12 +194,13 @@ def record_with_revoked_probation():
 
 def test_probation_revoked_affects_time_eligibility(record_with_revoked_probation):
     record = record_with_revoked_probation
-    expunger = Expunger(record)
-    expunger_result = expunger.run()
+    expunger_result = Expunger.run(record)
+
     assert len(expunger_result) == 6
     assert expunger_result[record.cases[0].charges[0].ambiguous_charge_id].date_will_be_eligible == date_class(
         2020, 11, 9
     )
+
 
 @pytest.fixture
 def record_with_odd_event_table_contents():
@@ -209,8 +210,8 @@ def record_with_odd_event_table_contents():
 
 
 def test_expunger_for_record_with_odd_event_table_contents(record_with_odd_event_table_contents):
-    expunger = Expunger(record_with_odd_event_table_contents)
-    assert expunger.run() == {
+    expunger_result = Expunger.run(record_with_odd_event_table_contents)
+    assert expunger_result == {
         "CASEJD1-1": TimeEligibility(
             status=EligibilityStatus.INELIGIBLE,
             reason="Never. Type ineligible charges are always time ineligible.",

--- a/src/backend/tests/test_friendly_rule.py
+++ b/src/backend/tests/test_friendly_rule.py
@@ -19,8 +19,8 @@ def test_eligible_mrc_with_single_arrest():
 
     arrest = ChargeFactory.create(disposition=DispositionCreator.create(ruling="Dismissed", date=Time.THREE_YEARS_AGO))
 
-    case = CaseFactory.create(charges=[three_yr_mrc, arrest])
-    record = Record([case])
+    case = CaseFactory.create(charges=tuple([three_yr_mrc, arrest]))
+    record = Record(tuple([case]))
     expunger_result = Expunger.run(record)
 
     assert expunger_result[arrest.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
@@ -56,8 +56,8 @@ def test_arrest_is_unaffected_if_conviction_eligibility_is_older():
     )
     arrest = ChargeFactory.create(disposition=DispositionCreator.create(ruling="Dismissed", date=Time.ONE_YEAR_AGO))
 
-    case = CaseFactory.create(charges=[violation_charge, arrest])
-    expunger_result = Expunger.run(Record([case]))
+    case = CaseFactory.create(charges=tuple([violation_charge, arrest]))
+    expunger_result = Expunger.run(Record(tuple([case])))
 
     assert expunger_result[arrest.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
     assert expunger_result[arrest.ambiguous_charge_id].date_will_be_eligible == arrest.date
@@ -79,8 +79,8 @@ def test_eligible_mrc_with_violation():
         case_number="1",
         disposition=DispositionCreator.create(ruling="Convicted", date=Time.THREE_YEARS_AGO),
     )
-    case = CaseFactory.create(case_number="1", charges=[three_yr_mrc, arrest, violation])
-    record = Record([case])
+    case = CaseFactory.create(case_number="1", charges=tuple([three_yr_mrc, arrest, violation]))
+    record = Record(tuple([case]))
     expunger_result = Expunger.run(record)
 
     assert expunger_result[three_yr_mrc.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
@@ -112,8 +112,8 @@ def test_needs_more_analysis_mrc_with_single_arrest():
     )
     arrest = ChargeFactory.create(disposition=DispositionCreator.create(ruling="Dismissed", date=Time.THREE_YEARS_AGO))
 
-    case = CaseFactory.create(charges=[three_yr_mrc, arrest])
-    record = Record([case])
+    case = CaseFactory.create(charges=tuple([three_yr_mrc, arrest]))
+    record = Record(tuple([case]))
     expunger_result = Expunger.run(record)
 
     ten_years_from_mrc = three_yr_mrc.disposition.date + Time.TEN_YEARS
@@ -145,8 +145,8 @@ def test_very_old_needs_more_analysis_mrc_with_single_arrest():
     )
     arrest = ChargeFactory.create(disposition=DispositionCreator.create(ruling="Dismissed", date=Time.THREE_YEARS_AGO))
 
-    case = CaseFactory.create(charges=[mrc, arrest])
-    record = Record([case])
+    case = CaseFactory.create(charges=tuple([mrc, arrest]))
+    record = Record(tuple([case]))
     expunger_result = Expunger.run(record)
 
     three_years_from_mrc = mrc.disposition.date + Time.THREE_YEARS
@@ -176,8 +176,8 @@ def test_arrest_time_eligibility_is_set_to_older_violation():
     )
     arrest = ChargeFactory.create(disposition=DispositionCreator.create(ruling="Dismissed", date=Time.ONE_YEAR_AGO))
 
-    case = CaseFactory.create(charges=[older_violation, newer_violation, arrest])
-    expunger_result = Expunger.run(Record([case]))
+    case = CaseFactory.create(charges=tuple([older_violation, newer_violation, arrest]))
+    expunger_result = Expunger.run(Record(tuple([case])))
 
     assert expunger_result[arrest.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
@@ -208,8 +208,8 @@ def test_3_violations_are_time_restricted():
     )
     arrest = ChargeFactory.create(disposition=DispositionCreator.create(ruling="Dismissed", date=Time.ONE_YEAR_AGO))
 
-    case = CaseFactory.create(charges=[violation_charge_3, violation_charge_2, violation_charge_1, arrest])
-    expunger_result = Expunger.run(Record([case]))
+    case = CaseFactory.create(charges=tuple([violation_charge_3, violation_charge_2, violation_charge_1, arrest]))
+    expunger_result = Expunger.run(Record(tuple([case])))
 
     earliest_date_eligible = min(
         expunger_result[violation_charge_1.ambiguous_charge_id].date_will_be_eligible,

--- a/src/backend/tests/test_friendly_rule.py
+++ b/src/backend/tests/test_friendly_rule.py
@@ -21,8 +21,7 @@ def test_eligible_mrc_with_single_arrest():
 
     case = CaseFactory.create(charges=[three_yr_mrc, arrest])
     record = Record([case])
-    expunger = Expunger(record)
-    expunger_result = expunger.run()
+    expunger_result = Expunger.run(record)
 
     assert expunger_result[arrest.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
     assert (
@@ -58,8 +57,7 @@ def test_arrest_is_unaffected_if_conviction_eligibility_is_older():
     arrest = ChargeFactory.create(disposition=DispositionCreator.create(ruling="Dismissed", date=Time.ONE_YEAR_AGO))
 
     case = CaseFactory.create(charges=[violation_charge, arrest])
-    expunger = Expunger(Record([case]))
-    expunger_result = expunger.run()
+    expunger_result = Expunger.run(Record([case]))
 
     assert expunger_result[arrest.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
     assert expunger_result[arrest.ambiguous_charge_id].date_will_be_eligible == arrest.date
@@ -83,9 +81,8 @@ def test_eligible_mrc_with_violation():
     )
     case = CaseFactory.create(case_number="1", charges=[three_yr_mrc, arrest, violation])
     record = Record([case])
-    expunger = Expunger(record)
+    expunger_result = Expunger.run(record)
 
-    expunger_result = expunger.run()
     assert expunger_result[three_yr_mrc.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
     assert expunger_result[three_yr_mrc.ambiguous_charge_id].reason == "Eligible now"
     assert expunger_result[three_yr_mrc.ambiguous_charge_id].date_will_be_eligible == date.today()
@@ -117,8 +114,7 @@ def test_needs_more_analysis_mrc_with_single_arrest():
 
     case = CaseFactory.create(charges=[three_yr_mrc, arrest])
     record = Record([case])
-    expunger = Expunger(record)
-    expunger_result = expunger.run()
+    expunger_result = Expunger.run(record)
 
     ten_years_from_mrc = three_yr_mrc.disposition.date + Time.TEN_YEARS
     assert expunger_result[arrest.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
@@ -151,8 +147,7 @@ def test_very_old_needs_more_analysis_mrc_with_single_arrest():
 
     case = CaseFactory.create(charges=[mrc, arrest])
     record = Record([case])
-    expunger = Expunger(record)
-    expunger_result = expunger.run()
+    expunger_result = Expunger.run(record)
 
     three_years_from_mrc = mrc.disposition.date + Time.THREE_YEARS
     assert expunger_result[arrest.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
@@ -182,8 +177,7 @@ def test_arrest_time_eligibility_is_set_to_older_violation():
     arrest = ChargeFactory.create(disposition=DispositionCreator.create(ruling="Dismissed", date=Time.ONE_YEAR_AGO))
 
     case = CaseFactory.create(charges=[older_violation, newer_violation, arrest])
-    expunger = Expunger(Record([case]))
-    expunger_result = expunger.run()
+    expunger_result = Expunger.run(Record([case]))
 
     assert expunger_result[arrest.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
@@ -215,8 +209,7 @@ def test_3_violations_are_time_restricted():
     arrest = ChargeFactory.create(disposition=DispositionCreator.create(ruling="Dismissed", date=Time.ONE_YEAR_AGO))
 
     case = CaseFactory.create(charges=[violation_charge_3, violation_charge_2, violation_charge_1, arrest])
-    expunger = Expunger(Record([case]))
-    expunger_result = expunger.run()
+    expunger_result = Expunger.run(Record([case]))
 
     earliest_date_eligible = min(
         expunger_result[violation_charge_1.ambiguous_charge_id].date_will_be_eligible,

--- a/src/backend/tests/test_time_analyzer.py
+++ b/src/backend/tests/test_time_analyzer.py
@@ -37,9 +37,8 @@ class TestSingleChargeDismissals(unittest.TestCase):
         )
         case = CaseFactory.create(charges=[three_yr_conviction, arrest, violation, violation_2])
         record = Record([case])
-        expunger = Expunger(record)
+        expunger_result = Expunger.run(record)
 
-        expunger_result = expunger.run()
         assert expunger_result[three_yr_conviction.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[three_yr_conviction.ambiguous_charge_id].reason
@@ -69,8 +68,8 @@ class TestSingleChargeDismissals(unittest.TestCase):
         )
         case = CaseFactory.create(charges=[mrc, arrest])
         record = Record([case])
-        expunger = Expunger(record)
-        expunger_result = expunger.run()
+        expunger_result = Expunger.run(record)
+
         assert expunger_result[arrest.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[arrest.ambiguous_charge_id].reason
@@ -89,8 +88,7 @@ class TestSingleChargeDismissals(unittest.TestCase):
         )
         case = CaseFactory.create(charges=[charge])
         record = Record([case])
-        expunger = Expunger(record)
-        expunger_result = expunger.run()
+        expunger_result = Expunger.run(record)
 
         assert expunger_result[charge.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
         assert expunger_result[charge.ambiguous_charge_id].reason == "Eligible now"
@@ -107,8 +105,7 @@ class TestSingleChargeDismissals(unittest.TestCase):
         )
         case = CaseFactory.create(charges=[ten_yr_charge, three_yr_mrc])
         record = Record([case])
-        expunger = Expunger(record)
-        expunger_result = expunger.run()
+        expunger_result = Expunger.run(record)
 
         assert expunger_result[ten_yr_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
@@ -136,8 +133,7 @@ class TestSingleChargeDismissals(unittest.TestCase):
         )
         case = CaseFactory.create(charges=[ten_yr_charge, less_than_three_yr_mrc])
         record = Record([case])
-        expunger = Expunger(record)
-        expunger_result = expunger.run()
+        expunger_result = Expunger.run(record)
 
         assert expunger_result[ten_yr_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
@@ -164,8 +160,7 @@ class TestSingleChargeDismissals(unittest.TestCase):
         )
         case = CaseFactory.create(charges=[charge])
         record = Record([case])
-        expunger = Expunger(record)
-        expunger_result = expunger.run()
+        expunger_result = Expunger.run(record)
 
         assert expunger_result[charge.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
         assert expunger_result[charge.ambiguous_charge_id].reason == "Eligible now"
@@ -177,8 +172,7 @@ class TestSingleChargeDismissals(unittest.TestCase):
         )
         case = CaseFactory.create(charges=[charge])
         record = Record([case])
-        expunger = Expunger(record)
-        expunger_result = expunger.run()
+        expunger_result = Expunger.run(record)
 
         assert expunger_result[charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
@@ -198,8 +192,7 @@ class TestSingleChargeDismissals(unittest.TestCase):
         )
         case = CaseFactory.create(charges=[charge])
         record = Record([case])
-        expunger = Expunger(record)
-        expunger_result = expunger.run()
+        expunger_result = Expunger.run(record)
 
         assert expunger_result[charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
@@ -216,8 +209,7 @@ class TestDismissalBlock(unittest.TestCase):
 
     def test_record_with_only_an_mrd_is_time_eligible(self):
         record = Record([self.case_1])
-        expunger = Expunger(record)
-        expunger_result = expunger.run()
+        expunger_result = Expunger.run(record)
 
         assert expunger_result[self.recent_dismissal.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
         assert expunger_result[self.recent_dismissal.ambiguous_charge_id].reason == "Eligible now"
@@ -230,8 +222,7 @@ class TestDismissalBlock(unittest.TestCase):
         self.case_1.charges.append(case_related_dismissal)
 
         record = Record([self.case_1])
-        expunger = Expunger(record)
-        expunger_result = expunger.run()
+        expunger_result = Expunger.run(record)
 
         assert expunger_result[self.recent_dismissal.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
         assert expunger_result[self.recent_dismissal.ambiguous_charge_id].reason == "Eligible now"
@@ -248,8 +239,7 @@ class TestDismissalBlock(unittest.TestCase):
         case_2 = CaseFactory.create(case_number="2", charges=[unrelated_dismissal])
 
         record = Record([self.case_1, case_2])
-        expunger = Expunger(record)
-        expunger_result = expunger.run()
+        expunger_result = Expunger.run(record)
 
         assert expunger_result[unrelated_dismissal.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
@@ -266,8 +256,7 @@ class TestDismissalBlock(unittest.TestCase):
         case = CaseFactory.create(charges=[convicted_charge])
 
         record = Record([self.case_1, case])
-        expunger = Expunger(record)
-        expunger_result = expunger.run()
+        expunger_result = Expunger.run(record)
 
         assert expunger_result[convicted_charge.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
         assert expunger_result[convicted_charge.ambiguous_charge_id].reason == "Eligible now"
@@ -280,8 +269,7 @@ class TestSecondMRCLogic(unittest.TestCase):
     def run_expunger(self, mrc, second_mrc):
         case = CaseFactory.create(charges=[mrc, second_mrc])
         record = Record([case])
-        expunger = Expunger(record)
-        return expunger.run()
+        return Expunger.run(record)
 
     def test_3_yr_old_conviction_2_yr_old_mrc(self):
         three_years_ago_charge = ChargeFactory.create(
@@ -371,8 +359,7 @@ def create_class_b_felony_charge(case_number, date, ruling="Convicted"):
 def test_felony_class_b_greater_than_20yrs():
     charge = create_class_b_felony_charge("1", Time.TWENTY_YEARS_AGO)
     case = CaseFactory.create(charges=[charge])
-    expunger = Expunger(Record([case]))
-    expunger_result = expunger.run()
+    expunger_result = Expunger.run(Record([case]))
 
     assert expunger_result[charge.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
     assert expunger_result[charge.ambiguous_charge_id].reason == "Eligible now"
@@ -382,8 +369,7 @@ def test_felony_class_b_greater_than_20yrs():
 def test_felony_class_b_less_than_20yrs():
     charge = create_class_b_felony_charge("1", Time.LESS_THAN_TWENTY_YEARS_AGO)
     case = CaseFactory.create(charges=[charge])
-    expunger = Expunger(Record([case]))
-    expunger_result = expunger.run()
+    expunger_result = Expunger.run(Record([case]))
 
     assert expunger_result[charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
@@ -401,8 +387,7 @@ def test_felony_class_b_with_subsequent_conviction():
     )
     case_2 = CaseFactory.create(case_number="2", charges=[subsequent_charge])
 
-    expunger = Expunger(Record([case_1, case_2]))
-    expunger_result = expunger.run()
+    expunger_result = Expunger.run(Record([case_1, case_2]))
 
     assert expunger_result[b_felony_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
@@ -424,8 +409,7 @@ def test_felony_class_b_with_prior_conviction():
     )
     case_2 = CaseFactory.create(case_number="2", charges=[prior_charge])
 
-    expunger = Expunger(Record([case_1, case_2]))
-    expunger_result = expunger.run()
+    expunger_result = Expunger.run(Record([case_1, case_2]))
 
     assert b_felony_charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
     assert (
@@ -444,8 +428,7 @@ def test_dismissed_felony_class_b_with_subsequent_conviction():
     )
     case_2 = CaseFactory.create(case_number="2", charges=[subsequent_charge])
 
-    expunger = Expunger(Record([case_1, case_2]))
-    expunger_result = expunger.run()
+    expunger_result = Expunger.run(Record([case_1, case_2]))
 
     assert b_felony_charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
     assert expunger_result[b_felony_charge.ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
@@ -472,10 +455,8 @@ def test_doubly_eligible_b_felony_gets_normal_eligibility_rule():
 
     possible_record_1 = Record([case_1a, case_2])
     possible_record_2 = Record([case_1b, case_2])
-    expunger = Expunger(possible_record_1)
-    expunger_result_1 = expunger.run()
-    expunger = Expunger(possible_record_2)
-    expunger_result_2 = expunger.run()
+    expunger_result_1 = Expunger.run(possible_record_1)
+    expunger_result_2 = Expunger.run(possible_record_2)
 
     assert manudel_type_eligilibility.status is EligibilityStatus.ELIGIBLE
     assert expunger_result_1[manudel_charges[0].ambiguous_charge_id].status is EligibilityStatus.ELIGIBLE
@@ -491,8 +472,7 @@ def test_single_violation_is_time_restricted():
     )
 
     case = CaseFactory.create(charges=[violation_charge])
-    expunger = Expunger(Record([case]))
-    expunger_result = expunger.run()
+    expunger_result = Expunger.run(Record([case]))
 
     assert expunger_result[violation_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
@@ -517,8 +497,7 @@ def test_2_violations_are_time_restricted():
     )
 
     case = CaseFactory.create(charges=[violation_charge_1, violation_charge_2])
-    expunger = Expunger(Record([case]))
-    expunger_result = expunger.run()
+    expunger_result = Expunger.run(Record([case]))
 
     assert expunger_result[violation_charge_1.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
@@ -559,8 +538,7 @@ def test_3_violations_are_time_restricted():
     )
 
     case = CaseFactory.create(charges=[violation_charge_3, violation_charge_2, violation_charge_1])
-    expunger = Expunger(Record([case]))
-    expunger_result = expunger.run()
+    expunger_result = Expunger.run(Record([case]))
 
     assert expunger_result[violation_charge_1.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
@@ -605,8 +583,7 @@ def test_nonblocking_charge_is_not_skipped_and_does_not_block():
     )
 
     case = CaseFactory.create(charges=[civil_offense, violation_charge])
-    expunger = Expunger(Record([case]))
-    expunger_result = expunger.run()
+    expunger_result = Expunger.run(Record([case]))
 
     assert expunger_result[civil_offense.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (


### PR DESCRIPTION
This completes the refactor to make Record a frozen dataclass: since Expunger.run is now completely side-effect free, we can apply a cache over it.

Additionally adjust _without_skippable_charges so that it returns a new Record: this ensures that the removed charges are also removed from their corresponding cases. This caused a rare bug in the friendly rule implementation for juvenile charges.

Relative to #1010 