### PR TITLE
Add a LRU cache to Expunger.run

### DIFF
--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -1,5 +1,6 @@
 from dataclasses import replace
 from datetime import date
+from functools import lru_cache
 from typing import Set, List, Iterator, Tuple, Dict
 
 from dateutil.relativedelta import relativedelta
@@ -16,6 +17,7 @@ from expungeservice.models.record import Record
 
 class Expunger:
     @staticmethod
+    @lru_cache(maxsize=32)
     def run(record: Record) -> Dict[str, TimeEligibility]:
         """
         Evaluates the expungement eligibility of a record.


### PR DESCRIPTION
This will speed up the disambiguate endpoint. For a certain median-ish size record of 20 charges, the disambiguate endpoint went from 400ms to 133ms.

Relative to #1011 

Relates to https://github.com/codeforpdx/recordexpungPDX/issues/972