### PR TITLE
Frontend questions feature

### DIFF
--- a/src/frontend/src/components/RecordSearch/Record/Cases.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Cases.tsx
@@ -8,7 +8,6 @@ interface Props {
 
 export default class Cases extends React.Component<Props> {
   render() {
-    console.log('cases', this.props.cases);
     const allCases = this.props.cases.map((caseInstance, index) => {
       return (
         <li key={index}>

--- a/src/frontend/src/components/RecordSearch/Record/Charge.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Charge.tsx
@@ -86,7 +86,7 @@ export default class Charge extends React.Component<Props> {
             </ul>
           </div>
         </div>
-        <Question ambiguous_charge_id= {this.props.charge.ambiguous_charge_id}/>
+        <Question ambiguous_charge_id= {ambiguous_charge_id}/>
       </div>
     );
   }

--- a/src/frontend/src/components/RecordSearch/Record/Charge.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Charge.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Eligibility from './Eligibility';
 import TimeEligibility from './TimeEligibility';
 import TypeEligibility from './TypeEligibility';
+import Question from './Question';
 import { ChargeData } from './types';
 
 interface Props {
@@ -11,6 +12,7 @@ interface Props {
 export default class Charge extends React.Component<Props> {
   render() {
     const {
+      ambiguous_charge_id,
       date,
       disposition,
       statute,
@@ -18,7 +20,6 @@ export default class Charge extends React.Component<Props> {
       type_name,
       expungement_result
     } = this.props.charge;
-
 
     const dispositionEvent = (disposition: any, date: any) => {
       let dispositionEvent;
@@ -85,6 +86,7 @@ export default class Charge extends React.Component<Props> {
             </ul>
           </div>
         </div>
+        <Question ambiguous_charge_id= {this.props.charge.ambiguous_charge_id}/>
       </div>
     );
   }

--- a/src/frontend/src/components/RecordSearch/Record/Question.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Question.tsx
@@ -9,39 +9,45 @@ interface Props {
   question?: QuestionData;
 }
 
-interface State {
-  selected_answer: string
-}
+class Question extends React.Component<Props> {
 
-class Question extends React.Component<Props, State> {
-
-  state = {
-    selected_answer: (
-    this.props.question ?
-    this.props.question.selected_answer :
-    "")
+  handleRadioChange = (e: React.BaseSyntheticEvent) => {
+    store.dispatch(selectAnswer(e.target.name, e.target.value))
   };
 
   render() {
-    return ( this.props.question ?
-      (
-        <div>
-          <div>Question</div>
-          <button
-            onClick={() => {
-              console.log("clicked");
-              store.dispatch(selectAnswer("15PK267144-1", "clicked for jordan"));
-              store.dispatch(selectAnswer("900633651-1", "clicked answer"));
-            }}
-                type="button">
-                    Alias
-          </button>
-          {"state: " + this.state.selected_answer}
-          {"props: " + this.props.question.selected_answer}
-
+    if (this.props.question) {
+    const options : {[option: string] : string} = this.props.question.options;
+    return (
+        <div className="flex-l items-start justify-between w-100 bt bw3 b--light-purple pt3">
+          <div>
+            <fieldset className="mb4">
+              <legend className="fw7">{this.props.question.question}</legend>
+              <div className="radio">
+                {Object.keys(options).map(
+                  (option_str :string)=>{
+                    const id : string = this.props.ambiguous_charge_id + options[option_str];
+                  return (
+                    <div key={id}>
+                    <input
+                      type="radio"
+                      name={this.props.ambiguous_charge_id}
+                      id={id}
+                      value={options[option_str]}
+                      onChange={this.handleRadioChange}
+                      />
+                    <label htmlFor={id}>{option_str}</label>
+                    </div>
+                    )
+                })}
+              </div>
+            </fieldset>
+          </div>
         </div>
-      ): null
-      );
+      )
+    } else {
+      return (<div></div>);
+    }
   }
 }
 
@@ -50,7 +56,6 @@ function mapStateToProps(state: AppState, ownProps: Props) {
   if (state.search.questions &&
     state.search.questions[ownProps.ambiguous_charge_id]) {
       question = state.search.questions[ownProps.ambiguous_charge_id];
-      console.log("with question");
       return {
         ambiguous_charge_id: ownProps.ambiguous_charge_id,
         question: question
@@ -60,8 +65,6 @@ function mapStateToProps(state: AppState, ownProps: Props) {
         ambiguous_charge_id: ownProps.ambiguous_charge_id,
        };
     }
-
-
 }
 
 

--- a/src/frontend/src/components/RecordSearch/Record/Question.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Question.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { QuestionData } from './types';
+import {QuestionData} from './types';
 import {selectAnswer} from '../../../redux/search/actions';
-import store, { AppState } from '../../../redux/store';
-import { connect } from 'react-redux';
+import store, {AppState} from '../../../redux/store';
+import {connect} from 'react-redux';
 
 interface Props {
   ambiguous_charge_id: string;
@@ -17,32 +17,26 @@ class Question extends React.Component<Props> {
 
   render() {
     if (this.props.question) {
-    const options : {[option: string] : string} = this.props.question.options;
-    return (
+      const options: { [option: string]: string } = this.props.question.options;
+      return (
         <div className="flex-l items-start justify-between w-100 bt bw3 b--light-purple pt3">
-          <div>
-            <fieldset className="mb4">
-              <legend className="fw7">{this.props.question.question}</legend>
-              <div className="radio">
-                {Object.keys(options).map(
-                  (option_str :string)=>{
-                    const id : string = this.props.ambiguous_charge_id + options[option_str];
-                  return (
-                    <div key={id}>
-                    <input
-                      type="radio"
-                      name={this.props.ambiguous_charge_id}
-                      id={id}
-                      value={options[option_str]}
-                      onChange={this.handleRadioChange}
-                      />
-                    <label htmlFor={id}>{option_str}</label>
-                    </div>
-                    )
-                })}
+        <div>
+        <fieldset className="mb4">
+        <legend className="fw7">{this.props.question.question}</legend>
+        <div className="radio">
+        {Object.keys(options).map(
+          (option_str: string) => {
+            const id: string = this.props.ambiguous_charge_id + options[option_str];
+            return (
+              <div key={id}>
+              <input type="radio" name={this.props.ambiguous_charge_id} id={id} value={options[option_str]} onChange={this.handleRadioChange}/>
+              <label htmlFor={id}>{option_str}</label>
               </div>
-            </fieldset>
-          </div>
+            )
+          })}
+        </div>
+        </fieldset>
+        </div>
         </div>
       )
     } else {
@@ -52,26 +46,26 @@ class Question extends React.Component<Props> {
 }
 
 function mapStateToProps(state: AppState, ownProps: Props) {
-  let question : QuestionData;
+  let question: QuestionData;
   if (state.search.questions &&
     state.search.questions[ownProps.ambiguous_charge_id]) {
-      question = state.search.questions[ownProps.ambiguous_charge_id];
-      return {
-        ambiguous_charge_id: ownProps.ambiguous_charge_id,
-        question: question
-       };
-    } else {
-      return {
-        ambiguous_charge_id: ownProps.ambiguous_charge_id,
-       };
-    }
+    question = state.search.questions[ownProps.ambiguous_charge_id];
+    return {
+      ambiguous_charge_id: ownProps.ambiguous_charge_id,
+      question: question
+    };
+  } else {
+    return {
+      ambiguous_charge_id: ownProps.ambiguous_charge_id,
+    };
+  }
 }
 
 
 export default connect(
   mapStateToProps,
   {
-    selectAnswer : selectAnswer
+    selectAnswer: selectAnswer
   }
 )(Question);
 

--- a/src/frontend/src/components/RecordSearch/Record/Question.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Question.tsx
@@ -47,7 +47,7 @@ class Question extends React.Component<Props> {
         </div>
       )
     } else {
-      return (<div></div>);
+      return (<></>);
     }
   }
 }

--- a/src/frontend/src/components/RecordSearch/Record/Question.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Question.tsx
@@ -19,24 +19,26 @@ class Question extends React.Component<Props> {
     if (this.props.question) {
       const options: { [option: string]: string } = this.props.question.options;
       return (
-        <div className="flex-l items-start justify-between w-100 bt bw3 b--light-purple pt3">
-        <div>
-        <fieldset className="mb4">
-        <legend className="fw7">{this.props.question.question}</legend>
-        <div className="radio">
-        {Object.keys(options).map(
-          (option_str: string) => {
-            const id: string = this.props.ambiguous_charge_id + options[option_str];
-            return (
-              <div key={id}>
-              <input type="radio" name={this.props.ambiguous_charge_id} id={id} value={options[option_str]} onChange={this.handleRadioChange}/>
-              <label htmlFor={id}>{option_str}</label>
-              </div>
-            )
-          })}
-        </div>
-        </fieldset>
-        </div>
+        <div className="w-100 bt bw3 b--light-purple pa3 pb1">
+          <fieldset className="relative mb4">
+            <legend className="fw7 mb2">{this.props.question.question}</legend>
+            <div className="radio">
+            {Object.keys(options).map(
+              (option_str: string) => {
+                const id: string = this.props.ambiguous_charge_id + options[option_str];
+                return (
+                  <div className="dib" key={id}>
+                  <input type="radio" name={this.props.ambiguous_charge_id} id={id} value={options[option_str]} onChange={this.handleRadioChange}/>
+                  <label htmlFor={id}>{option_str}</label>
+                  </div>
+                )
+              })}
+            </div>
+            <div className="radio-spinner absolute" role="status">
+              <span className="spinner spinner--sm mr1"></span>
+              <span className="f6 fw5">Updating&#8230;</span>
+            </div>
+          </fieldset>
         </div>
       )
     } else {

--- a/src/frontend/src/components/RecordSearch/Record/Question.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Question.tsx
@@ -7,6 +7,7 @@ import {connect} from 'react-redux';
 interface Props {
   ambiguous_charge_id: string;
   question?: QuestionData;
+  loading?: boolean;
 }
 
 class Question extends React.Component<Props> {
@@ -34,10 +35,14 @@ class Question extends React.Component<Props> {
                 )
               })}
             </div>
-            <div className="radio-spinner absolute" role="status">
-              <span className="spinner spinner--sm mr1"></span>
-              <span className="f6 fw5">Updating&#8230;</span>
-            </div>
+            {(this.props.loading ?
+              <div className="radio-spinner absolute" role="status">
+                <span className="spinner spinner--sm mr1"></span>
+                <span className="f6 fw5">Updating&#8230;</span>
+              </div> :
+                null
+              )
+            }
           </fieldset>
         </div>
       )
@@ -54,7 +59,8 @@ function mapStateToProps(state: AppState, ownProps: Props) {
     question = state.search.questions[ownProps.ambiguous_charge_id];
     return {
       ambiguous_charge_id: ownProps.ambiguous_charge_id,
-      question: question
+      question: question,
+      loading: state.search.loading,
     };
   } else {
     return {

--- a/src/frontend/src/components/RecordSearch/Record/Question.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Question.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { QuestionData } from './types';
+import {selectAnswer} from '../../../redux/search/actions';
+import store, { AppState } from '../../../redux/store';
+import { connect } from 'react-redux';
+
+interface Props {
+  ambiguous_charge_id: string;
+  question?: QuestionData;
+}
+
+interface State {
+  selected_answer: string
+}
+
+class Question extends React.Component<Props, State> {
+
+  state = {
+    selected_answer: (
+    this.props.question ?
+    this.props.question.selected_answer :
+    "")
+  };
+
+  render() {
+    return ( this.props.question ?
+      (
+        <div>
+          <div>Question</div>
+          <button
+            onClick={() => {
+              console.log("clicked");
+              store.dispatch(selectAnswer("15PK267144-1", "clicked for jordan"));
+              store.dispatch(selectAnswer("900633651-1", "clicked answer"));
+            }}
+                type="button">
+                    Alias
+          </button>
+          {"state: " + this.state.selected_answer}
+          {"props: " + this.props.question.selected_answer}
+
+        </div>
+      ): null
+      );
+  }
+}
+
+function mapStateToProps(state: AppState, ownProps: Props) {
+  let question : QuestionData;
+  if (state.search.questions &&
+    state.search.questions[ownProps.ambiguous_charge_id]) {
+      question = state.search.questions[ownProps.ambiguous_charge_id];
+      console.log("with question");
+      return {
+        ambiguous_charge_id: ownProps.ambiguous_charge_id,
+        question: question
+       };
+    } else {
+      return {
+        ambiguous_charge_id: ownProps.ambiguous_charge_id,
+       };
+    }
+
+
+}
+
+
+export default connect(
+  mapStateToProps,
+  {
+    selectAnswer : selectAnswer
+  }
+)(Question);
+

--- a/src/frontend/src/components/RecordSearch/Record/QuestionsBanner.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/QuestionsBanner.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { QuestionsData } from './types';
+import { AppState } from '../../../redux/store';
+import { connect } from 'react-redux';
+
+interface Props {
+  questions?: QuestionsData;
+}
+
+class QuestionsBanner extends React.Component<Props> {
+
+  getQuestionCases() : {[caseId: string]: boolean} {
+    let questionCaseIds : {[caseId: string]: boolean} = {};
+    if (this.props.questions) {
+        const re = /(.*)-[^-]*/;
+        let res: string[] | null = [];
+        let caseId: string;
+        let answered: boolean;
+        for (const ambiguousChargeId of Object.keys(this.props.questions)) {
+            res = re.exec(ambiguousChargeId);
+            caseId = res && res[1] ? res[1] : "";
+            answered = ((caseId!=="") && (this.props.questions[ambiguousChargeId]["answer"] !==""));
+            if (caseId !== ""){
+                if(!Object.keys(questionCaseIds).includes(caseId) || questionCaseIds[caseId]) {
+                    questionCaseIds[caseId] = answered;
+                }
+            }
+        }
+    }
+        return questionCaseIds;
+  }
+
+  renderCases() {
+      const questionCases: {[caseId: string]: boolean} = this.getQuestionCases();
+      return Object.keys(questionCases).map((caseId: string)=>{
+          if (questionCases[caseId]) {
+              return (
+                  <li className="mb2" key={"qb-"+caseId}>
+                    <span className="visually-hidden">Case resolved</span>
+                    <span className="fas fa-check green pr1" aria-hidden="true"></span>
+                    <a className="underline" href={"#"+caseId}>{caseId}</a>
+                    </li>
+                )
+          } else {
+              return (
+              <li className="mb2" key={"qb-"+caseId}>
+                    <span className="fas fa-question-circle purple pr1" aria-hidden="true"></span>
+                    <a className="underline" href={"#"+caseId}>{caseId}</a>
+                </li>
+                )
+          }
+    })
+  }
+
+  render() {
+    if (Object.keys(this.props.questions) > 0 ) {
+    return (
+        <div className="bt bw3 b--light-purple bg-white shadow pa3 mb3">
+            <div className="flex-lg justify-between">
+                <div className="mb3 pr5-lg mb0-ns">
+                    <p className="fw7 mb3">These cases need clarification before an accurate analysis can be determined</p>
+                    <ul className="list">
+                        {this.renderCases()}
+                    </ul>
+                </div>
+            </div>
+        </div>
+        ) } else {
+        return <div></div>
+    }
+}
+}
+
+function mapStateToProps(state: AppState, ownProps: Props) {
+  return {
+    questions: state.search.questions,
+   };
+}
+
+export default connect(
+  mapStateToProps
+)(QuestionsBanner);
+

--- a/src/frontend/src/components/RecordSearch/Record/QuestionsBanner.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/QuestionsBanner.tsx
@@ -9,46 +9,46 @@ interface Props {
 
 class QuestionsBanner extends React.Component<Props> {
 
-  getQuestionCases(): { [caseId: string]: boolean } {
-    let questionCaseIds: { [caseId: string]: boolean } = {};
+  getQuestionCaseNumbers(): { [caseNumber: string]: boolean } {
+    let questionCaseNumbers: { [caseNumber: string]: boolean } = {};
     if (this.props.questions) {
-      const re = /(.*)-[^-]*/;
-      let res: string[] | null = [];
-      let caseId: string;
+      let caseNumber: string;
       let answered: boolean;
       for (const ambiguousChargeId of Object.keys(this.props.questions)) {
-        res = re.exec(ambiguousChargeId);
-        caseId = res && res[1] ? res[1] : "";
-        answered = ((caseId !== "") && (this.props.questions[ambiguousChargeId]["answer"] !== ""));
-        if (caseId !== "") {
-          if (!Object.keys(questionCaseIds).includes(caseId) || questionCaseIds[caseId]) {
-            questionCaseIds[caseId] = answered;
-          }
+        caseNumber = this.props.questions[ambiguousChargeId]["case_number"];
+        answered = this.props.questions[ambiguousChargeId]["answer"] !== "";
+        if (!Object.keys(questionCaseNumbers).includes(caseNumber) || questionCaseNumbers[caseNumber]) {
+          questionCaseNumbers[caseNumber] = answered;
         }
       }
     }
-    return questionCaseIds;
+    return questionCaseNumbers;
+  }
+
+  renderStatus(answered: boolean) {
+    if (answered) {
+      return (
+        <>
+          <span className="visually-hidden">Case resolved</span>
+          <span className="fas fa-check green pr1" aria-hidden="true"></span>
+        </>
+      )
+    } else {
+      return (
+        <span className="fas fa-question-circle purple pr1" aria-hidden="true"></span>
+      )
+    }
   }
 
   renderCases() {
-    const questionCases: { [caseId: string]: boolean } = this.getQuestionCases();
-    return Object.keys(questionCases).map((caseId: string) => {
-      if (questionCases[caseId]) {
-        return (
-          <li className="mb2" key={"qb-" + caseId}>
-          <span className="visually-hidden">Case resolved</span>
-          <span className="fas fa-check green pr1" aria-hidden="true"></span>
-          <a className="underline" href={"#" + caseId}>{caseId}</a>
-          </li>
+    const questionCasesNumbers: { [caseNumber: string]: boolean } = this.getQuestionCaseNumbers();
+    return Object.keys(questionCasesNumbers).map((caseNumber: string) => {
+      return (
+        <li className="mb2" key={"qb-" + caseNumber}>
+          {this.renderStatus(questionCasesNumbers[caseNumber])}
+          <a className="underline" href={"#" + caseNumber}>{caseNumber}</a>
+        </li>
         )
-      } else {
-        return (
-          <li className="mb2" key={"qb-" + caseId}>
-          <span className="fas fa-question-circle purple pr1" aria-hidden="true"></span>
-          <a className="underline" href={"#" + caseId}>{caseId}</a>
-          </li>
-        )
-      }
     })
   }
 

--- a/src/frontend/src/components/RecordSearch/Record/QuestionsBanner.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/QuestionsBanner.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { QuestionsData } from './types';
-import { AppState } from '../../../redux/store';
-import { connect } from 'react-redux';
+import {QuestionsData} from './types';
+import {AppState} from '../../../redux/store';
+import {connect} from 'react-redux';
 
 interface Props {
   questions?: QuestionsData;
@@ -9,72 +9,73 @@ interface Props {
 
 class QuestionsBanner extends React.Component<Props> {
 
-  getQuestionCases() : {[caseId: string]: boolean} {
-    let questionCaseIds : {[caseId: string]: boolean} = {};
+  getQuestionCases(): { [caseId: string]: boolean } {
+    let questionCaseIds: { [caseId: string]: boolean } = {};
     if (this.props.questions) {
-        const re = /(.*)-[^-]*/;
-        let res: string[] | null = [];
-        let caseId: string;
-        let answered: boolean;
-        for (const ambiguousChargeId of Object.keys(this.props.questions)) {
-            res = re.exec(ambiguousChargeId);
-            caseId = res && res[1] ? res[1] : "";
-            answered = ((caseId!=="") && (this.props.questions[ambiguousChargeId]["answer"] !==""));
-            if (caseId !== ""){
-                if(!Object.keys(questionCaseIds).includes(caseId) || questionCaseIds[caseId]) {
-                    questionCaseIds[caseId] = answered;
-                }
-            }
+      const re = /(.*)-[^-]*/;
+      let res: string[] | null = [];
+      let caseId: string;
+      let answered: boolean;
+      for (const ambiguousChargeId of Object.keys(this.props.questions)) {
+        res = re.exec(ambiguousChargeId);
+        caseId = res && res[1] ? res[1] : "";
+        answered = ((caseId !== "") && (this.props.questions[ambiguousChargeId]["answer"] !== ""));
+        if (caseId !== "") {
+          if (!Object.keys(questionCaseIds).includes(caseId) || questionCaseIds[caseId]) {
+            questionCaseIds[caseId] = answered;
+          }
         }
+      }
     }
-        return questionCaseIds;
+    return questionCaseIds;
   }
 
   renderCases() {
-      const questionCases: {[caseId: string]: boolean} = this.getQuestionCases();
-      return Object.keys(questionCases).map((caseId: string)=>{
-          if (questionCases[caseId]) {
-              return (
-                  <li className="mb2" key={"qb-"+caseId}>
-                    <span className="visually-hidden">Case resolved</span>
-                    <span className="fas fa-check green pr1" aria-hidden="true"></span>
-                    <a className="underline" href={"#"+caseId}>{caseId}</a>
-                    </li>
-                )
-          } else {
-              return (
-              <li className="mb2" key={"qb-"+caseId}>
-                    <span className="fas fa-question-circle purple pr1" aria-hidden="true"></span>
-                    <a className="underline" href={"#"+caseId}>{caseId}</a>
-                </li>
-                )
-          }
+    const questionCases: { [caseId: string]: boolean } = this.getQuestionCases();
+    return Object.keys(questionCases).map((caseId: string) => {
+      if (questionCases[caseId]) {
+        return (
+          <li className="mb2" key={"qb-" + caseId}>
+          <span className="visually-hidden">Case resolved</span>
+          <span className="fas fa-check green pr1" aria-hidden="true"></span>
+          <a className="underline" href={"#" + caseId}>{caseId}</a>
+          </li>
+        )
+      } else {
+        return (
+          <li className="mb2" key={"qb-" + caseId}>
+          <span className="fas fa-question-circle purple pr1" aria-hidden="true"></span>
+          <a className="underline" href={"#" + caseId}>{caseId}</a>
+          </li>
+        )
+      }
     })
   }
 
   render() {
-    if (this.props.questions && Object.keys(this.props.questions).length > 0 ) {
-    return (
+    if (this.props.questions && Object.keys(this.props.questions).length > 0) {
+      return (
         <div className="bt bw3 b--light-purple bg-white shadow pa3 mb3">
-            <div className="flex-lg justify-between">
-                <div className="mb3 pr5-lg mb0-ns">
-                    <p className="fw7 mb3">These cases need clarification before an accurate analysis can be determined</p>
-                    <ul className="list">
-                        {this.renderCases()}
-                    </ul>
-                </div>
-            </div>
+        <div className="flex-lg justify-between">
+        <div className="mb3 pr5-lg mb0-ns">
+        <p className="fw7 mb3">These cases need clarification before an accurate analysis can be determined</p>
+        <ul className="list">
+        {this.renderCases()}
+        </ul>
         </div>
-        ) } else {
-        return <div></div>
+        </div>
+        </div>
+      )
+    } else {
+      return <div></div>
     }
-}
+  }
 }
 
 function mapStateToProps(state: AppState, ownProps: Props) {
   return {
     questions: state.search.questions,
-   };
+  };
 }
 
 export default connect(

--- a/src/frontend/src/components/RecordSearch/Record/QuestionsBanner.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/QuestionsBanner.tsx
@@ -53,7 +53,7 @@ class QuestionsBanner extends React.Component<Props> {
   }
 
   render() {
-    if (Object.keys(this.props.questions) > 0 ) {
+    if (this.props.questions && Object.keys(this.props.questions).length > 0 ) {
     return (
         <div className="bt bw3 b--light-purple bg-white shadow pa3 mb3">
             <div className="flex-lg justify-between">

--- a/src/frontend/src/components/RecordSearch/Record/RecordSummary/CaseNumbersList.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/RecordSummary/CaseNumbersList.tsx
@@ -12,7 +12,7 @@ export default class CaseNumbersList extends React.Component<Props> {
     const listItems = this.props.cases.map(((caseNumber:string, index:number) => {
       const id = "summary_li_" + caseNumber;
       return (
-        <li className="mb2" id={id}>
+        <li className="mb2" id={id} key={id}>
           <a href={"#" + caseNumber} className="underline">{caseNumber}</a>
         </li>
         )

--- a/src/frontend/src/components/RecordSearch/Record/RecordSummary/ChargesList.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/RecordSummary/ChargesList.tsx
@@ -13,14 +13,14 @@ export default class ChargesList extends React.Component<Props> {
       const listItems = this.buildListItems(chargesNames);
       const labelColor = (eligibilityDate==="now" ? "green" : "dark-blue");
       return (
-        <>
-          <div key={index} className="mb1">
+        <div key={index}>
+          <div className="mb1">
             <span className={"fw8 mb2 " + labelColor}> {"Eligible " + eligibilityDate} </span> <span className="fw8">{(chargesNames.length > 0 ? "(" + chargesNames.length + ")" : "" )}</span>
           </div>
           <ul className="list mb3">
            {listItems}
           </ul>
-        </>
+        </div>
       )
     }));
 

--- a/src/frontend/src/components/RecordSearch/Record/RecordSummary/ChargesList.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/RecordSummary/ChargesList.tsx
@@ -15,7 +15,7 @@ export default class ChargesList extends React.Component<Props> {
       return (
         <div key={index}>
           <div className="mb1">
-            <span className={"fw8 mb2 " + labelColor}> {"Eligible " + eligibilityDate} </span> <span className="fw8">{(chargesNames.length > 0 ? "(" + chargesNames.length + ")" : "" )}</span>
+            <span className={"fw7 ttc mb2 " + labelColor}> {"Eligible " + eligibilityDate} </span> <span>{(chargesNames.length > 0 ? "(" + chargesNames.length + ")" : "" )}</span>
           </div>
           <ul className="list mb3">
            {listItems}
@@ -26,7 +26,7 @@ export default class ChargesList extends React.Component<Props> {
 
     return (
       <div className="w-100 w-50-ns w-33-l br-ns b--light-gray ph3-m ph3-l mb3">
-        <h3 className="bt b--light-gray pt2 mb3"><span className="fw7">Charges</span> {this.props.totalCharges}</h3>
+        <h3 className="bt b--light-gray pt2 mb3"><span className="fw7">Charges</span> ({this.props.totalCharges})</h3>
         {summarizedCharges}
       </div>
     );

--- a/src/frontend/src/components/RecordSearch/Record/index.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/index.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import Cases from './Cases';
 import RecordSummary from './RecordSummary';
 import { RecordData } from './types';
+import QuestionsBanner from './QuestionsBanner';
 
 interface Props {
   record: RecordData;
 }
 
 export default class Record extends React.Component<Props> {
-
   render() {
     const errors = ( this.props.record.errors ?
       this.props.record.errors.map(((errorMessage: string, errorIndex: number) => {
@@ -39,6 +39,7 @@ export default class Record extends React.Component<Props> {
         {this.props.record.summary ? (
           <RecordSummary summary={this.props.record.summary}/>
           ) : null }
+        <QuestionsBanner/>
         {this.props.record.cases ? (
           <Cases cases={this.props.record.cases} />
         ) : null}

--- a/src/frontend/src/components/RecordSearch/Record/index.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/index.tsx
@@ -8,6 +8,7 @@ interface Props {
 }
 
 export default class Record extends React.Component<Props> {
+
   render() {
     const errors = ( this.props.record.errors ?
       this.props.record.errors.map(((errorMessage: string, errorIndex: number) => {
@@ -17,12 +18,12 @@ export default class Record extends React.Component<Props> {
         const errorMessageHTML = errorMessageArray.map(function (element) {
           if (element.match(/^\[.*\]$/)) {
               const caseNumber = element.slice(1, -1);
-              return <a className="underline" href={"#" + caseNumber}>{caseNumber}</a>;
+              return <a className="underline" href={"#" + caseNumber} key={caseNumber}>{caseNumber}</a>;
           } else {
               return element;
           }
         });
-        return <p role="status" id={id} className="bg-washed-red mv3 pa3 br3 fw6">
+        return <p role="status" id={id} key={id} className="bg-washed-red mv3 pa3 br3 fw6">
                   {errorMessageHTML}
                </p>
         }

--- a/src/frontend/src/components/RecordSearch/Record/types.ts
+++ b/src/frontend/src/components/RecordSearch/Record/types.ts
@@ -74,6 +74,7 @@ export interface QuestionsData {
 }
 
 export interface QuestionData {
+  case_number: string;
   ambiguous_charge_id: string;
   question: string;
   options: { [option: string]: string; };

--- a/src/frontend/src/components/RecordSearch/Record/types.ts
+++ b/src/frontend/src/components/RecordSearch/Record/types.ts
@@ -70,12 +70,12 @@ export interface ChargeEligibilityData {
 }
 
 export interface QuestionsData {
-  [ambiguous_charge_id: string] : QuestionData
+  [ambiguous_charge_id: string]: QuestionData
 }
 
 export interface QuestionData {
   ambiguous_charge_id: string;
   question: string;
-  options: {[option: string]: string;};
+  options: { [option: string]: string; };
   answer: string;
 }

--- a/src/frontend/src/components/RecordSearch/Record/types.ts
+++ b/src/frontend/src/components/RecordSearch/Record/types.ts
@@ -1,4 +1,5 @@
 export interface ChargeData {
+  ambiguous_charge_id: string;
   statute: string;
   expungement_result: any;
   name: string;
@@ -25,10 +26,11 @@ export interface CaseData {
 }
 
 export interface RecordData {
-  total_balance_Due?: number;
+  total_balance_due?: number;
   cases?: any[];
   errors?: string[];
   summary?: RecordSummaryData;
+  questions?: QuestionsData;
 }
 
 export interface RecordSummaryData {
@@ -65,4 +67,18 @@ export interface TimeEligibilityData {
 export interface ChargeEligibilityData {
   status: string;
   label: string;
+}
+
+export interface QuestionsData {
+  [ambiguous_charge_id: string] : QuestionData
+}
+
+export interface QuestionData {
+  ambiguous_charge_id: string;
+  question: string;
+  options: {[option: string]: string;};
+  editing: boolean;
+  analyzed: boolean;
+  selected_answer: string; // what the radio button is showing
+  submitted_answer: string; // the persistent value if you hit the "cancel" (editing) button
 }

--- a/src/frontend/src/components/RecordSearch/Record/types.ts
+++ b/src/frontend/src/components/RecordSearch/Record/types.ts
@@ -77,8 +77,5 @@ export interface QuestionData {
   ambiguous_charge_id: string;
   question: string;
   options: {[option: string]: string;};
-  editing: boolean;
-  analyzed: boolean;
-  selected_answer: string; // what the radio button is showing
-  submitted_answer: string; // the persistent value if you hit the "cancel" (editing) button
+  answer: string;
 }

--- a/src/frontend/src/components/RecordSearch/index.tsx
+++ b/src/frontend/src/components/RecordSearch/index.tsx
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { AppState } from '../../redux/store';
-import { RecordData } from './Record/types';
+import { RecordData, QuestionsData } from './Record/types';
 import {
   searchRecord,
-  clearRecord
+  clearRecord,
 } from '../../redux/search/actions';
 import SearchPanel from './SearchPanel';
 import Record from './Record';
@@ -15,6 +15,7 @@ type Props = {
   searchRecord: Function;
   clearRecord: Function;
   record?: RecordData;
+  questions?: QuestionsData
 };
 
 class RecordSearch extends Component<Props> {
@@ -29,6 +30,9 @@ class RecordSearch extends Component<Props> {
   render() {
     return (
       <main className="mw8 center ph2">
+        {
+          (this.props.questions ? JSON.stringify(this.props.questions) : "no questions")
+        }
         <SearchPanel searchRecord={this.props.searchRecord} />
         {this.props.record &&
         ((this.props.record.cases &&
@@ -55,7 +59,8 @@ class RecordSearch extends Component<Props> {
 
 const mapStateToProps = (state: AppState) => {
   return {
-    record: state.search.record
+    record: state.search.record,
+    questions: state.search.questions
   };
 };
 
@@ -63,6 +68,6 @@ export default connect(
   mapStateToProps,
   {
     searchRecord: searchRecord,
-    clearRecord: clearRecord
+    clearRecord: clearRecord,
   }
 )(RecordSearch);

--- a/src/frontend/src/components/RecordSearch/index.tsx
+++ b/src/frontend/src/components/RecordSearch/index.tsx
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { AppState } from '../../redux/store';
-import { RecordData, QuestionsData } from './Record/types';
+import { RecordData } from './Record/types';
 import {
   searchRecord,
-  clearRecord,
+  clearRecord
 } from '../../redux/search/actions';
 import SearchPanel from './SearchPanel';
 import Record from './Record';
@@ -15,7 +15,6 @@ type Props = {
   searchRecord: Function;
   clearRecord: Function;
   record?: RecordData;
-  questions?: QuestionsData
 };
 
 class RecordSearch extends Component<Props> {
@@ -30,9 +29,6 @@ class RecordSearch extends Component<Props> {
   render() {
     return (
       <main className="mw8 center ph2">
-        {
-          (this.props.questions ? JSON.stringify(this.props.questions) : "no questions")
-        }
         <SearchPanel searchRecord={this.props.searchRecord} />
         {this.props.record &&
         ((this.props.record.cases &&
@@ -59,8 +55,7 @@ class RecordSearch extends Component<Props> {
 
 const mapStateToProps = (state: AppState) => {
   return {
-    record: state.search.record,
-    questions: state.search.questions
+    record: state.search.record
   };
 };
 
@@ -68,6 +63,6 @@ export default connect(
   mapStateToProps,
   {
     searchRecord: searchRecord,
-    clearRecord: clearRecord,
+    clearRecord: clearRecord
   }
 )(RecordSearch);

--- a/src/frontend/src/redux/search/actions.ts
+++ b/src/frontend/src/redux/search/actions.ts
@@ -1,4 +1,5 @@
 import { Dispatch } from 'redux';
+import store from '../store';
 import apiService from '../../service/api-service';
 import { AxiosError, AxiosResponse } from 'axios';
 import {
@@ -6,21 +7,15 @@ import {
   SEARCH_RECORD_LOADING,
   SearchResponse,
   CLEAR_RECORD,
-  SELECT_ANSWER,
-  EDIT_ANSWER,
-  CANCEL_EDIT,
-  UPDATE_ANALYSIS,
-  QuestionEndpointData,
-  QuestionsEndpointData
+  SELECT_ANSWER
 } from './types';
 import {AliasData} from '../../components/RecordSearch/SearchPanel/types'
-import {RecordData, QuestionData, QuestionsData} from '../../components/RecordSearch/Record/types'
+import {RecordData} from '../../components/RecordSearch/Record/types'
 
 function storeSearchResponse(data: SearchResponse, dispatch: Dispatch) {
   if (validateSearchResponseData(data)) {
     const receivedRecord = data.record;
-    const questions : QuestionsData = processReceivedQuestions(receivedRecord.questions);
-    let record: RecordData = {
+    const record: RecordData = {
        total_balance_due: receivedRecord.total_balance_due,
        cases: receivedRecord.cases,
        errors: receivedRecord.errors,
@@ -29,7 +24,7 @@ function storeSearchResponse(data: SearchResponse, dispatch: Dispatch) {
     dispatch({
       type: SEARCH_RECORD,
       record: record,
-      questions: questions
+      questions: receivedRecord.questions
 
     });
   } else {
@@ -41,43 +36,6 @@ function validateSearchResponseData(data: SearchResponse): boolean {
   return data.hasOwnProperty('record');
 }
 
-function processReceivedQuestions(receivedQuestions: QuestionsEndpointData) : QuestionsData {
-  let processedQuestions: QuestionsData = {};
-  let processedQuestion: QuestionData;
-  let receivedQuestion: QuestionEndpointData;
-  for (const ambiguous_charge_id of Object.keys(receivedQuestions)){
-    receivedQuestion = receivedQuestions[ambiguous_charge_id]
-    processedQuestion = {
-      ambiguous_charge_id: receivedQuestion.ambiguous_charge_id,
-      question: receivedQuestion.question,
-      options: receivedQuestion.options,  //{[option: string]: string;};
-      editing: false,
-      analyzed: Boolean(receivedQuestion.answer),
-      selected_answer: receivedQuestion.answer,
-      submitted_answer: receivedQuestion.answer
-    };
-    processedQuestions[ambiguous_charge_id]=processedQuestion;
-  }
-  return processedQuestions;
-}
-
-/*function prepareDisambiguatingQuestions() : QuestionsEndpointData {
-  // ignore flags for editing, analyzed, submitted_answer
-  // but assemble the data object containing:
-  //   ambiguous_charge_id: string;
-  //   question : string;
-  //   options: {[option: string]: string;};
-  //   answer = selected_answer: string;
-//
-  }
-}*/
-
-export function disambiguateRecord() {
-  // const questions : QuestionsEndpointData = prepareDisambiguatingQuestions();
-  //return (dispatch: Dispatch)
-
-  // receive the record and questions and handle them identically to what search call is doing
-}
 export function searchRecord(
   aliases: AliasData[]
 ): any {
@@ -110,37 +68,27 @@ export function clearRecord() {
 
 export function selectAnswer(
   ambiguous_charge_id: string,
-  answer: string): any {
-  // when you hit a radio button, but nothing else visibly changes,
-  // update in redux because that will make it possible to send off data to the endpoint
-
-  // can either return a function that accepts a dispatch, and use the dispatch to
-  // return data objects to be handled in the reducer,
-  // or just return a data object to be handled in the reducer.
-  // in this case, just issue a data object
-
-  return {
-    type: SELECT_ANSWER,
-    ambiguous_charge_id: ambiguous_charge_id,
-    selected_answer: answer
-  }
-}
-
-export function updateAnalysis() {
-  // construct a request object with Question from redux contents,
-  // the request object has data structure QuestionEndpointData
-  // the answers sent are:
-  // whatever is in "selected", in all cases.
-  // send the disambiguate request,
-  // update the app state based on the response.
-  // for all questions that have a selected answer, switch analyzed = true.
-}
-
-export function editAnswer() {
-  // editing becomes true for that question, causing the display state (a property) to change.
-  // this only happens if the question has been analyzed
-}
-
-export function cancelEdit() {
-  // edit becomes false. the selected answer is reverted to the value of submitted answer.
+  answer: string
+): any {
+  return (dispatch: Dispatch) => {
+    dispatch({
+      type: SELECT_ANSWER,
+      ambiguous_charge_id: ambiguous_charge_id,
+      answer: answer
+    });
+   return apiService<SearchResponse>(dispatch, {
+      url: '/api/disambiguate',
+      data: {
+        questions: store.getState().search.questions
+      },
+      method: 'post',
+      withCredentials: true
+    })
+      .then((response: AxiosResponse<SearchResponse>) => {
+        storeSearchResponse(response.data, dispatch)
+      })
+      .catch((error: AxiosError<SearchResponse>) => {
+        alert(error.message);
+      });
+  };
 }

--- a/src/frontend/src/redux/search/actions.ts
+++ b/src/frontend/src/redux/search/actions.ts
@@ -1,7 +1,7 @@
-import { Dispatch } from 'redux';
+import {Dispatch} from 'redux';
 import store from '../store';
 import apiService from '../../service/api-service';
-import { AxiosError, AxiosResponse } from 'axios';
+import {AxiosError, AxiosResponse} from 'axios';
 import {
   SEARCH_RECORD,
   SEARCH_RECORD_LOADING,
@@ -16,11 +16,11 @@ function storeSearchResponse(data: SearchResponse, dispatch: Dispatch) {
   if (validateSearchResponseData(data)) {
     const receivedRecord = data.record;
     const record: RecordData = {
-       total_balance_due: receivedRecord.total_balance_due,
-       cases: receivedRecord.cases,
-       errors: receivedRecord.errors,
-       summary: receivedRecord.summary,
-       };
+      total_balance_due: receivedRecord.total_balance_due,
+      cases: receivedRecord.cases,
+      errors: receivedRecord.errors,
+      summary: receivedRecord.summary,
+    };
     dispatch({
       type: SEARCH_RECORD,
       record: record,
@@ -28,7 +28,7 @@ function storeSearchResponse(data: SearchResponse, dispatch: Dispatch) {
 
     });
   } else {
-  alert('Response data has unexpected format.');
+    alert('Response data has unexpected format.');
   }
 }
 
@@ -76,7 +76,7 @@ export function selectAnswer(
       ambiguous_charge_id: ambiguous_charge_id,
       answer: answer
     });
-   return apiService<SearchResponse>(dispatch, {
+    return apiService<SearchResponse>(dispatch, {
       url: '/api/disambiguate',
       data: {
         questions: store.getState().search.questions

--- a/src/frontend/src/redux/search/actions.ts
+++ b/src/frontend/src/redux/search/actions.ts
@@ -3,8 +3,8 @@ import store from '../store';
 import apiService from '../../service/api-service';
 import {AxiosError, AxiosResponse} from 'axios';
 import {
-  SEARCH_RECORD,
-  SEARCH_RECORD_LOADING,
+  DISPLAY_RECORD,
+  RECORD_LOADING,
   SearchResponse,
   CLEAR_RECORD,
   SELECT_ANSWER
@@ -22,10 +22,9 @@ function storeSearchResponse(data: SearchResponse, dispatch: Dispatch) {
       summary: receivedRecord.summary,
     };
     dispatch({
-      type: SEARCH_RECORD,
+      type: DISPLAY_RECORD,
       record: record,
       questions: receivedRecord.questions
-
     });
   } else {
     alert('Response data has unexpected format.');
@@ -41,7 +40,7 @@ export function searchRecord(
 ): any {
   return (dispatch: Dispatch) => {
     dispatch({
-      type: SEARCH_RECORD_LOADING
+      type: RECORD_LOADING
     });
     return apiService<SearchResponse>(dispatch, {
       url: '/api/search',

--- a/src/frontend/src/redux/search/actions.ts
+++ b/src/frontend/src/redux/search/actions.ts
@@ -16,6 +16,27 @@ import {
 import {AliasData} from '../../components/RecordSearch/SearchPanel/types'
 import {RecordData, QuestionData, QuestionsData} from '../../components/RecordSearch/Record/types'
 
+function storeSearchResponse(data: SearchResponse, dispatch: Dispatch) {
+  if (validateSearchResponseData(data)) {
+    const receivedRecord = data.record;
+    const questions : QuestionsData = processReceivedQuestions(receivedRecord.questions);
+    let record: RecordData = {
+       total_balance_due: receivedRecord.total_balance_due,
+       cases: receivedRecord.cases,
+       errors: receivedRecord.errors,
+       summary: receivedRecord.summary,
+       };
+    dispatch({
+      type: SEARCH_RECORD,
+      record: record,
+      questions: questions
+
+    });
+  } else {
+  alert('Response data has unexpected format.');
+  }
+}
+
 function validateSearchResponseData(data: SearchResponse): boolean {
   return data.hasOwnProperty('record');
 }
@@ -40,6 +61,23 @@ function processReceivedQuestions(receivedQuestions: QuestionsEndpointData) : Qu
   return processedQuestions;
 }
 
+/*function prepareDisambiguatingQuestions() : QuestionsEndpointData {
+  // ignore flags for editing, analyzed, submitted_answer
+  // but assemble the data object containing:
+  //   ambiguous_charge_id: string;
+  //   question : string;
+  //   options: {[option: string]: string;};
+  //   answer = selected_answer: string;
+//
+  }
+}*/
+
+export function disambiguateRecord() {
+  // const questions : QuestionsEndpointData = prepareDisambiguatingQuestions();
+  //return (dispatch: Dispatch)
+
+  // receive the record and questions and handle them identically to what search call is doing
+}
 export function searchRecord(
   aliases: AliasData[]
 ): any {
@@ -56,24 +94,7 @@ export function searchRecord(
       withCredentials: true
     })
       .then((response: AxiosResponse<SearchResponse>) => {
-        if (validateSearchResponseData(response.data)) {
-          const receivedRecord = response.data.record;
-          const questions : QuestionsData = processReceivedQuestions(receivedRecord.questions);
-          let record: RecordData = {
-             total_balance_due: receivedRecord.total_balance_due,
-             cases: receivedRecord.cases,
-             errors: receivedRecord.errors,
-             summary: receivedRecord.summary,
-             };
-          dispatch({
-            type: SEARCH_RECORD,
-            record: record,
-            questions: questions
-
-          });
-        } else {
-          alert('Response data has unexpected format.');
-        }
+        storeSearchResponse(response.data, dispatch)
       })
       .catch((error: AxiosError<SearchResponse>) => {
         alert(error.message);

--- a/src/frontend/src/redux/search/reducer.ts
+++ b/src/frontend/src/redux/search/reducer.ts
@@ -22,19 +22,24 @@ export function searchReducer(
       // action. We ignore existing cases and do not
       // necessarily include them in the new state. This
       // is a "destructive update".
-      return { ...state, record: action.record, questions: action.questions, loading: false };
+      return {
+        ...state,
+        record: action.record,
+        questions: action.questions,
+        loading: false
+      };
     case SEARCH_RECORD_LOADING:
       // When an API call is made for a record, loading state is toggled to true.
       // while loading state is true, a spinner is rendered on the screen. If loading
       // state is false, and no results were fetched, no "search results found" will be displayed.
       // return { ...state, record: {}, questions: {}, loading: true };
-      return { ...state, loading: true };
+      return {...state, loading: true};
     case CLEAR_RECORD:
-      return { ...state, record: {}, questions: {}, loading: false };
+      return {...state, record: {}, questions: {}, loading: false};
     case SELECT_ANSWER:
-      let questions : QuestionsData = JSON.parse(JSON.stringify(state.questions));
+      let questions: QuestionsData = JSON.parse(JSON.stringify(state.questions));
       if (questions && questions[action.ambiguous_charge_id]) {
-        questions[action.ambiguous_charge_id].answer=action.answer;
+        questions[action.ambiguous_charge_id].answer = action.answer;
       }
       return {...state, questions: questions};
     default:

--- a/src/frontend/src/redux/search/reducer.ts
+++ b/src/frontend/src/redux/search/reducer.ts
@@ -1,10 +1,15 @@
 import {
   SEARCH_RECORD,
   SEARCH_RECORD_LOADING,
+  CLEAR_RECORD,
+  SELECT_ANSWER,
+  EDIT_ANSWER,
+  CANCEL_EDIT,
+  UPDATE_ANALYSIS,
   SearchRecordState,
-  SearchRecordActionType,
-  CLEAR_RECORD
+  SearchRecordActionType
 } from './types';
+import {RecordData, QuestionsData} from '../../components/RecordSearch/Record/types'
 
 const initalState: SearchRecordState = {
   loading: false
@@ -20,14 +25,26 @@ export function searchReducer(
       // action. We ignore existing cases and do not
       // necessarily include them in the new state. This
       // is a "destructive update".
-      return { ...state, record: action.record, loading: false };
+      return { ...state, record: action.record, questions: action.questions, loading: false };
     case SEARCH_RECORD_LOADING:
       // When an API call is made for a record, loading state is toggled to true.
       // while loading state is true, a spinner is rendered on the screen. If loading
       // state is false, and no results were fetched, no "search results found" will be displayed.
-      return { ...state, record: {}, loading: true };
+      return { ...state, record: {}, questions: {}, loading: true };
     case CLEAR_RECORD:
-      return { ...state, record: {}, loading: false };
+      return { ...state, record: {}, questions: {}, loading: false };
+    case SELECT_ANSWER:
+      let questions : QuestionsData = JSON.parse(JSON.stringify(state.questions));
+      if (questions && questions[action.ambiguous_charge_id]) {
+        questions[action.ambiguous_charge_id].selected_answer=action.selected_answer;
+      }
+      return {...state, questions: questions};
+    case EDIT_ANSWER:
+      return state;
+    case CANCEL_EDIT:
+      return state;
+    case UPDATE_ANALYSIS:
+      return state;
     default:
       return state;
   }

--- a/src/frontend/src/redux/search/reducer.ts
+++ b/src/frontend/src/redux/search/reducer.ts
@@ -41,7 +41,7 @@ export function searchReducer(
       if (questions && questions[action.ambiguous_charge_id]) {
         questions[action.ambiguous_charge_id].answer = action.answer;
       }
-      return {...state, questions: questions};
+      return {...state, questions: questions, loading: true};
     default:
       return state;
   }

--- a/src/frontend/src/redux/search/reducer.ts
+++ b/src/frontend/src/redux/search/reducer.ts
@@ -1,6 +1,6 @@
 import {
-  SEARCH_RECORD,
-  SEARCH_RECORD_LOADING,
+  DISPLAY_RECORD,
+  RECORD_LOADING,
   CLEAR_RECORD,
   SELECT_ANSWER,
   SearchRecordState,
@@ -17,7 +17,7 @@ export function searchReducer(
   action: SearchRecordActionType
 ): SearchRecordState {
   switch (action.type) {
-    case SEARCH_RECORD:
+    case DISPLAY_RECORD:
       // The new state is the record returned in the
       // action. We ignore existing cases and do not
       // necessarily include them in the new state. This
@@ -28,7 +28,7 @@ export function searchReducer(
         questions: action.questions,
         loading: false
       };
-    case SEARCH_RECORD_LOADING:
+    case RECORD_LOADING:
       // When an API call is made for a record, loading state is toggled to true.
       // while loading state is true, a spinner is rendered on the screen. If loading
       // state is false, and no results were fetched, no "search results found" will be displayed.

--- a/src/frontend/src/redux/search/reducer.ts
+++ b/src/frontend/src/redux/search/reducer.ts
@@ -9,7 +9,7 @@ import {
   SearchRecordState,
   SearchRecordActionType
 } from './types';
-import {RecordData, QuestionsData} from '../../components/RecordSearch/Record/types'
+import {QuestionsData} from '../../components/RecordSearch/Record/types'
 
 const initalState: SearchRecordState = {
   loading: false
@@ -30,7 +30,8 @@ export function searchReducer(
       // When an API call is made for a record, loading state is toggled to true.
       // while loading state is true, a spinner is rendered on the screen. If loading
       // state is false, and no results were fetched, no "search results found" will be displayed.
-      return { ...state, record: {}, questions: {}, loading: true };
+      // return { ...state, record: {}, questions: {}, loading: true };
+      return { ...state, loading: true };
     case CLEAR_RECORD:
       return { ...state, record: {}, questions: {}, loading: false };
     case SELECT_ANSWER:

--- a/src/frontend/src/redux/search/reducer.ts
+++ b/src/frontend/src/redux/search/reducer.ts
@@ -3,9 +3,6 @@ import {
   SEARCH_RECORD_LOADING,
   CLEAR_RECORD,
   SELECT_ANSWER,
-  EDIT_ANSWER,
-  CANCEL_EDIT,
-  UPDATE_ANALYSIS,
   SearchRecordState,
   SearchRecordActionType
 } from './types';
@@ -37,15 +34,9 @@ export function searchReducer(
     case SELECT_ANSWER:
       let questions : QuestionsData = JSON.parse(JSON.stringify(state.questions));
       if (questions && questions[action.ambiguous_charge_id]) {
-        questions[action.ambiguous_charge_id].selected_answer=action.selected_answer;
+        questions[action.ambiguous_charge_id].answer=action.answer;
       }
       return {...state, questions: questions};
-    case EDIT_ANSWER:
-      return state;
-    case CANCEL_EDIT:
-      return state;
-    case UPDATE_ANALYSIS:
-      return state;
     default:
       return state;
   }

--- a/src/frontend/src/redux/search/types.ts
+++ b/src/frontend/src/redux/search/types.ts
@@ -1,4 +1,8 @@
-import {RecordData, RecordSummaryData, QuestionsData} from '../../components/RecordSearch/Record/types'
+import {
+  RecordData,
+  RecordSummaryData,
+  QuestionsData
+} from '../../components/RecordSearch/Record/types'
 
 export interface SearchResponse {
   record: RecordEndpointData;

--- a/src/frontend/src/redux/search/types.ts
+++ b/src/frontend/src/redux/search/types.ts
@@ -9,27 +9,13 @@ export interface RecordEndpointData {
   cases: any[];
   errors: string[];
   summary: RecordSummaryData;
-  questions: QuestionsEndpointData;
-}
-
-export interface QuestionsEndpointData {
-    [ambiguous_charge_id: string] : QuestionEndpointData;
-}
-
-export interface QuestionEndpointData {
-  ambiguous_charge_id: string;
-  question: string;
-  answer: string;
-  options: {[option: string]: string;};
+  questions: QuestionsData;
 }
 
 export const SEARCH_RECORD = 'SEARCH_RECORD';
 export const SEARCH_RECORD_LOADING = 'SEARCH_RECORD_LOADING';
 export const CLEAR_RECORD = 'CLEAR_RECORD';
 export const SELECT_ANSWER = 'SELECT_ANSWER';
-export const EDIT_ANSWER = 'EDIT_ANSWER';
-export const CANCEL_EDIT = 'CANCEL_EDIT';
-export const UPDATE_ANALYSIS = 'UPDATE_ANALYSIS';
 
 export interface SearchRecordState {
   loading: boolean;
@@ -48,14 +34,8 @@ interface SearchRecordAction {
 
 interface QuestionsAction {
   ambiguous_charge_id: string,
-  type:
-    | typeof SELECT_ANSWER
-    | typeof EDIT_ANSWER
-    | typeof CANCEL_EDIT
-    | typeof UPDATE_ANALYSIS
-  selected_answer: string
-
+  type: typeof SELECT_ANSWER
+  answer: string
 }
-// Add other Action types here like so:
-// export type RecordActionTypes = LoadRecordAction | OtherRecordAction;
+
 export type SearchRecordActionType = SearchRecordAction | QuestionsAction;

--- a/src/frontend/src/redux/search/types.ts
+++ b/src/frontend/src/redux/search/types.ts
@@ -1,17 +1,40 @@
-import {RecordData} from '../../components/RecordSearch/Record/types'
+import {RecordData, RecordSummaryData, QuestionsData} from '../../components/RecordSearch/Record/types'
 
 export interface SearchResponse {
-  record: RecordData;
+  record: RecordEndpointData;
 }
 
-// These constants are used as the 'type' field in Redux actions.
+export interface RecordEndpointData {
+  total_balance_due: number;
+  cases: any[];
+  errors: string[];
+  summary: RecordSummaryData;
+  questions: QuestionsEndpointData;
+}
+
+export interface QuestionsEndpointData {
+    [ambiguous_charge_id: string] : QuestionEndpointData;
+}
+
+export interface QuestionEndpointData {
+  ambiguous_charge_id: string;
+  question: string;
+  answer: string;
+  options: {[option: string]: string;};
+}
+
 export const SEARCH_RECORD = 'SEARCH_RECORD';
 export const SEARCH_RECORD_LOADING = 'SEARCH_RECORD_LOADING';
 export const CLEAR_RECORD = 'CLEAR_RECORD';
+export const SELECT_ANSWER = 'SELECT_ANSWER';
+export const EDIT_ANSWER = 'EDIT_ANSWER';
+export const CANCEL_EDIT = 'CANCEL_EDIT';
+export const UPDATE_ANALYSIS = 'UPDATE_ANALYSIS';
 
 export interface SearchRecordState {
   loading: boolean;
   record?: RecordData;
+  questions?: QuestionsData
 }
 
 interface SearchRecordAction {
@@ -20,8 +43,19 @@ interface SearchRecordAction {
     | typeof SEARCH_RECORD_LOADING
     | typeof CLEAR_RECORD;
   record: RecordData;
+  questions: QuestionsData;
 }
 
+interface QuestionsAction {
+  ambiguous_charge_id: string,
+  type:
+    | typeof SELECT_ANSWER
+    | typeof EDIT_ANSWER
+    | typeof CANCEL_EDIT
+    | typeof UPDATE_ANALYSIS
+  selected_answer: string
+
+}
 // Add other Action types here like so:
 // export type RecordActionTypes = LoadRecordAction | OtherRecordAction;
-export type SearchRecordActionType = SearchRecordAction;
+export type SearchRecordActionType = SearchRecordAction | QuestionsAction;

--- a/src/frontend/src/redux/search/types.ts
+++ b/src/frontend/src/redux/search/types.ts
@@ -16,8 +16,8 @@ export interface RecordEndpointData {
   questions: QuestionsData;
 }
 
-export const SEARCH_RECORD = 'SEARCH_RECORD';
-export const SEARCH_RECORD_LOADING = 'SEARCH_RECORD_LOADING';
+export const DISPLAY_RECORD = 'DISPLAY_RECORD';
+export const RECORD_LOADING = 'RECORD_LOADING';
 export const CLEAR_RECORD = 'CLEAR_RECORD';
 export const SELECT_ANSWER = 'SELECT_ANSWER';
 
@@ -29,8 +29,8 @@ export interface SearchRecordState {
 
 interface SearchRecordAction {
   type:
-    | typeof SEARCH_RECORD
-    | typeof SEARCH_RECORD_LOADING
+    | typeof DISPLAY_RECORD
+    | typeof RECORD_LOADING
     | typeof CLEAR_RECORD;
   record: RecordData;
   questions: QuestionsData;

--- a/src/frontend/src/styles/_globals.scss
+++ b/src/frontend/src/styles/_globals.scss
@@ -109,6 +109,10 @@ $washed-red: #f0e0e8;
   border-radius: 50%;
   border: 3px solid rgba(53, 126, 221, 0.2);
 }
+.spinner--sm {
+  width:16px;
+  height: 16px;
+}
 .spinner--light {
   border: 3px solid rgba(186, 216, 255, 0.2);
 }
@@ -137,6 +141,11 @@ $washed-red: #f0e0e8;
     -webkit-transform: rotate(360deg);
     tranform: rotate(360deg);
   }
+}
+
+.radio-spinner {
+  bottom: -1.4rem;
+  left: 0.38rem;
 }
 
 .loading-btn {
@@ -237,11 +246,15 @@ footer {
 
 .radio input[type='radio'] {
   opacity: 0;
+  display: block;
+  position: relative;
+  top: 0.5rem;
 }
 .radio label {
   position: relative;
-  display: block;
-  padding: 0.4rem 3rem 0 2.2rem;
+  top: -0.6rem;
+  display: inline-block;
+  padding: 0.4rem 1.5rem 0 2.1rem;
 }
 .radio label::before,
 .radio label::after {
@@ -273,8 +286,8 @@ footer {
   content: '';
 }
 .radio input[type='radio']:focus + label::before {
-  outline: auto 2px Highlight;
-  outline: auto 5px -webkit-focus-ring-color;
+  outline: 0;
+  border: 2px solid $blue;
 }
 
 // Change the breakpoint "ns" variable to be wider?


### PR DESCRIPTION
This behavior is simpler than the current mockups in #972 , because it  updates the record immediately on clicking a radio button option for each question. We should talk about this in our meeting. 

The current design only supports the possibility of one question per charge. This is true of the backend code also.


Comment on the code for building the banner:
- It doesn't duplicate case IDs.
- if there are multiple charges with questions on a single case, the list will show that case as "unanswered" until all the attached questions are answered, not just some of them. This is currently untested because I didn't have an example record on hand (extensive mock records for good offline testing is a forthcoming feature)
