### PR TITLE
add prod deploy targets and update docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,10 @@ frontend_down:
 frontend_logs:
 	docker-compose logs -f $(FRONTEND_SERVICE)
 
+# restart frontend
+frontend_restart:
+	docker-compose restart $(FRONTEND_SERVICE)
+
 # run frontend tests, watching enabled (default)
 frontend_test:
 	docker-compose exec $(FRONTEND_SERVICE) sh -c 'cd /src/frontend && npm test'

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,10 @@
 .PHONY: clean
 
-STACK_NAME := recordexpungpdx
-DB_CONTAINER_NAME := db
-BACKEND_CONTAINER_NAME := expungeservice
-FRONTEND_CONTAINER_NAME := webserver
 REQUIREMENTS_TXT := src/backend/requirements.txt
 OSFLAG 	:=
 ifeq ($(OS),Windows_NT)
 	OSFLAG = WIN32
 endif
-
 
 clean:
 ifeq ($(OSFLAG), WIN32)
@@ -21,81 +16,6 @@ else
 	find . -type f -name \*~ | xargs rm &
 	find . -type f -name \*pyc | xargs rm
 endif
-
-dev: dev_up
-
-dev_up:
-	docker-compose -f docker-compose.dev.yml up -d
-
-dev_down:
-	docker-compose -f docker-compose.dev.yml down
-
-dev_build:
-	docker-compose -f docker-compose.dev.yml build
-
-dev_logs:
-	docker-compose -f docker-compose.dev.yml logs -f
-
-dev_psql:
-	docker exec -ti $(shell docker ps -qf name=$(DB_CONTAINER_NAME)) psql -U postgres -d record_expunge # TODO: Extract db name from config/expungeservice/expungeservice.env
-
-bash_backend:
-	docker exec -it $(shell docker ps -qf name=$(BACKEND_CONTAINER_NAME)) /bin/bash
-
-bash_frontend:
-	docker exec -it $(shell docker ps -qf name=$(FRONTEND_CONTAINER_NAME)) /bin/bash
-
-database_image:
-	docker build --no-cache -t $(STACK_NAME):database config/postgres -f config/postgres/Dockerfile.dev
-
-expungeservice_image:
-	docker build --no-cache -t $(STACK_NAME):expungeservice src/backend/ -f src/backend/Dockerfile.dev
-
-dblogs:
-	docker logs --details -ft $(shell docker ps -qf name=$(DB_CONTAINER_NAME))
-
-applogs:
-	docker logs --details -ft $(shell docker ps -qf name=$(BACKEND_CONTAINER_NAME))
-
-weblogs:
-	docker logs --details -ft $(shell docker ps -qf name=$(FRONTEND_CONTAINER_NAME))
-
-dev_test:
-	docker exec -t $(shell docker ps -qf name=$(BACKEND_CONTAINER_NAME)) mypy
-	docker exec -t $(shell docker ps -qf name=$(BACKEND_CONTAINER_NAME)) pytest
-
-dev_drop_database:
-	docker volume rm $(shell docker volume ls -qf name=$(STACK_NAME))
-
-dev_mock_oeci_up:
-	docker-compose -f docker-compose.dev.yml -f src/frontend/developerUtils/docker-compose.mock-oeci.yml up -d
-
-deploy: deploy_backend deploy_frontend
-
-.ONESHELL:
-deploy_update_repo:
-	cd ~/recordexpungPDX/
-	git reset --hard
-	git checkout master
-	git pull origin master
-
-.ONESHELL:
-deploy_backend: deploy_update_repo
-	cd ~/recordexpungPDX/src/backend/
-	killall uwsgi
-	$(shell tr '\n' ' ' < ~/recordexpungPDX/config/expungeservice/expungeservice.production.env) nohup pipenv run uwsgi --socket 127.0.0.1:3031 --module expungeservice.wsgi &
-
-.ONESHELL:
-deploy_frontend: deploy_update_repo
-	cd ~/recordexpungPDX/src/frontend/
-	npm run build
-	cp -r build/* /usr/share/nginx/html/
-
-.PHONY: $(REQUIREMENTS_TXT)
-$(REQUIREMENTS_TXT):
-	pipenv lock -r > $@
-
-# ---
 
 BACKEND_SERVICE := expungeservice
 FRONTEND_SERVICE := node

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ You can get your dev environment up and running with installing only Docker and 
 
 ## Running the docker stack
 
-In the project's root directory, run `make new`. This pulls the dev-tagged "expungeservice" image and launches the containers using docker-compose. Stop the running stack with `make stop`.
+In the project's root directory, run `make new`. This pulls the dev-tagged "expungeservice" image and launches the containers using docker-compose. Start and stop the running stack with `make up` and `make down`.
 
-After this target completes, you can navigate to [http://localhost:3000](http://localhost:3000) in the browser and connect to the React dev server with full hot-module reloading. This may take a minute or two to come up before it is available. Check the service with `make frontend_logs`. Once everything is up, you can log in using either of the following credentials:
+After this target completes, you can navigate to [http://localhost:3000](http://localhost:3000) in the browser and connect to the React dev server with full hot-module reloading. This may take a minute or two to come up before it is available while it installs node modules. Check the service with `make frontend_logs`. Once everything is up, you can log in using either of the following credentials:
 
 * Email: admin@email.com, Password: admin
 * Email: user@email.com, Password: user
@@ -76,7 +76,7 @@ In the course of backend development, one may not need to be running the React/H
 $ make frontend_down frontend_build
 ```
 
-Then navigate to [http://localhost:5000](http://localhost:5000) to access the backend service directly. This is configured to serve the static files. `make up` will start the HMR dev server again at 3000 if you need it.
+Then navigate to [http://localhost:5000](http://localhost:5000) to access the backend service directly. This is configured to serve the static files. `make up` will start the HMR dev server again at 3000 if you stopped it.
 
 Whenever a dependency is added to the backend, someone needs to rebuild the dev-tagged image and push or folks will get errors when trying to run the stack. To do so, rebuild the image, and reload the backend with:
 
@@ -128,7 +128,7 @@ This runs a `pytest` command to execute all the unit tests inside the backend do
 To run a subset of test cases without first shelling into the docker container, you can use a docker-compose `exec` command, which specifies a container by service name and a runnable command in the container in a single step, e.g.:
 
 ```
-$ docker-compose exec expungeservice pytest ./tests/[subdir]
+$ docker-compose exec expungeservice pipenv run pytest tests/[subdir]
 ```
 
 To specify and run a subset of the test cases.

--- a/doc/design.md
+++ b/doc/design.md
@@ -20,13 +20,13 @@ Table of Contents
 Project Stack
 -------------
 
-The app stack is deployed as three services in a Docker stack:
+The development app stack is deployed as three services in a Docker Compose network:
 
-[ Web Server ]  -- Nginx, https enabled. Serves static pages and proxies API calls
+[ postgres ] -- PostgreSQL 10
 
-[ Backend API ] -- Python, Flask, Psycopg
+[ expungeservice ] -- Python 3.7, Flask, Psycopg
 
-[ Database ] -- PostgreSQL
+[ node ] -- NodeJS, React
 
 
 Project Layout
@@ -35,18 +35,14 @@ Project Layout
 This is a high-level [tree](https://linux.die.net/man/1/tree) of the project only listing "notable" folders/files.
 ```
 .
-├── Makefile : GNU Makefile controlling installing dependencies and running the application
+├── Makefile : GNU Makefile with targets for working with local dev environment
 ├── config : Project configuration files
-│   ├── expungeservice
-│   ├── nginx
 │   └── postgres
-├── deployment
 ├── doc : Developer-generated documentation folder
-├── docker-compose.dev.yml : Docker file that `make dev_up` invokes
+├── docker-compose.yml : Docker Compose file that `make` targets invoke
 └── src : Source directory
     ├── backend
-    │   ├── Dockerfile.dev
-    │   ├── Dockerfile.web
+    │   ├── Dockerfile
     │   ├── Pipfile : Pipenv file listing backend project dependencies
     │   ├── Pipfile.lock
     │   ├── expungeservice
@@ -54,7 +50,11 @@ This is a high-level [tree](https://linux.die.net/man/1/tree) of the project onl
     │   ├── mypy.ini : Configuration file to the mypy type checker 
     │   ├── setup.py
     │   └── tests
-    └── frontend
+    ├── frontend
+    └── ops
+        ├── Makefile : GNU Makefile with targets for building & deploying staging/prod images
+        └── docker/expungeservice
+            └── Dockerfile
 ```
 
 User Flow

--- a/doc/development.md
+++ b/doc/development.md
@@ -3,26 +3,13 @@ Project Development Tips
 
 This document describes a few things that may be useful for development.
 
-## When Pulling Changes From Master
+## Database named volume
 
-Code changes to the project's dependencies or database (tables or functions) are not reflected in the Docker stack until you manually rebuild the corresponding Docker images and replace the database Docker Volume, which is a persistent storage container attached to the ephemeral Docker stack container.
-
- To perform both of these steps:
-
- ```
- make dev_down
- make dev_drop_database
- make dev_build
- make dev_up
-
- ```
-
-If you don't want to lose the contents of your database ... well we don't currently have a tool to automatically export/import the data. But we need it! See Issue #299, and feel free to add this feature.
+The postgres database service uses a named Docker volume `recordexpungpdx_postgresql_data` that persists across container lifecycles. To remove this and other volumes created by the compose file, use `make clobber`.
 
 ## In-project guide to using Docker:
 
-Available here: [doc/docker.md](https://github.com/codeforpdx/recordexpungPDX/blob/master/doc/docker.md)
-
+Available here: [doc/docker.md](docker.md)
 
 ## Create a Local User
 
@@ -30,28 +17,31 @@ You can create user accounts manually in your local database if you'd like to do
 
 1. Choose a password and compute its bcrypt hash:
 
-In the project directory, run
-```
-docker exec -ti pipenv run python
-```
-to open the python interactive terminal with the project's dependencies loaded. Then run
+In the project directory, run:
 
 ```
-$ from werkzeug.security import generate_password_hash
-$ generate_password_hash('your_password')
+$ docker-compose exec expungeservice pipenv run python
+```
+
+to open the python interactive terminal with the project's dependencies loaded. Then run:
+
+```python
+>>> from werkzeug.security import generate_password_hash
+>>> generate_password_hash('your_password')
 ```
 
 2. Choose an email address and insert it and your password hash into the database:
 
-In the project directory, run
+In the project directory, run:
+
 ```
-make dev_psql
+$ docker-compose exec --user=postgres postgres psql record_expunge_dev
 ```
 
 This launches the PSQL interactive environment in the project's postgres docker container. In this terminal, run:
 
-```
-$ SELECT * FROM USERS_CREATE('your_email', 'your_hashed_password', 'your name', 'your group name', true);
+```sql
+record_expunge_dev=# SELECT * FROM USERS_CREATE('your_email', 'your_hashed_password', 'your name', 'your group name', true);
 ```
 
 providing your actual email and hashed password each in the single-quotes.
@@ -63,7 +53,7 @@ This runs a custom SQL function which inserts your user credentials.
 
 See design.md for the specifications of each API endpoint.
 
-To test the endpoint calls for /auth_token and /users respectively, run:
+To test the endpoint calls for /auth\_token and /users respectively, run:
 
 ```
 $ curl -X GET -i -H "Content-Type: application/json" "localhost:5000/api/auth_token" --data '{"email":"your_email", "password":"your_password"}'
@@ -71,13 +61,13 @@ $ curl -X GET -i -H "Content-Type: application/json" "localhost:5000/api/auth_to
 
 which should return something like this:
 
-```
+```json
 {
   "auth_token": "[long hash string]"
 }
 ```
 
-the auth_token string provides a claim that a particular user is logged in. Subsequent endpoints that require authorization will read the auth_token string to verify the logged-in user's credentials.
+the auth\_token string provides a claim that a particular user is logged in. Subsequent endpoints that require authorization will read the auth\_token string to verify the logged-in user's credentials.
 
 To run the /users/ POST endpoint, run
 
@@ -85,13 +75,15 @@ To run the /users/ POST endpoint, run
 $ curl -X POST -i -H "Content-Type: application/json" -H "Authorization: Bearer [auth-string]" localhost:5000/api/users --data '{"email":"new_email", "password":"new_password", "admin":false}'
 ```
 
-replacing `[auth-string]` with the auth_token value you just received. This should return:
+replacing `[auth-string]` with the auth\_token value you just received. This should return:
 
+```json
 {
   "admin": false,
   "email": "new_email",
   "timestamp": "[timestamp]"
 }
+```
 
 ## Mock Endpoints that make 3rd-party requests:
 

--- a/doc/recordsponge.com_devops_overview.md
+++ b/doc/recordsponge.com_devops_overview.md
@@ -23,4 +23,7 @@ Setting up swapspace version 1, size = 3.9 GiB (4145737728 bytes)
 no label, UUID=31f4b6de-d752-4b83-ba6a-2f27fb94784e
 ```
 
-No [Docker](https://www.docker.com/) containers have been used so far on production but that may change as the deployment pipeline is WIP.
+See more at:
+
+* [Docker config](../doc/docker.md)
+* [Digital Ocean host config](../src/ops/README.md#digitalocean-host-config)

--- a/src/ops/Makefile
+++ b/src/ops/Makefile
@@ -20,7 +20,7 @@ rsync:
 
 # echo out version.json
 version:
-	echo {\"recordexpungPDX\":\"$$(git rev-parse HEAD)\",\"branch\":\"$$(git rev-parse --abbrev-ref HEAD)\"} \
+	echo "{\"recordexpungPDX\":\"$$(git rev-parse HEAD)\",\"branch\":\"$$(git rev-parse --abbrev-ref HEAD)\"}" \
 		> docker/expungeservice/frontend/build/version.json
 
 # build an expungeservice image with the given RS_ENV tag ('staging', 'prod', etc)

--- a/src/ops/Makefile
+++ b/src/ops/Makefile
@@ -20,7 +20,8 @@ rsync:
 
 # echo out version.json
 version:
-	echo {\"recordexpungPDX\":\"$$(git rev-parse HEAD)\"} > docker/expungeservice/frontend/build/version.json
+	echo {\"recordexpungPDX\":\"$$(git rev-parse HEAD)\",\"branch\":\"$$(git rev-parse --abbrev-ref HEAD)\"} \
+		> docker/expungeservice/frontend/build/version.json
 
 # build an expungeservice image with the given RS_ENV tag ('staging', 'prod', etc)
 image: rsync env_check
@@ -63,7 +64,7 @@ endif
 #   * '*.env' with database credentials and TIER in _remote_ /etc/recordsponge/
 #
 ssh_deploy: env_check port_check
-	@echo ssh recordsponge -C \
+	@ssh recordsponge -C \
 		'docker pull recordsponge/expungeservice:$(DEPLOY_TAG); \
 		 docker stop $(RS_ENV); \
 		 docker run --rm -d --name $(RS_ENV) --env-file /etc/recordsponge/$(RS_ENV).env -p $(PORT):5000 recordsponge/expungeservice:$(DEPLOY_TAG)'

--- a/src/ops/Makefile
+++ b/src/ops/Makefile
@@ -1,14 +1,13 @@
 # make sure RS_ENV is set and not 'dev'
 env_check:
 ifndef RS_ENV
-	@echo error: set RS_ENV to 'staging' or 'prod' 1>&2
+	@echo error: RS_ENV value required 1>&2
 	@exit 1
 endif
 ifeq ($(RS_ENV),dev)
 	@echo error: RS_ENV can not be set to 'dev' 1>&2
 	@exit 1
 endif
-
 # remove source from docker image context tree
 clean:
 	rm -rf docker/expungeservice/backend \
@@ -32,27 +31,67 @@ image: rsync env_check
 push: env_check
 	docker push recordsponge/expungeservice:$(RS_ENV)
 
+# --- deploys
+
+# configure port
+ifeq ($(RS_ENV),staging)
+PORT := 3032
+else ifeq ($(RS_ENV),prod)
+PORT := 3031
+endif
+
+# configure DEPLOY_TAG
+ifndef DEPLOY_TAG
+DEPLOY_TAG := $(RS_ENV)
+endif
+
+# validate PORT setting
+port_check:
+ifndef PORT
+	@echo error: PORT value required - default for '$(RS_ENV)' not found 1>&2
+	@exit 1
+endif
+
+# ssh to digitalocean host and perform deploy.
+#
+#   * name of container based on RS_ENV e.g. 'staging' or 'prod'
+#   * PORT determined by RS_ENV, override on command line
+#   * DEPLOY_TAG defaults to RS_ENV, override on command line
+#
+# expects:
+#   * 'Host recordsponge' section in _local_ ~/.ssh/config (see /src/ops/README.md#SSH_Config)
+#   * '*.env' with database credentials and TIER in _remote_ /etc/recordsponge/
+#
+ssh_deploy: env_check port_check
+	@echo ssh recordsponge -C \
+		'docker pull recordsponge/expungeservice:$(DEPLOY_TAG); \
+		 docker stop $(RS_ENV); \
+		 docker run --rm -d --name $(RS_ENV) --env-file /etc/recordsponge/$(RS_ENV).env -p $(PORT):5000 recordsponge/expungeservice:$(DEPLOY_TAG)'
+
 # --- staging
 
 # build staging image
-staging_image:
-	@make clean
+staging_image: clean
 	@cd ../..; make frontend_build
 	@make rsync version image RS_ENV=staging
 
 staging_push:
 	@make push RS_ENV=staging
 
-# perform staging deploy
-#
-# expects:
-#   * 'Host recordsponge' section in ~/.ssh/config
-#   * 'staging.env' with database credentials and TIER in remote home dir
-ssh_staging_deploy:
-	@ssh recordsponge -C \
-		'docker pull recordsponge/expungeservice:staging; \
-		 docker stop staging; \
-		 docker run --rm -d --name staging --env-file staging.env -p 3032:5000 recordsponge/expungeservice:staging'
-
 # build and deploy staging
-staging: staging_image staging_push ssh_staging_deploy
+staging: staging_image staging_push
+	@make ssh_deploy RS_ENV=staging
+
+# --- production
+
+# build prod image
+prod_image: clean
+	@cd ../..; make frontend_build
+	@make rsync version image RS_ENV=prod
+
+prod_push:
+	@make push RS_ENV=prod
+
+# build and deploy prod
+prod: prod_image prod_push
+	@make ssh_deploy RS_ENV=prod

--- a/src/ops/README.md
+++ b/src/ops/README.md
@@ -27,15 +27,14 @@ The local developer environment for this project relies on 3 containers:
 * Python 3.7 to serve the Flask app (API & static files)
 * PostgreSQL 10 to be the database
 
-In trying to keep things simple, we only customize the Python container and use
-published base images for Node and Postgres directly. The Python container is
-configured to have all the run-time dependencies and the virutalenv defined by
-`Pipfile.lock`.
+We only customize the Python container and use published base images for Node
+and Postgres directly. The Python container is configured to have all the
+run-time dependencies and the virutalenv defined by `Pipfile.lock`.
 
-There are no run-time node requirements, since react-scripts will build a
+For node, there are no run-time requirements, since react-scripts will build a
 complete static tree of HTML, CSS, and JavaScript for production deploys. The
 Flask app is configured to serve these statically built files. This keeps
-deploys simple, see below.
+deploys simple, see [below](#Deploys).
 
 #### Python dependencies
 
@@ -112,7 +111,7 @@ TIER.
 
 A `recordsponge` organization has been created on Docker hub. The `expungeservice`
 repository under this org contains images with tags for `dev` (local), `staging`
-(dev.recordsponge.com), and (in the future) `prod` (recordsponge.com).
+(dev.recordsponge.com), and `prod` (recordsponge.com).
 
 ### DigitalOcean host config
 
@@ -138,7 +137,7 @@ key. You should now be able to connect with:
 $ ssh recordsponge
 ```
 
-#### SSL config
+#### TLS/SSL config
 
 LetsEncrypt is fully configured. See:
 
@@ -149,25 +148,15 @@ LetsEncrypt is fully configured. See:
 
 #### nginx config
 
-nginx is currently configured to serve the following domains:
-
-`recordsponge.com`:
-
-* requires GitHub access & git source tree on host
-* direct process, managed by hand
-* serves static files from `/usr/share/nginx/html`
-* `uwsgi_pass` proxy method
-* OOMs
-
-See `/etc/nginx/sites-available/recordexpunge-nginx.conf`.
-
-`dev.recordsponge.com`:
-
 * `proxy_pass` proxy method
 * terminates SSL, passes everything else to port
 * single-container listening on port
 
-See `/etc/nginx/sites-available/dev.recordsponge.com.conf`.
+| domain | conf file |
+|-|-|
+| recordpsonge.com | `/etc/nginx/sites-available/recordexpunge-nginx.conf` |
+| dev.recordpsonge.com | `/etc/nginx/sites-available/dev.recordsponge.com.conf` |
+|-|-|
 
 #### PostgreSQL config
 
@@ -188,11 +177,10 @@ TODO: find out details
 ### Steps to deploy
 
 NOTE: These steps assume the above configurations and a tangible example exists in
-the `staging` target of `src/ops/Makefile`.
+the `staging` and `prod` targets of [src/ops/Makefile](/src/ops/Makefile).
 
-1. build tagged image
-2. push tagged image
-3. connect to production host
-4. pull tagged image
-5. stop container
-6. start container
+1. build, tag, and push new image
+2. connect to production host
+3. pull new image
+4. stop container
+5. start container from new image


### PR DESCRIPTION
* adds `prod` and supporting deploy targets in src/ops/Makefile
* adds `frontend_restart` and doc reference in main Makefile
* updates relevant files in doc/

NEEDS TESTING