### PR TITLE
Ignore files under src/ops/docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,4 @@ src/backend/logs
 config/expungeservice/expungeservice.production.env
 src/backend/tests/endpoints/flask_session
 src/backend/flask_session
+src/ops/docker


### PR DESCRIPTION
These files get generated during staging deploy and should be ignored.