### PR TITLE
add sorting by date to RecordCreator

### DIFF
--- a/src/backend/expungeservice/record_creator.py
+++ b/src/backend/expungeservice/record_creator.py
@@ -67,5 +67,5 @@ class RecordCreator:
 
     @staticmethod
     def sort_record_by_case_date(record):
-        sortedCases = sorted(record.cases, key=lambda case: case.date, reverse=True)
-        return replace(record, cases=tuple(sortedCases))
+        sorted_cases = sorted(record.cases, key=lambda case: case.date, reverse=True)
+        return replace(record, cases=tuple(sorted_cases))

--- a/src/backend/expungeservice/record_creator.py
+++ b/src/backend/expungeservice/record_creator.py
@@ -62,4 +62,10 @@ class RecordCreator:
             charge_id_to_time_eligibilities.append(charge_id_to_time_eligibility)
             ambiguous_record_with_errors.append(record_with_errors)
         record = RecordMerger.merge(ambiguous_record_with_errors, charge_id_to_time_eligibilities)
-        return record
+        sorted_record = RecordCreator.sort_record_by_case_date(record)
+        return sorted_record
+
+    @staticmethod
+    def sort_record_by_case_date(record):
+        sortedCases = sorted(record.cases, key=lambda case: case.date, reverse=True)
+        return replace(record, cases=tuple(sortedCases))

--- a/src/backend/tests/crawler/test_crawler.py
+++ b/src/backend/tests/crawler/test_crawler.py
@@ -16,30 +16,30 @@ def test_search_function():
             "X0003": CaseDetails.CASE_WITHOUT_DISPOS,
         },
     )
-
+    # sorting by date results in the order X0003, X0002, X0001
     assert record.__class__ == Record
     assert len(record.cases) == 3
 
-    assert len(record.cases[0].charges) == 3
-    assert len(record.cases[1].charges) == 1
     assert len(record.cases[2].charges) == 3
+    assert len(record.cases[1].charges) == 1
+    assert len(record.cases[0].charges) == 3
 
-    assert record.cases[0].charges[0].disposition.ruling == "Convicted - Failure to Appear"
-    assert record.cases[0].charges[0].disposition.date == datetime.date(datetime.strptime("06/12/2017", "%m/%d/%Y"))
-    assert record.cases[0].charges[1].disposition.ruling == "Dismissed"
-    assert record.cases[0].charges[1].disposition.date == datetime.date(datetime.strptime("06/12/2017", "%m/%d/%Y"))
-    assert record.cases[0].charges[2].disposition.ruling == "Dismissed"
-    assert record.cases[0].charges[2].disposition.date == datetime.date(datetime.strptime("06/12/2017", "%m/%d/%Y"))
+    assert record.cases[2].charges[0].disposition.ruling == "Convicted - Failure to Appear"
+    assert record.cases[2].charges[0].disposition.date == datetime.date(datetime.strptime("06/12/2017", "%m/%d/%Y"))
+    assert record.cases[2].charges[1].disposition.ruling == "Dismissed"
+    assert record.cases[2].charges[1].disposition.date == datetime.date(datetime.strptime("06/12/2017", "%m/%d/%Y"))
+    assert record.cases[2].charges[2].disposition.ruling == "Dismissed"
+    assert record.cases[2].charges[2].disposition.date == datetime.date(datetime.strptime("06/12/2017", "%m/%d/%Y"))
 
     assert record.cases[1].charges[0].disposition.ruling == "Dismissed"
     assert record.cases[1].charges[0].disposition.date == datetime.date(datetime.strptime("04/30/1992", "%m/%d/%Y"))
 
-    assert record.cases[2].charges[0].disposition is None
-    assert record.cases[2].charges[0].disposition is None
-    assert record.cases[2].charges[1].disposition is None
-    assert record.cases[2].charges[1].disposition is None
-    assert record.cases[2].charges[2].disposition is None
-    assert record.cases[2].charges[2].disposition is None
+    assert record.cases[0].charges[0].disposition is None
+    assert record.cases[0].charges[0].disposition is None
+    assert record.cases[0].charges[1].disposition is None
+    assert record.cases[0].charges[1].disposition is None
+    assert record.cases[0].charges[2].disposition is None
+    assert record.cases[0].charges[2].disposition is None
 
 
 def test_a_blank_search_response():
@@ -72,7 +72,7 @@ def test_nonzero_balance_due_on_case():
         },
     )
 
-    assert record.cases[0].get_balance_due() == 1516.80
+    assert record.cases[2].get_balance_due() == 1516.80
 
 
 def test_zero_balance_due_on_case():

--- a/src/backend/tests/endpoints/test_search.py
+++ b/src/backend/tests/endpoints/test_search.py
@@ -10,6 +10,7 @@ from expungeservice.models.ambiguous import AmbiguousCase
 from expungeservice.models.record import Question
 from tests.endpoints.endpoint_util import EndpointShared
 from tests.factories.crawler_factory import CrawlerFactory
+from expungeservice.record_creator import RecordCreator
 
 
 @pytest.fixture
@@ -50,9 +51,12 @@ def mock_save_result_fail(request_data, record):
 
 
 def check_response_record_matches_mock_crawler_search(record_dict, mock_record):
+    # response data is now sorted by date just before return in search.py
+    # so test cases should be sorted with same method when testing against search.py
+    sorted_mock_record = RecordCreator.sort_record_by_case_date(mock_record)
     assert record_dict["total_balance_due"] == mock_record.total_balance_due
     case_numbers = [case["case_number"] for case in record_dict["cases"]]
-    mocked_case_numbers = [case.case_number for case in mock_record.cases]
+    mocked_case_numbers = [case.case_number for case in sorted_mock_record.cases]
     assert case_numbers == mocked_case_numbers
 
 

--- a/src/backend/tests/test_crawler_expunger.py
+++ b/src/backend/tests/test_crawler_expunger.py
@@ -199,7 +199,7 @@ def test_probation_revoked_affects_time_eligibility(record_with_revoked_probatio
     expunger_result = Expunger.run(record)
 
     assert len(expunger_result) == 6
-    assert expunger_result[record.cases[0].charges[0].ambiguous_charge_id].date_will_be_eligible == date_class(
+    assert expunger_result[record.cases[2].charges[0].ambiguous_charge_id].date_will_be_eligible == date_class(
         2020, 11, 9
     )
 

--- a/src/backend/tests/test_sort_record_by_date.py
+++ b/src/backend/tests/test_sort_record_by_date.py
@@ -1,41 +1,35 @@
 from expungeservice.record_creator import RecordCreator
-from tests.factories.crawler_factory import CrawlerFactory
+from expungeservice.models.record import Record
 from tests.factories.case_factory import CaseFactory
-import datetime
-
-
-def test_ensure_unsorted():
-    mock_data = CrawlerFactory.create()
-    mock_cases = mock_data.cases
-    assert mock_cases[0].date == datetime.date(1963, 3, 23)
-    assert mock_cases[1].date == datetime.date(1963, 4, 11)
-    assert mock_cases[2].date == datetime.date(2012, 4, 1)
 
 
 def test_sort_by_case_date():
-    mock_data = CrawlerFactory.create()
-    sortedRecord = RecordCreator.sort_record_by_case_date(mock_data)
-    sorted_mock_cases = sortedRecord.cases
-    assert sorted_mock_cases[0].date == datetime.date(2012, 4, 1)
-    assert sorted_mock_cases[1].date == datetime.date(1963, 4, 11)
-    assert sorted_mock_cases[2].date == datetime.date(1963, 3, 23)
+    case1 = CaseFactory.create(case_number="1", date_location=["1/1/2018", "Multnomah"])
+    case2 = CaseFactory.create(case_number="2", date_location=["1/1/2019", "Multnomah"])
+    case3 = CaseFactory.create(case_number="3", date_location=["1/1/2020", "Multnomah"])
+
+    record = Record(tuple([case1, case2, case3]))
+    assert record.cases[0].case_number == "1"
+    assert record.cases[1].case_number == "2"
+    assert record.cases[2].case_number == "3"
+
+    sorted_record = RecordCreator.sort_record_by_case_date(record)
+    assert sorted_record.cases[0].case_number == "3"
+    assert sorted_record.cases[1].case_number == "2"
+    assert sorted_record.cases[2].case_number == "1"
 
 
 def test_sort_if_all_dates_are_same():
-    mock_data = CrawlerFactory.create()
-    mock_cases = mock_data.cases
-    mock_cases[0].date = datetime.date(1963, 3, 23)
-    mock_cases[1].date = datetime.date(1963, 3, 23)
-    mock_cases[2].date = datetime.date(1963, 3, 23)
+    case1 = CaseFactory.create(case_number="1")
+    case2 = CaseFactory.create(case_number="2")
+    case3 = CaseFactory.create(case_number="3")
 
-    assert mock_cases[0].case_number == "X0001"
-    assert mock_cases[1].case_number == "X0002"
-    assert mock_cases[2].case_number == "X0003"
+    record = Record(tuple([case1, case2, case3]))
+    assert record.cases[0].case_number == "1"
+    assert record.cases[1].case_number == "2"
+    assert record.cases[2].case_number == "3"
 
-    sortedData = RecordCreator.sort_record_by_case_date(mock_data)
-    sortedCases = sortedData.cases
-
-    # data should be untouched
-    assert sortedCases[0].case_number == "X0001"
-    assert sortedCases[1].case_number == "X0002"
-    assert sortedCases[2].case_number == "X0003"
+    sorted_record = RecordCreator.sort_record_by_case_date(record)
+    assert sorted_record.cases[0].case_number == "1"
+    assert sorted_record.cases[1].case_number == "2"
+    assert sorted_record.cases[2].case_number == "3"

--- a/src/backend/tests/test_sort_record_by_date.py
+++ b/src/backend/tests/test_sort_record_by_date.py
@@ -1,0 +1,41 @@
+from expungeservice.record_creator import RecordCreator
+from tests.factories.crawler_factory import CrawlerFactory
+from tests.factories.case_factory import CaseFactory
+import datetime
+
+
+def test_ensure_unsorted():
+    mock_data = CrawlerFactory.create()
+    mock_cases = mock_data.cases
+    assert mock_cases[0].date == datetime.date(1963, 3, 23)
+    assert mock_cases[1].date == datetime.date(1963, 4, 11)
+    assert mock_cases[2].date == datetime.date(2012, 4, 1)
+
+
+def test_sort_by_case_date():
+    mock_data = CrawlerFactory.create()
+    sortedRecord = RecordCreator.sort_record_by_case_date(mock_data)
+    sorted_mock_cases = sortedRecord.cases
+    assert sorted_mock_cases[0].date == datetime.date(2012, 4, 1)
+    assert sorted_mock_cases[1].date == datetime.date(1963, 4, 11)
+    assert sorted_mock_cases[2].date == datetime.date(1963, 3, 23)
+
+
+def test_sort_if_all_dates_are_same():
+    mock_data = CrawlerFactory.create()
+    mock_cases = mock_data.cases
+    mock_cases[0].date = datetime.date(1963, 3, 23)
+    mock_cases[1].date = datetime.date(1963, 3, 23)
+    mock_cases[2].date = datetime.date(1963, 3, 23)
+
+    assert mock_cases[0].case_number == "X0001"
+    assert mock_cases[1].case_number == "X0002"
+    assert mock_cases[2].case_number == "X0003"
+
+    sortedData = RecordCreator.sort_record_by_case_date(mock_data)
+    sortedCases = sortedData.cases
+
+    # data should be untouched
+    assert sortedCases[0].case_number == "X0001"
+    assert sortedCases[1].case_number == "X0002"
+    assert sortedCases[2].case_number == "X0003"


### PR DESCRIPTION
replaces #979 to account for new disambiguate logic, placing the `sort` call in `analyze_ambiguous_record` where it gets called by both the `search` and `disambiguate` endpoints.   

co-author @jjames1011 