### PR TITLE
 is_admin cookie used to correctly show or hide admin buttons

### DIFF
--- a/src/backend/expungeservice/endpoints/auth.py
+++ b/src/backend/expungeservice/endpoints/auth.py
@@ -1,9 +1,10 @@
 from flask.views import MethodView
-from flask import request, jsonify, g
+from flask import request, make_response, g
 from flask_login import login_required, logout_user
 from flask_login.login_manager import LoginManager
 from werkzeug.security import check_password_hash
 from dacite import from_dict
+import time
 
 from expungeservice.request import check_data_fields
 from expungeservice.request import error
@@ -28,7 +29,13 @@ class AuthToken(MethodView):
         user = from_dict(data_class=User, data=user_db_result)
         User.login_user(user)
 
-        return jsonify({"is_admin": user.admin})
+        response = make_response()
+        if user.admin:
+            response.set_cookie(
+                "is_admin",
+                expires=time.time() + 365 * 24 * 60 * 60,  # type: ignore # 1 year lifetime matches flask login cookie
+            )
+        return response, 200
 
 
 class Logout(MethodView):

--- a/src/backend/tests/endpoints/test_auth.py
+++ b/src/backend/tests/endpoints/test_auth.py
@@ -28,7 +28,6 @@ def test_auth_token_valid_credentials(service):
     response = service.login(service.user_data["user1"]["email"], service.user_data["user1"]["password"])
 
     assert response.status_code == 200
-    assert response.headers.get("Content-type") == "application/json"
     cookie = service.client.cookie_jar._cookies["localhost.local"]["/"]["session"]
     assert cookie.version == 0
     assert cookie.name == "session"
@@ -37,7 +36,7 @@ def test_auth_token_valid_credentials(service):
     assert cookie.domain == "localhost.local"
     assert not cookie.domain_specified
     assert not cookie.domain_initial_dot
-    assert response.get_json()["is_admin"] is False
+    assert "is_admin" not in service.client.cookie_jar._cookies["localhost.local"]["/"]
 
 
 def test_auth_token_invalid_username(service):
@@ -121,7 +120,7 @@ def __login_user_with_custom_duration(service, monkeypatch, duration):
 
 def test_is_admin_auth_token(service):
     login_response = service.login(service.user_data["admin"]["email"], service.user_data["admin"]["password"])
-    assert login_response.get_json()["is_admin"]
+    assert "is_admin" in service.client.cookie_jar._cookies["localhost.local"]["/"]
 
     response = service.client.get("/api/test/admin_protected")
     assert response.status_code == 200

--- a/src/frontend/src/redux/system/actions.ts
+++ b/src/frontend/src/redux/system/actions.ts
@@ -1,5 +1,5 @@
 import apiService from '../../service/api-service';
-import { removeCookie, hasOeciToken } from '../../service/cookie-service';
+import { removeCookie, hasOeciToken, isAdmin } from '../../service/cookie-service';
 import history from '../../service/history';
 import { LOG_IN, LOG_OUT } from './types';
 import { Dispatch } from 'redux';
@@ -14,7 +14,7 @@ export function logIn(email: string, password: string): any {
     }).then((response: any) => {
       dispatch({
         type: LOG_IN,
-        isAdmin: response.data.is_admin
+        isAdmin: isAdmin()
       });
       history.push('/oeci');
     });
@@ -39,7 +39,8 @@ export function logOut(): any {
 
 export function refreshLocalAuth() {
   return {
-    type: LOG_IN
+    type: LOG_IN,
+    isAdmin: isAdmin()
   };
 }
 

--- a/src/frontend/src/service/cookie-service.ts
+++ b/src/frontend/src/service/cookie-service.ts
@@ -5,19 +5,16 @@ interface Cookie {
 }
 
 const getKeyValue = (inputCookie: string) =>
-  // splits the cookie-string on only the first '='
   [
     inputCookie.substring(0, inputCookie.indexOf('=')),
     inputCookie.substring(inputCookie.indexOf('=') + 1, inputCookie.length)
   ];
 
 export function decodeCookie() {
-  // first splits cookie into separate strings and then mapped to a returned object
   return document.cookie
     .split(';')
     .reduce((returnObject: Cookie, currentCookie) => {
       const [key, value] = getKeyValue(currentCookie);
-      // trim whitespace off of 'key'
       returnObject[key.trim()] = value;
       return returnObject;
     }, {});
@@ -26,10 +23,15 @@ export function decodeCookie() {
 export function removeCookie() {
   document.cookie = 'remember_token=; max-age=0;';
   document.cookie = 'oeci_token=; max-age=0;';
+  document.cookie = 'is_admin=; max-age=0;';
 }
 
 export function hasOeciToken() {
   return decodeCookie().oeci_token ? true : false;
+}
+
+export function isAdmin() {
+  return document.cookie.includes("is_admin");
 }
 
 export function checkOeciRedirect() {


### PR DESCRIPTION
This lets the frontend correctly show the Admin buttons even in a later session, after the browser has been closed and reopened.

The `is_admin` flag is updated in redux state once at login and once in "refreshLocalAuth()", when a new session begins.

Replaces #918, which was a different approach that used local storage. Closes #862 