### PR TITLE
update a few rules strings and the generated doc

### DIFF
--- a/doc/charge_types.md
+++ b/doc/charge_types.md
@@ -1,10 +1,15 @@
 # Charge Types
 The expungement system defines this custom set of charge types, to compute their correct type eligibility."
 ## Civil Offense
-\[rules documentation not added yet\]
+Expungement, generally speaking, only applies to criminal offenses. Civil offenses and administrative procedures – even those subject to punishments including jail time – are not eligible for expungement. The distinction between criminal and civil charges is far from clear. See, e.g. Brown v. Multnomah County Dist. Court, 570 P. 2d 52 - Or: Supreme Court 1977 ('There is no easy test for when the imposition of a sanction is a "criminal prosecution" within the meaning of the constitutional guarantees.') However, at least the following are not eligible under the expungement statute:
+ * Contempt of Court
+ * Extradition/Fugitive Complaint
+ * Parking tickets
+ These charges are ineligible even if they are marked as Violations or some other level that would normally qualify them as eligible.
 
-## Contempt of Court
- This is a civil offense that is always ineligible regardless of level / conviction status 
+
+## Dismissed Criminal Charge
+All non-duii criminal charges that are dismissed fall under this charge type.
 
 ## DUII
 A DUII conviction is not eligible for expungement, as it is considered a traffic violation.
@@ -12,6 +17,9 @@ A DUII dismissal resulting from completion of diversion (paying a fine, victim's
 HOWEVER, a DUII dismissal resulting from a Not Guilty verdict at trial, or is otherwise dismissed other than through diversion, is type-eligible like other dismissals.
 Therefore, to determine whether a dismissal is eligible, ask the client whether their case was dismissed through diversion or by a Not Guilty verdict or some way other than through diversion.
 
+
+## Diverted DUII
+A DUII dismissal resulting from completion of diversion is ineligible under ORS 137.225(8)(b).
 
 ## Felony Class A
 Class A felony convictions generally are omitted from the statute, and are ineligible, unless that Class A Felony was related to the Manufacturing/Delivery/Possession of Marijuana.
@@ -36,22 +44,29 @@ always eligible under 137.225(5)(b).
 Class C felony dismissals are always eligible under 137.225(1)(b).
 
 ## Juvenile
-\[rules documentation not added yet\]
+Juvenile records do not follow the general expungement rules. They are governed by a completely separate statute, ORS 419A.260 and 419A.262. We do not include them in our expungement analysis because information related to the cases is generally not available online, and the process for expunging these records is very different. Below is a summary of the juvenile expungement law.
 
-## Manufacture/Delivery
-Manufacture/Delivery is possibly eligible if it pertains to marijuana, under statute 137.226.
-Otherwise, it follows the normal eligibility rules for charge level and is typically a Class A or Class B Felony.
-It might be a marijuana charge if the charge is for schedule 1, or if the schedule is not specified in the charge name. If it's schedule 2, we can conclude that it's not a marijuana charge.
-The charge type is most easily idenfiable by name, so we check the presence of either of the following in the charge name (lowercase): "delivery", "manu/del".
-If it's not a marijuana charge, This charge type may or may not have time eligibility under the Class B Felony rule. Because it's simpler to determine time eligibility for a B felony, we instruct the user to determine this information manually:
-A Class B Felony that meets no other eligibility criteria will become eligible only after 20 years, and only if the person has no subsequent charges, other than traffic violations.
-A dismissed Manufacture/Delivery charge is eligible under 137.225(1)(b).
+In general, Under 419A.262(8), anyone can file for a motion for expungement in juvenile cases. The motion will then go to a contested hearing. Then “the juvenile court, after a hearing when the matter is contested, may order expunction of all or any part of the person’s record if it finds that to do so would be in the best interests of the person and the public.”
 
+The hearing will not be contested if a person meets certain narrow criteria:
+
+    1. At least five years have elapsed since the date of the person’s most recent termination;
+    2. Since the date of the most recent termination, the person has not been convicted of a felony or a Class A misdemeanor
+    3. No proceedings seeking a criminal conviction or an adjudication in a juvenile court are pending against the person
+    4. The person is not within the jurisdiction of any juvenile court on the basis of a petition alleging an act or behavior as defined in ORS 419B.100
+    5. The juvenile department is not aware of any pending investigation of the conduct of the person by any law enforcement agency.
+
+Additionally, under 419A.262(3)(B), cases for prostitution are automatically eligible for expungement if the person was 18 years or younger at the time of the conduct, and under 419A.262(9), “Romeo and Juliet” cases are eligible for expungement.
+
+The list of charges in ORS 419A.260(1)(d)(J) excludes certain charges from expungement eligibility. These charges generally would not be juvenile records since Oregon’s “Measure 11” requires the defendants in such cases to be charged as adults.
 
 ## Marijuana Eligible
 ORS 137.226 makes eligible additional marijuana-related charges - in particular, those crimes which are now considered minor felonies or below.
     One way to identify a marijuana crime is if it has the statute section 475860.
     Also if "marijuana", "marij", or "mj" are in the charge name, we conclude it's a marijuana eligible charge (after filtering out MarijuanaIneligible charges by statute).
+
+## Marijuana Eligible (Below age 21)
+Under ORS 137.226, marijuana convictions where the offender was under the age of 21 are eligible for conviction in a year assuming their record has no other charges.
 
 ## Marijuana Ineligible
 ORS 137.226 makes eligible additional marijuana-related charges - in particular, those crimes which are now considered minor felonies or below. However, there are certain marijuana-related crimes which are still considered major felonies. These are:
@@ -73,16 +88,19 @@ Parking Tickets are not eligible. ORS 137.225(7)(a) specifically prohibits expun
 ## Person Felony Class B
 If a [Class B Felony](#FelonyClassB) is also defined as a person felony under Oregon law, it is type-ineligible.
 A person felony is defined in section 14 of this page: (https://secure.sos.state.or.us/oard/displayDivisionRules.action?selectedDivision=712)
-In some cases, the statute named in this list includes a subsection. Because OECI can have a data error that excludes the subsection, records that are a B felony and also charged under one of these sections are tagged with Needs More Analysis, because the charge may or may not constitute a person felony depending on the subsection under which the person was charged.
 Dismissal of a person felony is eligible as usual under 137.225(1)(b).
 A person felony that is below a class B felony is not considered under this subsection and lower levels of charge may still be eligible, with the exceptions named elsewhere such as in [Subsection 6](#Subsection6).
 
 
 ## Sex Crime
+Sex Crimes are type-ineligible for expungement other than a narrow exception for "Romeo and Juliet" cases.
+For further detail, see 137.225(6)(a)
 
-        Sex Crimes are type-ineligible for expungement, other than a narrow exception for "Romeo and Juliet" cases.
-        For further detail, see 137.225(6)(a)
-        
+## 137.225(6)(f) related sex crime
+In some cases, a statutory rape charge may be eligible for a young offender. Please contact michael@qiu-qiulaw.com for manual analysis.
+
+## 137.225(6)(f) related sex crime
+See other entry for this charge type
 
 ## Subsection 6
 Subsection (6) names five felony statutes that have specific circumstances of the case under which they are ineligible.
@@ -93,10 +111,9 @@ The three remaining specifications in the statute are:
  * 163.205 (Criminal mistreatment I) is ineligible if the victim at the time of the crime was 65 years of age or older or a minor; otherwise eligible as a [Class C Felony](#FelonyClassC).
  * 163.575 (Endangering the welfare of a minor) (1)(a) is ineligible when the offense constitutes child abuse as defined in ORS 419B.005 (Definitions); otherwise eligible as a (Class A) [Misdemeanor](#Misdemeanor).
  * 163.145 (Criminally negligent homicide) is ineligible when that offense was punishable as a Class C felony.
-Dismissals are eligible under 137.225(1)(b).
 
-## Traffic Non-Violation
-\[rules documentation not added yet\]
+## Traffic Offense
+A conviction for a State or municipal traffic offense is not eligible for expungement. Common convictions under this category include Driving While Suspended/Revoked, Possession of a Stolen Vehicle, Driving Under the Influence of Intoxicants, and Failure to Perform Duties of a Driver.
 
 ## Traffic Violation
 Convictions for traffic-related offenses are not eligible for expungement under ORS 137.225(7)(a). This includes Violations, Misdemeanors, and Felonies. Traffic-related charges include Reckless Driving, Driving While Suspended, DUII, Failure to Perform Duties of a Driver, Giving False Information to a Police Officer (when in a car), Fleeing/Attempting to Elude a Police Officer, Possession of a Stolen Vehicle
@@ -105,7 +122,7 @@ Dismissed traffic-related Violations are not eligible for expungement
 HOWEVER, dismissed traffic-related Misdemeanors and Felonies, like all dismissed Misdemeanors and Felonies, ARE eligible for expungement.
 
 ## Unclassified
-\[rules documentation not added yet\]
+RecordSponge was not able to read this charge based on the information provided in the online records, and is therefore unable to determine its eligibility for expungement. Furthermore, if the conviction date was within the last ten years, your expungement analysis for your other cases may not be correct.
 
 ## Violation
 Violation convictions are eligible under ORS 137.225(5)(d).

--- a/src/backend/expungeservice/models/charge_types/duii.py
+++ b/src/backend/expungeservice/models/charge_types/duii.py
@@ -27,11 +27,6 @@ Therefore, to determine whether a dismissal is eligible, ask the client whether 
 @dataclass(frozen=True)
 class DivertedDuii(Charge):
     type_name: str = "Diverted DUII"
-
+    expungement_rules = "A DUII dismissal resulting from completion of diversion is ineligible under ORS 137.225(8)(b)."
     def _type_eligibility(self):
-        """
-        DUII charges can be diverted, and in some cases the Disposition will
-        reflect this and in others it will say Dismissed.  We need to handle
-        both possibilities.
-        """
         return TypeEligibility(EligibilityStatus.INELIGIBLE, reason="137.225(8)(b) - Diverted DUIIs are ineligible",)

--- a/src/backend/expungeservice/models/charge_types/sex_crimes.py
+++ b/src/backend/expungeservice/models/charge_types/sex_crimes.py
@@ -8,10 +8,8 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 class SexCrime(Charge):
     type_name: str = "Sex Crime"
     expungement_rules: str = (
-        """
-        Sex Crimes are type-ineligible for expungement other than a narrow exception for "Romeo and Juliet" cases.
-        For further detail, see 137.225(6)(a)
-        """
+        """Sex Crimes are type-ineligible for expungement other than a narrow exception for "Romeo and Juliet" cases.
+For further detail, see 137.225(6)(a)"""
     )
 
     statutes = [
@@ -62,7 +60,7 @@ class SexCrime(Charge):
 @dataclass(frozen=True)
 class RomeoAndJulietNMASexCrime(Charge):
     type_name: str = "137.225(6)(f) related sex crime"
-    expungement_rules: str = ("""Please contact michael@qiu-qiulaw.com for manual analysis.""")
+    expungement_rules: str = ("""In some cases, a statutory rape charge may be eligible for a young offender. Please contact michael@qiu-qiulaw.com for manual analysis.""")
 
     def _type_eligibility(self):
         if self.dismissed():
@@ -77,7 +75,7 @@ class RomeoAndJulietNMASexCrime(Charge):
 @dataclass(frozen=True)
 class RomeoAndJulietIneligibleSexCrime(Charge):
     type_name: str = "137.225(6)(f) related sex crime"
-    expungement_rules: str = ("""TODO""")
+    expungement_rules: str = ("""See other entry for this charge type""")
 
     def _type_eligibility(self):
         if self.dismissed():


### PR DESCRIPTION
Adds the final rules strings for every type.

Because the disambiguation feature needed to split a few charge types that "feel" like one type into two classes, namely `RomeoAndJulietIneligibleSexCrime` and `DUII`, that makes the generated documentation a bit awkward for those entries. We can resolve this as part of showing documentation in the frontend, by adding an in-page link to the "primary" class entry for each "split" type.

#797 