### PR TITLE
Logging refactor

### DIFF
--- a/src/backend/expungeservice/app.py
+++ b/src/backend/expungeservice/app.py
@@ -40,7 +40,6 @@ def create_app(env_name):
     sess.init_app(app)
 
     attach_logger(app)
-    app.logger.setLevel(logging.DEBUG)
 
     __register_endpoints(app)
 

--- a/src/backend/expungeservice/app.py
+++ b/src/backend/expungeservice/app.py
@@ -36,6 +36,7 @@ def create_app(env_name):
     # app initiliazation
     app = Flask(__name__, static_folder=FRONTEND_BUILD_DIR)
     app.config.from_object(app_config[env_name])
+    app.config.from_mapping(TIER=env_name)
     sess = Session()
     sess.init_app(app)
 

--- a/src/backend/expungeservice/loggers.py
+++ b/src/backend/expungeservice/loggers.py
@@ -36,8 +36,11 @@ class ColoredFormatter(DetailedFormatter):
 def attach_logger(app):
     app.logger = logging.getLogger("recordexpunge")
     app.logger.setLevel(logging.DEBUG)
-    colored_stdout_handler(app.logger)
-    file_handler(app.logger)
+    if app.config["TIER"] == "development":
+        colored_stdout_handler(app.logger)
+        file_handler(app.logger)
+    else:
+        stdout_handler(app.logger)
 
 def colored_stdout_handler(logger):
     stdout_handler = logging.StreamHandler()
@@ -50,3 +53,9 @@ def file_handler(logger):
     log_file_handler.setLevel(logging.DEBUG)
     log_file_handler.setFormatter(DetailedFormatter())
     logger.addHandler(log_file_handler)
+
+def stdout_handler(logger):
+    stdout_handler = logging.StreamHandler()
+    stdout_handler.setLevel(logging.DEBUG)
+    stdout_handler.setFormatter(DetailedFormatter())
+    logger.addHandler(stdout_handler)

--- a/src/backend/expungeservice/loggers.py
+++ b/src/backend/expungeservice/loggers.py
@@ -34,16 +34,19 @@ class ColoredFormatter(DetailedFormatter):
 
 
 def attach_logger(app):
-
     app.logger = logging.getLogger("recordexpunge")
+    app.logger.setLevel(logging.DEBUG)
+    colored_stdout_handler(app.logger)
+    file_handler(app.logger)
 
-    # create console handler with a higher log level
+def colored_stdout_handler(logger):
     stdout_handler = logging.StreamHandler()
     stdout_handler.setLevel(logging.DEBUG)
     stdout_handler.setFormatter(ColoredFormatter())
-    app.logger.addHandler(stdout_handler)
+    logger.addHandler(stdout_handler)
 
+def file_handler(logger):
     log_file_handler = logging.FileHandler("logs/expungeservice_log.txt")
     log_file_handler.setLevel(logging.DEBUG)
     log_file_handler.setFormatter(DetailedFormatter())
-    app.logger.addHandler(log_file_handler)
+    logger.addHandler(log_file_handler)

--- a/src/backend/expungeservice/request.py
+++ b/src/backend/expungeservice/request.py
@@ -1,9 +1,9 @@
-from flask import abort, jsonify, make_response
+from flask import abort, current_app, jsonify, make_response
 import logging
 
 
 def error(code, message):
-    logging.error("code %i %s" % (code, message), stack_info=True)
+    current_app.logger.error("code %i %s" % (code, message), stack_info=True)
     abort(make_response(jsonify(message=message), code))
 
 

--- a/src/ops/Makefile
+++ b/src/ops/Makefile
@@ -34,11 +34,13 @@ push: env_check
 
 # --- deploys
 
-# configure port
+# configure port & syslog facility
 ifeq ($(RS_ENV),staging)
 PORT := 3032
+FACILITY := local1
 else ifeq ($(RS_ENV),prod)
 PORT := 3031
+FACILITY := local0
 endif
 
 # configure DEPLOY_TAG
@@ -67,7 +69,15 @@ ssh_deploy: env_check port_check
 	@ssh recordsponge -C \
 		'docker pull recordsponge/expungeservice:$(DEPLOY_TAG); \
 		 docker stop $(RS_ENV); \
-		 docker run --rm -d --name $(RS_ENV) --env-file /etc/recordsponge/$(RS_ENV).env -p $(PORT):5000 recordsponge/expungeservice:$(DEPLOY_TAG)'
+		 docker run --rm -d \
+		            --name $(RS_ENV) \
+								--env-file /etc/recordsponge/$(RS_ENV).env \
+								-p $(PORT):5000 \
+								--log-driver syslog \
+								--log-opt syslog-address=udp://172.17.0.1 \
+								--log-opt syslog-facility=$(FACILITY) \
+								--log-opt tag=$(RS_ENV) \
+								recordsponge/expungeservice:$(DEPLOY_TAG)'
 
 # --- staging
 


### PR DESCRIPTION
address #463 ( and eventually #640 ) - changes in devops make using docker drivers for logs in deployed environments a goal. to handle error notifications, a [log handler](https://flask.palletsprojects.com/en/1.1.x/logging/#email-errors-to-admins) can be configured, or something similar and simple to post to a slack channel.

For local dev, this PR leaves the current *file* logging and colorized stdout logging in place. i do recommend eventually deprecating file logging in development.

This PR also adds TIER to app.config so it can be cased on to determine logging handlers, making production use only a non-colorized stdout.

Last commit is to use syslog docker logging drivers on the production host for standardized capture, rotation, etc. With all these changes, the staging and prod images should run everything logging to stdout, which will be routed by the docker driver into syslog, configured to deliver to /var/log/recordsponge/*.log on the host. For example, SSH into the host and run: `tail -f /var/log/recordsponge/staging.log`, browse to the dev.recordsponge.com site, and you will see the output. standard logrotate is also configured.