### PR TITLE
comment out local file log, remove extra syslog config

### DIFF
--- a/src/backend/expungeservice/loggers.py
+++ b/src/backend/expungeservice/loggers.py
@@ -38,7 +38,7 @@ def attach_logger(app):
     app.logger.setLevel(logging.DEBUG)
     if app.config["TIER"] == "development":
         colored_stdout_handler(app.logger)
-        file_handler(app.logger)
+        # file_handler(app.logger)
     else:
         stdout_handler(app.logger)
 

--- a/src/ops/Makefile
+++ b/src/ops/Makefile
@@ -74,7 +74,6 @@ ssh_deploy: env_check port_check
 								--env-file /etc/recordsponge/$(RS_ENV).env \
 								-p $(PORT):5000 \
 								--log-driver syslog \
-								--log-opt syslog-address=udp://172.17.0.1 \
 								--log-opt syslog-facility=$(FACILITY) \
 								--log-opt tag=$(RS_ENV) \
 								recordsponge/expungeservice:$(DEPLOY_TAG)'


### PR DESCRIPTION
simplify syslog config and comment out log file.

i realized i over complicated syslog: the docker daemon has access to rsyslogd's unix socket, so no need to open UDP ports on the `docker0` interface (thus not deal with circular init deps), nor tell the container a specific address.