### PR TITLE
Freeze node docker container to pull node version 13.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
   frontend:
     runs-on: ubuntu-latest
     container:
-      image: node:alpine
+      image: node:13.13.0-alpine
       env:
         CI: true
     steps:

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ frontend_build: frontend_clean
 	docker run --rm \
 		-v `pwd`/src/frontend:/src/frontend \
 		-v recordexpungpdx_node_modules:/src/frontend/node_modules \
-		node:alpine /bin/sh -c 'cd /src/frontend && npm run build'
+		node:13.13.0-alpine /bin/sh -c 'cd /src/frontend && npm run build'
 
 # delete react built files
 frontend_clean:

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -79,7 +79,7 @@ While the full dev stack is running, you can use the app in two different ways:
 
 #### Frontend Development
 
-The frontend stack uses [react-scripts](https://github.com/facebook/create-react-app#readme) which starts a hot-module-reloading dev server for quick iterative work. This is run inside the `node` service, which runs from the stock `node:alpine` image and mounts a persistent named volume to house the node\_modules. This service is listening at:
+The frontend stack uses [react-scripts](https://github.com/facebook/create-react-app#readme) which starts a hot-module-reloading dev server for quick iterative work. This is run inside the `node` service, which runs from the stock `node:13.13.0-alpine` image and mounts a persistent named volume to house the node\_modules. This service is listening at:
 
 [http://localhost:3000](http://localhost:3000)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     command: sh -c "cd /src/frontend && npm install && npm start"
     depends_on:
       - expungeservice
-    image: node:alpine
+    image: node:13.13.0-alpine
     ports:
       - "3000:3000"
     volumes:


### PR DESCRIPTION
Our frontend tests started failing today: see https://github.com/codeforpdx/recordexpungPDX/pull/1057/checks?check_run_id=608399130. Since we don't specify the node version in docker, the node version was automatically bumped to node v14, which is not compatible with the latest node-sass version. This change freezes our node version at 13.13.