### PR TITLE
Move disambiguate endpoint functions into search endpoint

### DIFF
--- a/src/backend/expungeservice/database/db_util.py
+++ b/src/backend/expungeservice/database/db_util.py
@@ -5,6 +5,7 @@ import uuid
 import hashlib
 from flask_login import current_user
 
+
 def rollback_errors(db_operation):
     @functools.wraps(db_operation)
     def wrapper(database, *args, **kwargs):
@@ -18,9 +19,9 @@ def rollback_errors(db_operation):
     return wrapper
 
 
-def save_search_event(request_data, record):
+def save_search_event(aliases_data):
     user_id = current_user.user_id
-    search_param_string = user_id + json.dumps(request_data["aliases"], sort_keys=True)
+    search_param_string = user_id + json.dumps(aliases_data, sort_keys=True)
     hashed_search_params = hashlib.sha256(search_param_string.encode()).hexdigest()
     _db_insert_search_event(g.database, user_id, hashed_search_params)
 
@@ -32,8 +33,5 @@ def _db_insert_search_event(database, user_id, hashed_search_params):
         INSERT INTO  SEARCH_RESULTS(search_result_id, user_id, hashed_search_params)
         VALUES ( uuid_generate_v4(), %(user_id)s, %(params)s);
         """,
-        {
-            "user_id": uuid.UUID(user_id).hex,
-            "params": hashed_search_params,
-        },
+        {"user_id": uuid.UUID(user_id).hex, "params": hashed_search_params,},
     )

--- a/src/backend/expungeservice/endpoints/search.py
+++ b/src/backend/expungeservice/endpoints/search.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Dict, Any
 
 from dacite import from_dict
 from flask.views import MethodView
@@ -27,30 +27,42 @@ class Search(MethodView):
         check_data_fields(request_data, ["aliases"])
         for alias in request_data["aliases"]:
             check_data_fields(alias, ["first_name", "last_name", "middle_name", "birth_date"])
-
+        aliases_data = request_data["aliases"]
+        questions_data = request_data.get("questions")
         cipher = DataCipher(key=current_app.config.get("SECRET_KEY"))
-
         if not "oeci_token" in request.cookies.keys():
             error(401, "Missing login credentials to OECI.")
         decrypted_credentials = cipher.decrypt(request.cookies["oeci_token"])
         username, password = decrypted_credentials["oeci_username"], decrypted_credentials["oeci_password"]
+        return Search.build_response(username, password, aliases_data, questions_data)
 
-        aliases = [from_dict(data_class=Alias, data=alias) for alias in request_data["aliases"]]
+    @staticmethod
+    def build_response(username, password, aliases_data, questions_data):
+        aliases = [from_dict(data_class=Alias, data=alias) for alias in aliases_data]
         record, ambiguous_record, questions = RecordCreator.build_record(username, password, tuple(aliases))
+        # TODO: Remove
         if questions:
             session["ambiguous_record"] = ambiguous_record
-
+        if questions_data:
+            questions, record = Search.disambiguate_record(ambiguous_record, questions_data)
         try:
-            save_search_event(request_data, record)
+            save_search_event(aliases_data)
         except Exception as ex:
             logging.error("Saving search result failed with exception: %s" % ex, stack_info=True)
-
         record_summary = RecordSummarizer.summarize(record, questions)
         response_data = {"record": record_summary}
-        encoded_response = json.dumps(response_data, cls=ExpungeModelEncoder)
-        return encoded_response
+        return json.dumps(response_data, cls=ExpungeModelEncoder)
+
+    @staticmethod
+    def disambiguate_record(ambiguous_record, questions_data):
+        questions_as_list = [from_dict(data_class=Question, data=question) for id, question in questions_data.items()]
+        questions = dict(list(map(lambda q: (q.ambiguous_charge_id, q), questions_as_list)))
+        updated_ambiguous_record = RecordMerger.filter_ambiguous_record(ambiguous_record, questions_as_list)
+        record = RecordCreator.analyze_ambiguous_record(updated_ambiguous_record)
+        return questions, record
 
 
+# TODO: Deprecated: Remove
 class Disambiguate(MethodView):
     @login_required
     def post(self):

--- a/src/backend/tests/test_save_search_event.py
+++ b/src/backend/tests/test_save_search_event.py
@@ -2,9 +2,9 @@ import pytest
 from flask import g
 
 from tests.endpoints.endpoint_util import EndpointShared
-from tests.factories.crawler_factory import CrawlerFactory
 from expungeservice.database import get_database
 from expungeservice.database.db_util import save_search_event
+
 
 @pytest.fixture
 def service():
@@ -23,17 +23,9 @@ def test_save_search_event(service):
         request_data = {
             "aliases": [{"first_name": "John", "last_name": "Doe", "middle_name": "Test", "birth_date": "01/01/1980",}]
         }
-
-        record = CrawlerFactory.create()
-
         service.login(service.user_data["user1"]["email"], service.user_data["user1"]["password"])
-
         g.database = get_database()
-
-        save_search_event(request_data, record)
-
+        save_search_event(request_data["aliases"])
         g.database.connection.commit()
 
-    service.check_search_event_saved(
-        service.user_data["user1"]["user_id"], request_data
-    )
+    service.check_search_event_saved(service.user_data["user1"]["user_id"], request_data)


### PR DESCRIPTION
This temporarily duplicates functionality as the frontend needs to be updated to use the new search endpoint for both calls.