### PR TITLE
Ask felony class level for a Felony Unclassified charge

### DIFF
--- a/src/backend/expungeservice/charge_classifier.py
+++ b/src/backend/expungeservice/charge_classifier.py
@@ -117,6 +117,12 @@ class ChargeClassifier:
                 return AmbiguousChargeTypeWithQuestion([FelonyClassB])
         if level == "Felony Class A":
             return AmbiguousChargeTypeWithQuestion([FelonyClassA])
+        if level == "Felony Unclassified":
+            question_string = "Was the charge for an A Felony, B Felony, or C Felony?"
+            options = ["A Felony", "B Felony", "C Felony"]
+            return AmbiguousChargeTypeWithQuestion(
+                [FelonyClassA, FelonyClassB, FelonyClassC], question_string, options
+            )
 
     @staticmethod
     def _marijuana_ineligible(statute, section):
@@ -136,22 +142,9 @@ class ChargeClassifier:
     @staticmethod
     def _manufacture_delivery(name, level, statute):
         if any([keyword in name for keyword in ["delivery", "manu/del", "manufactur"]]):
-            if "2" in name or "heroin" in name or "cocaine" in name or "meth" in name:
-                if level == "Felony Unclassified":
-                    question_string = "Was the charge for an A Felony or B Felony?"
-                    options = ["A Felony", "B Felony"]
-                    return AmbiguousChargeTypeWithQuestion([FelonyClassA, FelonyClassB], question_string, options)
-                else:
-                    return ChargeClassifier._classification_by_level(level, statute)
-            elif "3" in name or "4" in name:
-                if level == "Felony Unclassified":
-                    question_string = "Was the charge for an A Felony, B Felony, or C Felony?"
-                    options = ["A Felony", "B Felony", "C Felony"]
-                    return AmbiguousChargeTypeWithQuestion(
-                        [FelonyClassA, FelonyClassB, FelonyClassC], question_string, options
-                    )
-                else:
-                    return ChargeClassifier._classification_by_level(level, statute)
+            if any([non_marijuana_keyword in name for non_marijuana_keyword in [
+                "2", "3", "4", "heroin", "cocaine", "meth"]]):
+                return ChargeClassifier._classification_by_level(level, statute)
             else:
                 # The name contains either a "1" or no schedule number, and is possibly a marijuana charge.
                 if level == "Felony Unclassified":

--- a/src/backend/expungeservice/charge_classifier.py
+++ b/src/backend/expungeservice/charge_classifier.py
@@ -141,9 +141,16 @@ class ChargeClassifier:
 
     @staticmethod
     def _manufacture_delivery(name, level, statute):
-        if any([keyword in name for keyword in ["delivery", "manu/del", "manufactur"]]):
-            if any([non_marijuana_keyword in name for non_marijuana_keyword in [
-                "2", "3", "4", "heroin", "cocaine", "meth"]]):
+        if any([manu_del_keyword in name for manu_del_keyword in ["delivery", "manu/del", "manufactur"]]):
+            if any([schedule_2_keyword in name for schedule_2_keyword in [
+                "2", "heroin", "cocaine", "meth"]]):
+                if level == "Felony Unclassified":
+                    question_string = "Was the charge for an A Felony or B Felony?"
+                    options = ["A Felony", "B Felony"]
+                    return AmbiguousChargeTypeWithQuestion(
+                        [FelonyClassA, FelonyClassB], question_string, options
+                    )
+            elif "3" in name or "4" in name:
                 return ChargeClassifier._classification_by_level(level, statute)
             else:
                 # The name contains either a "1" or no schedule number, and is possibly a marijuana charge.

--- a/src/backend/tests/models/charge_types/test_felony_unclassified.py
+++ b/src/backend/tests/models/charge_types/test_felony_unclassified.py
@@ -1,0 +1,21 @@
+from expungeservice.models.expungement_result import EligibilityStatus
+
+from tests.factories.charge_factory import ChargeFactory
+from tests.models.test_charge import Dispositions
+from expungeservice.record_merger import RecordMerger
+
+
+def test_felony_unclassified_charge():
+    charges = ChargeFactory.create_ambiguous_charge(
+        name="Criminal Forfeiture",
+        statute="CH666",
+        level="Felony Unclassified",
+        disposition=Dispositions.CONVICTED,
+    )
+    type_eligibility = RecordMerger.merge_type_eligibilities(charges)
+
+    assert type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert (
+        type_eligibility.reason
+        == "Ineligible by omission from statute ⬥ Convictions that fulfill the conditions of 137.225(5)(a) are eligible ⬥ Eligible under 137.225(5)(b)"
+    )

--- a/src/backend/tests/models/charge_types/test_manufacture_delivery.py
+++ b/src/backend/tests/models/charge_types/test_manufacture_delivery.py
@@ -107,7 +107,7 @@ def test_manufacture_delivery_1():
     assert type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert (
         type_eligibility.reason
-        == "Ineligible by omission from statute ⬥ Convictions that fulfill the conditions of 137.225(5)(a) are eligible"
+        == "Ineligible by omission from statute ⬥ Convictions that fulfill the conditions of 137.225(5)(a) are eligible ⬥ Eligible under 137.225(5)(b)"
     )
 
 
@@ -123,5 +123,5 @@ def test_manufacture_delivery_heroin():
     assert type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert (
         type_eligibility.reason
-        == "Ineligible by omission from statute ⬥ Convictions that fulfill the conditions of 137.225(5)(a) are eligible"
+        == "Ineligible by omission from statute ⬥ Convictions that fulfill the conditions of 137.225(5)(a) are eligible ⬥ Eligible under 137.225(5)(b)"
     )

--- a/src/backend/tests/models/charge_types/test_manufacture_delivery.py
+++ b/src/backend/tests/models/charge_types/test_manufacture_delivery.py
@@ -95,7 +95,7 @@ def test_manufacture_delivery_manufacturing_name():
     )
 
 
-def test_manufacture_delivery_1():
+def test_manufacture_delivery_2():
     charges = ChargeFactory.create_ambiguous_charge(
         name="MANUFACTURING CONTROLLED SUB 2",
         statute="4759921A",
@@ -107,7 +107,7 @@ def test_manufacture_delivery_1():
     assert type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert (
         type_eligibility.reason
-        == "Ineligible by omission from statute ⬥ Convictions that fulfill the conditions of 137.225(5)(a) are eligible ⬥ Eligible under 137.225(5)(b)"
+        == "Ineligible by omission from statute ⬥ Convictions that fulfill the conditions of 137.225(5)(a) are eligible"
     )
 
 
@@ -123,5 +123,5 @@ def test_manufacture_delivery_heroin():
     assert type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert (
         type_eligibility.reason
-        == "Ineligible by omission from statute ⬥ Convictions that fulfill the conditions of 137.225(5)(a) are eligible ⬥ Eligible under 137.225(5)(b)"
+        == "Ineligible by omission from statute ⬥ Convictions that fulfill the conditions of 137.225(5)(a) are eligible"
     )


### PR DESCRIPTION
This disambiguating question removes a few known instances of an Unclassified Charge Type.

It also lets us clean up Manu/Del logic a bit. It includes a small change to how manu/del charges behaved: we used to assume that, if a manu/del charge was schedule 2, or heroin, meth, or cocaine, the charge could only be Felony Class A or B. Schedule 3 or 4 could be Class A, B, or C.

Now, all of these charges with "non-marijuana identifiers" can be answered (if Felony Unclassified) as felony class A, B, or C.

This actually matches the way we handle Person Felonies: namely, it's possible that a charge that's statutorily one Felony class can be prosecuted as a different class, so we take the actual charge class that was prosecuted to determine eligibility.

closes #1049 