### PR TITLE
Remove account link from header

### DIFF
--- a/src/frontend/src/components/Header/index.tsx
+++ b/src/frontend/src/components/Header/index.tsx
@@ -43,15 +43,6 @@ class Header extends React.Component<Props> {
                 Admin
               </button>
             ) : null}
-            {this.props.isAdmin ? (
-              <button
-                onClick={() => history.push('/account')}
-                className="link mid-gray hover-blue f6 f5-ns dib pa3"
-              >
-                Account
-              </button>
-            ) : null}
-
               <LogOut>
               {/* Nesting the button within a <Link> tag here would
                 render but creates invalid HTML.


### PR DESCRIPTION
Follow up from https://github.com/codeforpdx/recordexpungPDX/pull/1047

It looks like there was intent to remove the account link: https://github.com/codeforpdx/recordexpungPDX/pull/1047/files#diff-55e17045cee2e59c129fd7d44781c75bL29.