### PR TITLE
Edit record results backend support

### DIFF
--- a/src/backend/expungeservice/endpoints/search.py
+++ b/src/backend/expungeservice/endpoints/search.py
@@ -27,19 +27,18 @@ class Search(MethodView):
         aliases_data = request_data["aliases"]
         questions_data = request_data.get("questions")
         edits_data = request_data.get("edits") or {}
-        additions_data = request_data.get("additions") or []
         cipher = DataCipher(key=current_app.config.get("SECRET_KEY"))
         if not "oeci_token" in request.cookies.keys():
             error(401, "Missing login credentials to OECI.")
         decrypted_credentials = cipher.decrypt(request.cookies["oeci_token"])
         username, password = decrypted_credentials["oeci_username"], decrypted_credentials["oeci_password"]
-        return Search.build_response(username, password, aliases_data, questions_data, edits_data, additions_data)
+        return Search.build_response(username, password, aliases_data, questions_data, edits_data)
 
     @staticmethod
-    def build_response(username, password, aliases_data, questions_data, edits_data, additions_data):
+    def build_response(username, password, aliases_data, questions_data, edits_data):
         aliases = [from_dict(data_class=Alias, data=alias) for alias in aliases_data]
         record, ambiguous_record, questions = RecordCreator.build_record(
-            RecordCreator.build_search_results, username, password, tuple(aliases), edits_data, additions_data
+            RecordCreator.build_search_results, username, password, tuple(aliases), edits_data
         )
         if questions_data:
             questions, record = Search.disambiguate_record(ambiguous_record, questions_data)

--- a/src/backend/expungeservice/endpoints/search.py
+++ b/src/backend/expungeservice/endpoints/search.py
@@ -26,17 +26,19 @@ class Search(MethodView):
             check_data_fields(alias, ["first_name", "last_name", "middle_name", "birth_date"])
         aliases_data = request_data["aliases"]
         questions_data = request_data.get("questions")
+        edits_data = request_data.get("edits") or {}
+        additions_data = request_data.get("additions") or []
         cipher = DataCipher(key=current_app.config.get("SECRET_KEY"))
         if not "oeci_token" in request.cookies.keys():
             error(401, "Missing login credentials to OECI.")
         decrypted_credentials = cipher.decrypt(request.cookies["oeci_token"])
         username, password = decrypted_credentials["oeci_username"], decrypted_credentials["oeci_password"]
-        return Search.build_response(username, password, aliases_data, questions_data)
+        return Search.build_response(username, password, aliases_data, questions_data, edits_data, additions_data)
 
     @staticmethod
-    def build_response(username, password, aliases_data, questions_data):
+    def build_response(username, password, aliases_data, questions_data, edits_data, additions_data):
         aliases = [from_dict(data_class=Alias, data=alias) for alias in aliases_data]
-        record, ambiguous_record, questions = RecordCreator.build_record(username, password, tuple(aliases))
+        record, ambiguous_record, questions = RecordCreator.build_record(username, password, tuple(aliases), edits_data, additions_data)
         if questions_data:
             questions, record = Search.disambiguate_record(ambiguous_record, questions_data)
         try:

--- a/src/backend/expungeservice/endpoints/search.py
+++ b/src/backend/expungeservice/endpoints/search.py
@@ -38,7 +38,9 @@ class Search(MethodView):
     @staticmethod
     def build_response(username, password, aliases_data, questions_data, edits_data, additions_data):
         aliases = [from_dict(data_class=Alias, data=alias) for alias in aliases_data]
-        record, ambiguous_record, questions = RecordCreator.build_record(username, password, tuple(aliases), edits_data, additions_data)
+        record, ambiguous_record, questions = RecordCreator.build_record(
+            RecordCreator.build_search_results, username, password, tuple(aliases), edits_data, additions_data
+        )
         if questions_data:
             questions, record = Search.disambiguate_record(ambiguous_record, questions_data)
         try:

--- a/src/backend/expungeservice/record_creator.py
+++ b/src/backend/expungeservice/record_creator.py
@@ -20,11 +20,7 @@ from expungeservice.models.disposition import DispositionCreator
 class RecordCreator:
     @staticmethod
     def build_record(
-        search: Callable,
-        username: str,
-        password: str,
-        aliases: Tuple[Alias, ...],
-        edits: Dict[str, Dict[str, Any]],
+        search: Callable, username: str, password: str, aliases: Tuple[Alias, ...], edits: Dict[str, Dict[str, Any]],
     ) -> Tuple[Record, AmbiguousRecord, Dict[str, Question]]:
         search_results, errors = search(username, password, aliases)
         if errors:
@@ -39,16 +35,14 @@ class RecordCreator:
                     lambda case: case.summary.case_number,
                 )
             ]
-            user_edited_search_results = RecordCreator._edit_search_results(
-                cases_with_unique_case_number, edits
-            )
+            user_edited_search_results = RecordCreator._edit_search_results(cases_with_unique_case_number, edits)
             ambiguous_record, questions = RecordCreator.build_ambiguous_record(user_edited_search_results)
             record = RecordCreator.analyze_ambiguous_record(ambiguous_record)
             questions_as_dict = dict(list(map(lambda q: (q.ambiguous_charge_id, q), questions)))
             return record, ambiguous_record, questions_as_dict
 
-    # TODO: In the future we will add a cache here
     @staticmethod
+    @lru_cache(maxsize=4)
     def build_search_results(
         username: str, password: str, aliases: Tuple[Alias, ...]
     ) -> Tuple[List[OeciCase], List[str]]:

--- a/src/backend/expungeservice/record_creator.py
+++ b/src/backend/expungeservice/record_creator.py
@@ -25,7 +25,6 @@ class RecordCreator:
         password: str,
         aliases: Tuple[Alias, ...],
         edits: Dict[str, Dict[str, Any]],
-        additions: List[Dict[str, Any]],
     ) -> Tuple[Record, AmbiguousRecord, Dict[str, Question]]:
         search_results, errors = search(username, password, aliases)
         if errors:
@@ -41,7 +40,7 @@ class RecordCreator:
                 )
             ]
             user_edited_search_results = RecordCreator._edit_search_results(
-                cases_with_unique_case_number, edits, additions
+                cases_with_unique_case_number, edits
             )
             ambiguous_record, questions = RecordCreator.build_ambiguous_record(user_edited_search_results)
             record = RecordCreator.analyze_ambiguous_record(ambiguous_record)
@@ -131,7 +130,7 @@ class RecordCreator:
         return ambiguous_case, questions
 
     @staticmethod
-    def _edit_search_results(search_result_cases: List[OeciCase], edits, additions) -> List[OeciCase]:
+    def _edit_search_results(search_result_cases: List[OeciCase], edits) -> List[OeciCase]:
         edited_cases: List[OeciCase] = []
         for case in search_result_cases:
             case_number = case.summary.case_number
@@ -141,8 +140,7 @@ class RecordCreator:
                 # else: if the action name for this case_number isn't "edit", assume it is "delete" and skip it
             else:
                 edited_cases.append(case)
-        new_cases = RecordCreator._build_additional_cases(additions)
-        return edited_cases + new_cases
+        return edited_cases
 
     @staticmethod
     def _edit_case(case, edits):
@@ -187,8 +185,3 @@ class RecordCreator:
             else:
                 edited_charges.append(charge)
         return edited_charges
-
-    @staticmethod
-    def _build_additional_cases(additions):
-        # todo: implement
-        return []

--- a/src/backend/expungeservice/record_creator.py
+++ b/src/backend/expungeservice/record_creator.py
@@ -1,7 +1,8 @@
 from dataclasses import replace
 from functools import lru_cache
 from itertools import product, groupby
-from typing import List, Dict, Tuple
+from typing import List, Dict, Tuple, Any
+from datetime import datetime
 
 import requests
 
@@ -9,17 +10,16 @@ from expungeservice.charge_creator import ChargeCreator
 from expungeservice.crawler.crawler import Crawler, InvalidOECIUsernamePassword, OECIUnavailable
 from expungeservice.expunger import ErrorChecker, Expunger
 from expungeservice.models.ambiguous import AmbiguousCharge, AmbiguousCase, AmbiguousRecord
-from expungeservice.models.case import Case, OeciCase
+from expungeservice.models.case import Case, OeciCase, CaseCreator
 from expungeservice.record_merger import RecordMerger
 from expungeservice.models.record import Record, Question, Alias
 from expungeservice.request import error
-
+from expungeservice.models.disposition import DispositionCreator
 
 class RecordCreator:
     @staticmethod
-    @lru_cache(maxsize=4)
     def build_record(
-        username: str, password: str, aliases: Tuple[Alias, ...]
+        username: str, password: str, aliases: Tuple[Alias, ...], edits: Dict[str, Dict[str, Any]], additions: List[Dict[str,Any]]
     ) -> Tuple[Record, AmbiguousRecord, Dict[str, Question]]:
         search_results, errors = RecordCreator._build_search_results(username, password, aliases)
         if errors:
@@ -34,8 +34,8 @@ class RecordCreator:
                     lambda case: case.summary.case_number,
                 )
             ]
-            user_edited_search_results = RecordCreator.edit_search_results(
-                cases_with_unique_case_number, user_edits=None
+            user_edited_search_results = RecordCreator._edit_search_results(
+                cases_with_unique_case_number, edits, additions
             )
             ambiguous_record, questions = RecordCreator.build_ambiguous_record(user_edited_search_results)
             record = RecordCreator.analyze_ambiguous_record(ambiguous_record)
@@ -124,7 +124,64 @@ class RecordCreator:
             ambiguous_case.append(possible_case)
         return ambiguous_case, questions
 
-    # TODO: implement.
     @staticmethod
-    def edit_search_results(cases_with_unique_case_number: List[OeciCase], user_edits) -> List[OeciCase]:
-        return cases_with_unique_case_number
+    def _edit_search_results(search_result_cases: List[OeciCase], edits, additions) -> List[OeciCase]:
+        edited_cases: List[OeciCase] = []
+        for case in search_result_cases:
+            case_number = case.summary.case_number
+            if case_number in edits.keys():
+                if edits[case_number]["action"] == "edit":
+                    edited_cases.append(RecordCreator._edit_case(case, edits[case_number]))
+                # else: if the action name for this case_number isn't "edit", assume it is "delete" and skip it
+            else:
+                edited_cases.append(case)
+        new_cases = RecordCreator._build_additional_cases(additions)
+        return edited_cases + new_cases
+
+    @staticmethod
+    def _edit_case(case, edits):
+        if "summary" in edits.keys():
+            case_summary_edits: Dict[str, Any] = {}
+            for key,value in edits["summary"].items():
+                if key in ("date", "probation_revoked"):
+                    case_summary_edits[key] = datetime.date(datetime.strptime(value, "%m/%d/%Y"))
+                elif key == "balance_due":
+                    case_summary_edits["balance_due_in_cents"] = CaseCreator.compute_balance_due_in_cents(value)
+                elif key == "birth_year":
+                    case_summary_edits["birth_year"] = int(value)
+                else:
+                    case_summary_edits[key] = value
+            edited_summary = replace(case.summary, **case_summary_edits)
+        else:
+            edited_summary = case.summary
+        if "charges" in edits.keys():
+            edited_charges = RecordCreator._edit_charges(case.charges, edits["charges"])
+        else:
+            edited_charges = case.charges
+        return OeciCase(edited_summary, edited_charges)
+
+    @staticmethod
+    def _edit_charges(charges, edits):
+        edited_charges = []
+        for charge in charges:
+            # TODO: deleting charges not supported yet
+            if charge.id in edits.keys():
+                charge_edits: Dict[str, Any] =  {}
+                for key,value in edits[charge.id].items():
+                    if key == "disposition":
+                        charge_edits["disposition"] = DispositionCreator.create(
+                            datetime.date(datetime.strptime(edits[charge.id]["disposition"]["date"], "%m/%d/%Y")),
+                            edits[charge.id]["disposition"]["ruling"])
+                    elif key == "date":
+                        charge_edits["date"] = datetime.date(datetime.strptime(value, "%m/%d/%Y"))
+                    else:
+                        charge_edits[key] = value
+                edited_charges.append(replace(charge, **charge_edits))
+            else:
+                edited_charges.append(charge)
+        return edited_charges
+
+    @staticmethod
+    def _build_additional_cases(additions):
+        # todo: implement
+        return []

--- a/src/backend/tests/factories/crawler_factory.py
+++ b/src/backend/tests/factories/crawler_factory.py
@@ -37,6 +37,6 @@ class CrawlerFactory:
                 m.get("{}{}{}".format(base_url, "CaseDetail.aspx?CaseID=", key), text=value)
 
             aliases = (Alias(first_name="John", last_name="Doe", middle_name="", birth_date=""),)
-            return RecordCreator.build_record( #.__wrapped__(
-                "username", "password", aliases, {}, []
+            return RecordCreator.build_record(  # .__wrapped__(
+                RecordCreator.build_search_results, "username", "password", aliases, {}, []
             )  # __wrapped__ bypasses the LRU cache

--- a/src/backend/tests/factories/crawler_factory.py
+++ b/src/backend/tests/factories/crawler_factory.py
@@ -38,5 +38,5 @@ class CrawlerFactory:
 
             aliases = (Alias(first_name="John", last_name="Doe", middle_name="", birth_date=""),)
             return RecordCreator.build_record(  # .__wrapped__(
-                RecordCreator.build_search_results, "username", "password", aliases, {}, []
+                RecordCreator.build_search_results, "username", "password", aliases, {}
             )  # __wrapped__ bypasses the LRU cache

--- a/src/backend/tests/factories/crawler_factory.py
+++ b/src/backend/tests/factories/crawler_factory.py
@@ -37,6 +37,6 @@ class CrawlerFactory:
                 m.get("{}{}{}".format(base_url, "CaseDetail.aspx?CaseID=", key), text=value)
 
             aliases = (Alias(first_name="John", last_name="Doe", middle_name="", birth_date=""),)
-            return RecordCreator.build_record(  # .__wrapped__(
-                RecordCreator.build_search_results, "username", "password", aliases, {}
-            )  # __wrapped__ bypasses the LRU cache
+            return RecordCreator.build_record(
+                RecordCreator.build_search_results.__wrapped__, "username", "password", aliases, {}
+            )

--- a/src/backend/tests/factories/crawler_factory.py
+++ b/src/backend/tests/factories/crawler_factory.py
@@ -37,6 +37,6 @@ class CrawlerFactory:
                 m.get("{}{}{}".format(base_url, "CaseDetail.aspx?CaseID=", key), text=value)
 
             aliases = (Alias(first_name="John", last_name="Doe", middle_name="", birth_date=""),)
-            return RecordCreator.build_record.__wrapped__(
-                "username", "password", aliases
+            return RecordCreator.build_record( #.__wrapped__(
+                "username", "password", aliases, {}, []
             )  # __wrapped__ bypasses the LRU cache

--- a/src/backend/tests/test_edit_results.py
+++ b/src/backend/tests/test_edit_results.py
@@ -1,0 +1,162 @@
+import copy
+import json
+from typing import List, Any, Callable, Tuple
+from datetime import datetime
+
+import pytest
+
+from expungeservice.crawler.crawler import Crawler
+from expungeservice.endpoints import search
+from expungeservice.models.ambiguous import AmbiguousCase
+from expungeservice.models.case import Case, OeciCase, CaseSummary
+from expungeservice.models.charge import OeciCharge
+from expungeservice.models.record import Question, Record
+from expungeservice.models.disposition import Disposition, DispositionStatus
+from tests.endpoints.endpoint_util import EndpointShared
+from tests.factories.crawler_factory import CrawlerFactory
+from expungeservice.record_creator import RecordCreator
+
+
+class Service:
+    pass
+
+case_1 = OeciCase(
+    CaseSummary(
+        name = "John Doe",
+        birth_year = 1980,
+        case_number = "X0001",
+        citation_number = "X0001",
+        location = "earth",
+        date = datetime.date(datetime.strptime("1/1/2001", "%m/%d/%Y")),
+        violation_type = "Something",
+        current_status = "CLOSED",
+        case_detail_link = "alink",
+        balance_due_in_cents = 0),
+    (
+        OeciCharge(
+            id= "1",
+            name= "manufacturing",
+            statute= "100.000",
+            level= "Felony Class B",
+            date= datetime.date(datetime.strptime("1/1/2000", "%m/%d/%Y")),
+            disposition= Disposition(
+                date= datetime.date(datetime.strptime("1/1/2001", "%m/%d/%Y")),
+                ruling= "Convicted",
+                status= DispositionStatus.CONVICTED,
+                amended= False
+                )
+            ),
+        OeciCharge(
+            id= "2",
+            name= "assault 3",
+            statute= "200.000",
+            level= "Felony Class C",
+            date= datetime.date(datetime.strptime("1/1/2001", "%m/%d/%Y")),
+            disposition=None
+            )
+        )
+    )
+case_2 = OeciCase(
+    CaseSummary(
+        name = "John Albert Doe",
+        birth_year = 1970,
+        case_number = "X0002",
+        citation_number = "X0002",
+        location = "america",
+        date = datetime.date(datetime.strptime("1/1/2001", "%m/%d/%Y")),
+        violation_type = "Something Else",
+        current_status = "CLOSED",
+        case_detail_link = "alink",
+        balance_due_in_cents = 0),
+    (
+        OeciCharge(
+            id= "1",
+            name= "driving",
+            statute= "100.000",
+            level= "Misdemeanor",
+            date= datetime.date(datetime.strptime("1/1/2000", "%m/%d/%Y")),
+            disposition= Disposition(
+                date= datetime.date(datetime.strptime("1/1/2001", "%m/%d/%Y")),
+                ruling= "Convicted",
+                status= DispositionStatus.CONVICTED,
+                amended= False
+                )
+            ),
+        OeciCharge(
+            id= "2",
+            name= "assault 3",
+            statute= "200.000",
+            level= "Violation",
+            date= datetime.date(datetime.strptime("1/1/2001", "%m/%d/%Y")),
+            disposition=None
+            )
+        )
+    )
+mock_search_results = {
+    "empty":[],
+    "single_case_two_charges":[case_1],
+    "two_cases_two_charges_each":[case_1, case_2]
+    }
+
+@pytest.fixture
+def service():
+    return Service()
+
+def mock_build_search_results(mocked_record_name) -> Callable[[Any, Any, Any], List[OeciCase]]:
+    def _build_search_results(username, password, aliases):
+        return mock_search_results[mocked_record_name], []
+
+    return _build_search_results
+
+def test_no_op(service, monkeypatch):
+    monkeypatch.setattr(RecordCreator, "_build_search_results", mock_build_search_results("two_cases_two_charges_each"))
+
+    record, ambiguous_record, questions = RecordCreator.build_record("username", "password", (), {}, [])
+    print(record)
+    assert len(record.cases) == 2
+    assert len(record.cases[0].charges) == 2
+    assert record.cases[0].charges[1].disposition == None
+
+def test_edit_some_fields_on_case(service, monkeypatch):
+    monkeypatch.setattr(RecordCreator, "_build_search_results", mock_build_search_results("two_cases_two_charges_each"))
+
+    record, ambiguous_record, questions = RecordCreator.build_record(
+        "username", "password", (),
+        {"X0002": {"action": "edit", "summary":{"location":"ocean", "balance_due": "100", "date": "1/1/1001",}}},
+        []
+        )
+    assert len(record.cases) == 2
+    assert record.cases[0].summary.location == "earth"
+    assert record.cases[1].summary.location == "ocean"
+    assert record.cases[1].summary.balance_due_in_cents == 10000
+    assert record.cases[1].summary.date == datetime.date(datetime.strptime("1/1/1001", "%m/%d/%Y"))
+
+    location = "earth",
+    current_status = "CLOSED",
+
+def test_delete_case(service, monkeypatch):
+    monkeypatch.setattr(RecordCreator, "_build_search_results", mock_build_search_results("single_case_two_charges"))
+    record, ambiguous_record, questions = RecordCreator.build_record(
+        "username", "password", (),
+        {"X0001": {"action": "delete"}},
+        []
+        )
+    assert record == Record((), ())
+
+def test_add_disposition(service, monkeypatch):
+    monkeypatch.setattr(RecordCreator, "_build_search_results", mock_build_search_results("single_case_two_charges"))
+    record, ambiguous_record, questions = RecordCreator.build_record(
+        "username", "password", (),
+        {"X0001": {
+            "action": "edit",
+            "charges":{
+                "2":{
+                    "disposition":{
+                        "date": "1/1/2001",
+                        "ruling": "Convicted"
+                    }
+                }
+            }
+        }}, [])
+    print(record)
+    assert record.cases[0].charges[1].disposition.status == DispositionStatus.CONVICTED

--- a/src/backend/tests/test_edit_results.py
+++ b/src/backend/tests/test_edit_results.py
@@ -1,162 +1,147 @@
-import copy
-import json
 from typing import List, Any, Callable, Tuple
 from datetime import datetime
 
 import pytest
 
-from expungeservice.crawler.crawler import Crawler
-from expungeservice.endpoints import search
-from expungeservice.models.ambiguous import AmbiguousCase
-from expungeservice.models.case import Case, OeciCase, CaseSummary
+from expungeservice.models.case import OeciCase, CaseSummary
 from expungeservice.models.charge import OeciCharge
-from expungeservice.models.record import Question, Record
+from expungeservice.models.record import Record
 from expungeservice.models.disposition import Disposition, DispositionStatus
-from tests.endpoints.endpoint_util import EndpointShared
-from tests.factories.crawler_factory import CrawlerFactory
 from expungeservice.record_creator import RecordCreator
 
 
 class Service:
     pass
 
+
 case_1 = OeciCase(
     CaseSummary(
-        name = "John Doe",
-        birth_year = 1980,
-        case_number = "X0001",
-        citation_number = "X0001",
-        location = "earth",
-        date = datetime.date(datetime.strptime("1/1/2001", "%m/%d/%Y")),
-        violation_type = "Something",
-        current_status = "CLOSED",
-        case_detail_link = "alink",
-        balance_due_in_cents = 0),
+        name="John Doe",
+        birth_year=1980,
+        case_number="X0001",
+        citation_number="X0001",
+        location="earth",
+        date=datetime.date(datetime.strptime("1/1/2001", "%m/%d/%Y")),
+        violation_type="Something",
+        current_status="CLOSED",
+        case_detail_link="alink",
+        balance_due_in_cents=0,
+    ),
     (
         OeciCharge(
-            id= "1",
-            name= "manufacturing",
-            statute= "100.000",
-            level= "Felony Class B",
-            date= datetime.date(datetime.strptime("1/1/2000", "%m/%d/%Y")),
-            disposition= Disposition(
-                date= datetime.date(datetime.strptime("1/1/2001", "%m/%d/%Y")),
-                ruling= "Convicted",
-                status= DispositionStatus.CONVICTED,
-                amended= False
-                )
+            id="1",
+            name="manufacturing",
+            statute="100.000",
+            level="Felony Class B",
+            date=datetime.date(datetime.strptime("1/1/2000", "%m/%d/%Y")),
+            disposition=Disposition(
+                date=datetime.date(datetime.strptime("1/1/2001", "%m/%d/%Y")),
+                ruling="Convicted",
+                status=DispositionStatus.CONVICTED,
+                amended=False,
             ),
+        ),
         OeciCharge(
-            id= "2",
-            name= "assault 3",
-            statute= "200.000",
-            level= "Felony Class C",
-            date= datetime.date(datetime.strptime("1/1/2001", "%m/%d/%Y")),
-            disposition=None
-            )
-        )
-    )
+            id="2",
+            name="assault 3",
+            statute="200.000",
+            level="Felony Class C",
+            date=datetime.date(datetime.strptime("1/1/2001", "%m/%d/%Y")),
+            disposition=None,
+        ),
+    ),
+)
 case_2 = OeciCase(
     CaseSummary(
-        name = "John Albert Doe",
-        birth_year = 1970,
-        case_number = "X0002",
-        citation_number = "X0002",
-        location = "america",
-        date = datetime.date(datetime.strptime("1/1/2001", "%m/%d/%Y")),
-        violation_type = "Something Else",
-        current_status = "CLOSED",
-        case_detail_link = "alink",
-        balance_due_in_cents = 0),
+        name="John Albert Doe",
+        birth_year=1970,
+        case_number="X0002",
+        citation_number="X0002",
+        location="america",
+        date=datetime.date(datetime.strptime("1/1/2001", "%m/%d/%Y")),
+        violation_type="Something Else",
+        current_status="CLOSED",
+        case_detail_link="alink",
+        balance_due_in_cents=0,
+    ),
     (
         OeciCharge(
-            id= "1",
-            name= "driving",
-            statute= "100.000",
-            level= "Misdemeanor",
-            date= datetime.date(datetime.strptime("1/1/2000", "%m/%d/%Y")),
-            disposition= Disposition(
-                date= datetime.date(datetime.strptime("1/1/2001", "%m/%d/%Y")),
-                ruling= "Convicted",
-                status= DispositionStatus.CONVICTED,
-                amended= False
-                )
+            id="1",
+            name="driving",
+            statute="100.000",
+            level="Misdemeanor",
+            date=datetime.date(datetime.strptime("1/1/2000", "%m/%d/%Y")),
+            disposition=Disposition(
+                date=datetime.date(datetime.strptime("1/1/2001", "%m/%d/%Y")),
+                ruling="Convicted",
+                status=DispositionStatus.CONVICTED,
+                amended=False,
             ),
+        ),
         OeciCharge(
-            id= "2",
-            name= "assault 3",
-            statute= "200.000",
-            level= "Violation",
-            date= datetime.date(datetime.strptime("1/1/2001", "%m/%d/%Y")),
-            disposition=None
-            )
-        )
-    )
-mock_search_results = {
-    "empty":[],
-    "single_case_two_charges":[case_1],
-    "two_cases_two_charges_each":[case_1, case_2]
-    }
+            id="2",
+            name="assault 3",
+            statute="200.000",
+            level="Violation",
+            date=datetime.date(datetime.strptime("1/1/2001", "%m/%d/%Y")),
+            disposition=None,
+        ),
+    ),
+)
+mock_search_results = {"empty": [], "single_case_two_charges": [case_1], "two_cases_two_charges_each": [case_1, case_2]}
+
 
 @pytest.fixture
 def service():
     return Service()
 
-def mock_build_search_results(mocked_record_name) -> Callable[[Any, Any, Any], List[OeciCase]]:
+
+def search(mocked_record_name) -> Callable[[Any, Any, Any], Tuple[List[OeciCase], List[str]]]:
     def _build_search_results(username, password, aliases):
         return mock_search_results[mocked_record_name], []
 
     return _build_search_results
 
-def test_no_op(service, monkeypatch):
-    monkeypatch.setattr(RecordCreator, "_build_search_results", mock_build_search_results("two_cases_two_charges_each"))
 
-    record, ambiguous_record, questions = RecordCreator.build_record("username", "password", (), {}, [])
-    print(record)
+def test_no_op(service):
+    record, ambiguous_record, questions = RecordCreator.build_record(
+        search("two_cases_two_charges_each"), "username", "password", (), {}, []
+    )
     assert len(record.cases) == 2
     assert len(record.cases[0].charges) == 2
     assert record.cases[0].charges[1].disposition == None
 
-def test_edit_some_fields_on_case(service, monkeypatch):
-    monkeypatch.setattr(RecordCreator, "_build_search_results", mock_build_search_results("two_cases_two_charges_each"))
 
+def test_edit_some_fields_on_case(service):
     record, ambiguous_record, questions = RecordCreator.build_record(
-        "username", "password", (),
-        {"X0002": {"action": "edit", "summary":{"location":"ocean", "balance_due": "100", "date": "1/1/1001",}}},
-        []
-        )
+        search("two_cases_two_charges_each"),
+        "username",
+        "password",
+        (),
+        {"X0002": {"action": "edit", "summary": {"location": "ocean", "balance_due": "100", "date": "1/1/1001",}}},
+        [],
+    )
     assert len(record.cases) == 2
     assert record.cases[0].summary.location == "earth"
     assert record.cases[1].summary.location == "ocean"
     assert record.cases[1].summary.balance_due_in_cents == 10000
     assert record.cases[1].summary.date == datetime.date(datetime.strptime("1/1/1001", "%m/%d/%Y"))
 
-    location = "earth",
-    current_status = "CLOSED",
 
-def test_delete_case(service, monkeypatch):
-    monkeypatch.setattr(RecordCreator, "_build_search_results", mock_build_search_results("single_case_two_charges"))
+def test_delete_case(service):
     record, ambiguous_record, questions = RecordCreator.build_record(
-        "username", "password", (),
-        {"X0001": {"action": "delete"}},
-        []
-        )
+        search("single_case_two_charges"), "username", "password", (), {"X0001": {"action": "delete"}}, [],
+    )
     assert record == Record((), ())
 
-def test_add_disposition(service, monkeypatch):
-    monkeypatch.setattr(RecordCreator, "_build_search_results", mock_build_search_results("single_case_two_charges"))
+
+def test_add_disposition(service):
     record, ambiguous_record, questions = RecordCreator.build_record(
-        "username", "password", (),
-        {"X0001": {
-            "action": "edit",
-            "charges":{
-                "2":{
-                    "disposition":{
-                        "date": "1/1/2001",
-                        "ruling": "Convicted"
-                    }
-                }
-            }
-        }}, [])
-    print(record)
+        search("single_case_two_charges"),
+        "username",
+        "password",
+        (),
+        {"X0001": {"action": "edit", "charges": {"2": {"disposition": {"date": "1/1/2001", "ruling": "Convicted"}}}}},
+        [],
+    )
     assert record.cases[0].charges[1].disposition.status == DispositionStatus.CONVICTED

--- a/src/backend/tests/test_edit_results.py
+++ b/src/backend/tests/test_edit_results.py
@@ -1,5 +1,5 @@
 from typing import List, Any, Callable, Tuple
-from datetime import datetime
+from datetime import datetime, date
 
 import pytest
 
@@ -21,7 +21,7 @@ case_1 = OeciCase(
         case_number="X0001",
         citation_number="X0001",
         location="earth",
-        date=datetime.date(datetime.strptime("1/1/2001", "%m/%d/%Y")),
+        date=date(2001, 1, 1),
         violation_type="Something",
         current_status="CLOSED",
         case_detail_link="alink",
@@ -33,12 +33,9 @@ case_1 = OeciCase(
             name="manufacturing",
             statute="100.000",
             level="Felony Class B",
-            date=datetime.date(datetime.strptime("1/1/2000", "%m/%d/%Y")),
+            date=date(2000, 1, 1),
             disposition=Disposition(
-                date=datetime.date(datetime.strptime("1/1/2001", "%m/%d/%Y")),
-                ruling="Convicted",
-                status=DispositionStatus.CONVICTED,
-                amended=False,
+                date=date(2001, 1, 1), ruling="Convicted", status=DispositionStatus.CONVICTED, amended=False,
             ),
         ),
         OeciCharge(
@@ -46,7 +43,7 @@ case_1 = OeciCase(
             name="assault 3",
             statute="200.000",
             level="Felony Class C",
-            date=datetime.date(datetime.strptime("1/1/2001", "%m/%d/%Y")),
+            date=date(2001, 1, 1),
             disposition=None,
         ),
     ),
@@ -58,7 +55,7 @@ case_2 = OeciCase(
         case_number="X0002",
         citation_number="X0002",
         location="america",
-        date=datetime.date(datetime.strptime("1/1/2001", "%m/%d/%Y")),
+        date=date(2001, 1, 1),
         violation_type="Something Else",
         current_status="CLOSED",
         case_detail_link="alink",
@@ -70,21 +67,13 @@ case_2 = OeciCase(
             name="driving",
             statute="100.000",
             level="Misdemeanor",
-            date=datetime.date(datetime.strptime("1/1/2000", "%m/%d/%Y")),
+            date=date(2000, 1, 1),
             disposition=Disposition(
-                date=datetime.date(datetime.strptime("1/1/2001", "%m/%d/%Y")),
-                ruling="Convicted",
-                status=DispositionStatus.CONVICTED,
-                amended=False,
+                date=date(2001, 1, 1), ruling="Convicted", status=DispositionStatus.CONVICTED, amended=False,
             ),
         ),
         OeciCharge(
-            id="2",
-            name="assault 3",
-            statute="200.000",
-            level="Violation",
-            date=datetime.date(datetime.strptime("1/1/2001", "%m/%d/%Y")),
-            disposition=None,
+            id="2", name="assault 3", statute="200.000", level="Violation", date=date(2001, 1, 1), disposition=None,
         ),
     ),
 )

--- a/src/backend/tests/test_edit_results.py
+++ b/src/backend/tests/test_edit_results.py
@@ -1,17 +1,11 @@
 from typing import List, Any, Callable, Tuple
 from datetime import datetime, date
 
-import pytest
-
 from expungeservice.models.case import OeciCase, CaseSummary
 from expungeservice.models.charge import OeciCharge
 from expungeservice.models.record import Record
 from expungeservice.models.disposition import Disposition, DispositionStatus
 from expungeservice.record_creator import RecordCreator
-
-
-class Service:
-    pass
 
 
 case_1 = OeciCase(
@@ -80,11 +74,6 @@ case_2 = OeciCase(
 mock_search_results = {"empty": [], "single_case_two_charges": [case_1], "two_cases_two_charges_each": [case_1, case_2]}
 
 
-@pytest.fixture
-def service():
-    return Service()
-
-
 def search(mocked_record_name) -> Callable[[Any, Any, Any], Tuple[List[OeciCase], List[str]]]:
     def _build_search_results(username, password, aliases):
         return mock_search_results[mocked_record_name], []
@@ -92,7 +81,7 @@ def search(mocked_record_name) -> Callable[[Any, Any, Any], Tuple[List[OeciCase]
     return _build_search_results
 
 
-def test_no_op(service):
+def test_no_op():
     record, ambiguous_record, questions = RecordCreator.build_record(
         search("two_cases_two_charges_each"), "username", "password", (), {}, []
     )
@@ -101,7 +90,7 @@ def test_no_op(service):
     assert record.cases[0].charges[1].disposition == None
 
 
-def test_edit_some_fields_on_case(service):
+def test_edit_some_fields_on_case():
     record, ambiguous_record, questions = RecordCreator.build_record(
         search("two_cases_two_charges_each"),
         "username",
@@ -117,14 +106,14 @@ def test_edit_some_fields_on_case(service):
     assert record.cases[1].summary.date == datetime.date(datetime.strptime("1/1/1001", "%m/%d/%Y"))
 
 
-def test_delete_case(service):
+def test_delete_case():
     record, ambiguous_record, questions = RecordCreator.build_record(
         search("single_case_two_charges"), "username", "password", (), {"X0001": {"action": "delete"}}, [],
     )
     assert record == Record((), ())
 
 
-def test_add_disposition(service):
+def test_add_disposition():
     record, ambiguous_record, questions = RecordCreator.build_record(
         search("single_case_two_charges"),
         "username",

--- a/src/backend/tests/test_edit_results.py
+++ b/src/backend/tests/test_edit_results.py
@@ -83,7 +83,7 @@ def search(mocked_record_name) -> Callable[[Any, Any, Any], Tuple[List[OeciCase]
 
 def test_no_op():
     record, ambiguous_record, questions = RecordCreator.build_record(
-        search("two_cases_two_charges_each"), "username", "password", (), {}, []
+        search("two_cases_two_charges_each"), "username", "password", (), {}
     )
     assert len(record.cases) == 2
     assert len(record.cases[0].charges) == 2
@@ -97,7 +97,6 @@ def test_edit_some_fields_on_case():
         "password",
         (),
         {"X0002": {"action": "edit", "summary": {"location": "ocean", "balance_due": "100", "date": "1/1/1001",}}},
-        [],
     )
     assert len(record.cases) == 2
     assert record.cases[0].summary.location == "earth"
@@ -108,7 +107,7 @@ def test_edit_some_fields_on_case():
 
 def test_delete_case():
     record, ambiguous_record, questions = RecordCreator.build_record(
-        search("single_case_two_charges"), "username", "password", (), {"X0001": {"action": "delete"}}, [],
+        search("single_case_two_charges"), "username", "password", (), {"X0001": {"action": "delete"}},
     )
     assert record == Record((), ())
 
@@ -120,6 +119,5 @@ def test_add_disposition():
         "password",
         (),
         {"X0001": {"action": "edit", "charges": {"2": {"disposition": {"date": "1/1/2001", "ruling": "Convicted"}}}}},
-        [],
     )
     assert record.cases[0].charges[1].disposition.status == DispositionStatus.CONVICTED


### PR DESCRIPTION
Search endpoint accepts two new fields: `edits`, and `additions`

This commit implements editing and deleting cases, and editing charges, but not adding new cases, or adding/deleting new charges. Putting `additions` in the request does nothing for now.

The code has a little bit of slop like the pointless "service" fixture used in the test case that I didn't really look into.

This change is sufficient to support editing Dispositions on a record.