### PR TITLE
Add list of charges with disposition originally unknown to API

### DIFF
--- a/src/backend/expungeservice/charge_creator.py
+++ b/src/backend/expungeservice/charge_creator.py
@@ -10,7 +10,7 @@ from expungeservice.models.record import Question
 
 class ChargeCreator:
     @staticmethod
-    def create(charge_id, **kwargs) -> Tuple[AmbiguousCharge, Optional[Question]]:
+    def create(ambiguous_charge_id, **kwargs) -> Tuple[AmbiguousCharge, Optional[Question]]:
         case_number = kwargs["case_number"]
         violation_type = kwargs["violation_type"]
         name = kwargs["name"]
@@ -23,7 +23,7 @@ class ChargeCreator:
             violation_type, name, statute, level, section, birth_year, disposition
         ).classify()
         kwargs["statute"] = statute
-        kwargs["ambiguous_charge_id"] = f"{case_number}-{charge_id}"
+        kwargs["ambiguous_charge_id"] = ambiguous_charge_id
         classifications = ambiguous_charge_type_with_questions.ambiguous_charge_type
         question = ambiguous_charge_type_with_questions.question
         options = ambiguous_charge_type_with_questions.options
@@ -31,7 +31,7 @@ class ChargeCreator:
         ambiguous_charge = []
         options_dict = {}
         for i, classification in enumerate(classifications):
-            uid = f"{case_number}-{charge_id}-{i}"
+            uid = f"{ambiguous_charge_id}-{i}"
             charge_dict = {**kwargs, "id": uid}
             charge = from_dict(data_class=classification, data=charge_dict)
             ambiguous_charge.append(charge)

--- a/src/backend/expungeservice/crawler/crawler.py
+++ b/src/backend/expungeservice/crawler/crawler.py
@@ -77,7 +77,8 @@ class Crawler:
         probation_revoked = case_parser_data.probation_revoked
         charges: List[OeciCharge] = []
         for charge_id, charge_dict in case_parser_data.hashed_charge_data.items():
-            charge = Crawler._build_oeci_charge(charge_id, charge_dict, case_parser_data)
+            ambiguous_charge_id = f"{case_summary.case_number}-{charge_id}"
+            charge = Crawler._build_oeci_charge(charge_id, ambiguous_charge_id, charge_dict, case_parser_data)
             charges.append(charge)
         updated_case_summary = replace(
             case_summary, balance_due_in_cents=balance_due_in_cents, probation_revoked=probation_revoked
@@ -110,13 +111,13 @@ class Crawler:
         return "Case Records" in response.text
 
     @staticmethod
-    def _build_oeci_charge(charge_id, charge_dict, case_parser_data) -> OeciCharge:
+    def _build_oeci_charge(charge_id, ambiguous_charge_id, charge_dict, case_parser_data) -> OeciCharge:
         charge_dict["date"] = datetime.date(datetime.strptime(charge_dict["date"], "%m/%d/%Y"))
         if case_parser_data.hashed_dispo_data.get(charge_id):
             disposition = Crawler._build_disposition(case_parser_data, charge_id)
-            return OeciCharge(charge_id, disposition=disposition, **charge_dict)
+            return OeciCharge(ambiguous_charge_id, disposition=disposition, **charge_dict)
         else:
-            return OeciCharge(charge_id, disposition=None, **charge_dict)
+            return OeciCharge(ambiguous_charge_id, disposition=None, **charge_dict)
 
     @staticmethod
     def _build_disposition(case_parser_data, charge_id):

--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -15,7 +15,7 @@ from expungeservice.models.expungement_result import (
 
 @dataclass(frozen=True)
 class OeciCharge:
-    id: str
+    ambiguous_charge_id: str
     name: str
     statute: str
     level: str
@@ -25,7 +25,7 @@ class OeciCharge:
 
 @dataclass(frozen=True)
 class Charge(OeciCharge):
-    ambiguous_charge_id: str
+    id: str
     case_number: str
     expungement_result: ExpungementResult = ExpungementResult()  # TODO: Remove default value
     type_name: str = "Unknown"

--- a/src/backend/expungeservice/models/record_summary.py
+++ b/src/backend/expungeservice/models/record_summary.py
@@ -14,6 +14,7 @@ class CountyBalance:
 class RecordSummary:
     record: Record
     questions: Dict[str, Question]
+    disposition_was_unknown: List[str]
     total_charges: int
     cases_sorted: Dict[str, List[str]]
     eligible_charges_by_date: List[Tuple[str, List[str]]]

--- a/src/backend/expungeservice/record_summarizer.py
+++ b/src/backend/expungeservice/record_summarizer.py
@@ -7,7 +7,7 @@ from datetime import date
 
 class RecordSummarizer:
     @staticmethod
-    def summarize(record, questions: Dict[str, Question]) -> RecordSummary:
+    def summarize(record, questions: Dict[str, Question], disposition_was_unknown: List[str]) -> RecordSummary:
         fully_eligible_cases = []
         fully_ineligible_cases = []
         partially_eligible_cases = []
@@ -75,6 +75,7 @@ class RecordSummarizer:
         return RecordSummary(
             record=record,
             questions=questions,
+            disposition_was_unknown=disposition_was_unknown,
             cases_sorted=cases_sorted,
             eligible_charges_by_date=eligible_charges_by_date,
             total_charges=total_charges,

--- a/src/backend/expungeservice/serializer.py
+++ b/src/backend/expungeservice/serializer.py
@@ -19,6 +19,7 @@ class ExpungeModelEncoder(flask.json.JSONEncoder):
                     "total_cases": record_summary.total_cases,
                 },
                 "questions": record_summary.questions,
+                "disposition_was_unknown": record_summary.disposition_was_unknown,
             },
         }
 

--- a/src/backend/tests/endpoints/test_disambiguate.py
+++ b/src/backend/tests/endpoints/test_disambiguate.py
@@ -60,6 +60,7 @@ DUII_SEARCH_RESPONSE = {
                 "violation_type": "Misdemeanor",
             }
         ],
+        "disposition_was_unknown": [],
         "errors": [],
         "questions": {
             "CASEJD1-1": {
@@ -135,6 +136,7 @@ DIVERTED_RESPONSE = {
                 "violation_type": "Misdemeanor",
             }
         ],
+        "disposition_was_unknown": [],
         "errors": [],
         "questions": {
             "CASEJD1-1": {
@@ -173,8 +175,9 @@ def record_with_single_duii():
 def test_disambiguate_endpoint_with_no_answers(record_with_single_duii):
     ambiguous_record = record_with_single_duii[1]
     questions = json.loads(json.dumps(record_with_single_duii[2]))
+    unknown_dispositions = record_with_single_duii[3]
     questions, record = Search.disambiguate_record(ambiguous_record, questions)
-    record_summary = RecordSummarizer.summarize(record, questions)
+    record_summary = RecordSummarizer.summarize(record, questions, unknown_dispositions)
     response_data = {"record": record_summary}
     response_as_dict = json.loads(json.dumps(response_data, cls=ExpungeModelEncoder))
     assert response_as_dict == DUII_SEARCH_RESPONSE
@@ -192,8 +195,9 @@ def test_disambiguate_endpoint_with_diverted_answer(record_with_single_duii):
         )
     }
     questions = json.loads(json.dumps(answers))
+    unknown_dispositions = record_with_single_duii[3]
     questions, record = Search.disambiguate_record(ambiguous_record, questions)
-    record_summary = RecordSummarizer.summarize(record, questions)
+    record_summary = RecordSummarizer.summarize(record, questions, unknown_dispositions)
     response_data = {"record": record_summary}
     response_as_dict = json.loads(json.dumps(response_data, cls=ExpungeModelEncoder))
     assert response_as_dict == DIVERTED_RESPONSE

--- a/src/backend/tests/factories/charge_factory.py
+++ b/src/backend/tests/factories/charge_factory.py
@@ -55,7 +55,7 @@ class ChargeFactory:
             "disposition": disposition,
             "violation_type": violation_type,
         }
-        charges = ChargeCreator.create(cls.charge_count, **kwargs)[0]
+        charges = ChargeCreator.create(str(cls.charge_count), **kwargs)[0]
         return charges
 
     @classmethod
@@ -80,6 +80,6 @@ class ChargeFactory:
             "violation_type": violation_type,
         }
 
-        charges = ChargeCreator.create(cls.charge_count, **kwargs)[0]
+        charges = ChargeCreator.create(str(cls.charge_count), **kwargs)[0]
         assert len(charges) == 1
         return charges[0]

--- a/src/backend/tests/factories/crawler_factory.py
+++ b/src/backend/tests/factories/crawler_factory.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Dict
+from typing import Tuple, Dict, List
 
 import requests_mock
 
@@ -24,7 +24,7 @@ class CrawlerFactory:
     def create_ambiguous_record_with_questions(
         record=JohnDoe.RECORD_WITH_CLOSED_CASES,
         cases={"X0001": CaseDetails.case_x(), "X0002": CaseDetails.case_x(), "X0003": CaseDetails.case_x()},
-    ) -> Tuple[Record, AmbiguousRecord, Dict[str, Question]]:
+    ) -> Tuple[Record, AmbiguousRecord, Dict[str, Question], List[str]]:
         base_url = "https://publicaccess.courts.oregon.gov/PublicAccessLogin/"
         with requests_mock.Mocker() as m:
             m.post(URL.login_url(), text=PostLoginPage.POST_LOGIN_PAGE)

--- a/src/backend/tests/models/test_record_summarizer.py
+++ b/src/backend/tests/models/test_record_summarizer.py
@@ -99,7 +99,7 @@ def test_record_summarizer_multiple_cases():
     expunger_result = Expunger.run(record)
 
     merged_record = RecordMerger.merge([record], [expunger_result])
-    record_summary = RecordSummarizer.summarize(merged_record, {})
+    record_summary = RecordSummarizer.summarize(merged_record, {}, [])
 
     assert record_summary.total_balance_due == 1000.00
     assert record_summary.total_cases == 5
@@ -119,7 +119,7 @@ def test_record_summarizer_multiple_cases():
 
 def test_record_summarizer_no_cases():
     record = Record(tuple([]))
-    record_summary = RecordSummarizer.summarize(record, {})
+    record_summary = RecordSummarizer.summarize(record, {}, [])
 
     assert record_summary.total_balance_due == 0.00
     assert record_summary.total_cases == 0

--- a/src/backend/tests/test_crawler_expunger.py
+++ b/src/backend/tests/test_crawler_expunger.py
@@ -72,6 +72,17 @@ This might be an error in the OECI database. Time analysis is ignoring this char
 
 
 @pytest.fixture
+def record_tuple_without_dispos():
+    return CrawlerFactory.create_ambiguous_record_with_questions(
+        JohnDoe.SINGLE_CASE_RECORD, {"CASEJD1": CaseDetails.CASE_WITHOUT_DISPOS}
+    )
+
+
+def test_case_without_dispos_for_unknown_dispositions(record_tuple_without_dispos):
+    assert [1, 2, 3] == record_tuple_without_dispos[3]
+
+
+@pytest.fixture
 def record_with_unrecognized_dispo():
     return CrawlerFactory.create(
         cases={

--- a/src/backend/tests/test_crawler_expunger.py
+++ b/src/backend/tests/test_crawler_expunger.py
@@ -79,7 +79,7 @@ def record_tuple_without_dispos():
 
 
 def test_case_without_dispos_for_unknown_dispositions(record_tuple_without_dispos):
-    assert [1, 2, 3] == record_tuple_without_dispos[3]
+    assert ["CASEJD1-1", "CASEJD1-2", "CASEJD1-3"] == record_tuple_without_dispos[3]
 
 
 @pytest.fixture

--- a/src/backend/tests/test_edit_results.py
+++ b/src/backend/tests/test_edit_results.py
@@ -82,7 +82,7 @@ def search(mocked_record_name) -> Callable[[Any, Any, Any], Tuple[List[OeciCase]
 
 
 def test_no_op():
-    record, ambiguous_record, questions = RecordCreator.build_record(
+    record, ambiguous_record, questions, _ = RecordCreator.build_record(
         search("two_cases_two_charges_each"), "username", "password", (), {}
     )
     assert len(record.cases) == 2
@@ -91,7 +91,7 @@ def test_no_op():
 
 
 def test_edit_some_fields_on_case():
-    record, ambiguous_record, questions = RecordCreator.build_record(
+    record, ambiguous_record, questions, _ = RecordCreator.build_record(
         search("two_cases_two_charges_each"),
         "username",
         "password",
@@ -106,14 +106,14 @@ def test_edit_some_fields_on_case():
 
 
 def test_delete_case():
-    record, ambiguous_record, questions = RecordCreator.build_record(
+    record, ambiguous_record, questions, _ = RecordCreator.build_record(
         search("single_case_two_charges"), "username", "password", (), {"X0001": {"action": "delete"}},
     )
     assert record == Record((), ())
 
 
 def test_add_disposition():
-    record, ambiguous_record, questions = RecordCreator.build_record(
+    record, ambiguous_record, questions, _ = RecordCreator.build_record(
         search("single_case_two_charges"),
         "username",
         "password",

--- a/src/backend/tests/test_edit_results.py
+++ b/src/backend/tests/test_edit_results.py
@@ -23,7 +23,7 @@ case_1 = OeciCase(
     ),
     (
         OeciCharge(
-            id="1",
+            ambiguous_charge_id="X0001-1",
             name="manufacturing",
             statute="100.000",
             level="Felony Class B",
@@ -33,7 +33,7 @@ case_1 = OeciCase(
             ),
         ),
         OeciCharge(
-            id="2",
+            ambiguous_charge_id="X0001-2",
             name="assault 3",
             statute="200.000",
             level="Felony Class C",
@@ -57,7 +57,7 @@ case_2 = OeciCase(
     ),
     (
         OeciCharge(
-            id="1",
+            ambiguous_charge_id="X0002-1",
             name="driving",
             statute="100.000",
             level="Misdemeanor",
@@ -67,7 +67,12 @@ case_2 = OeciCase(
             ),
         ),
         OeciCharge(
-            id="2", name="assault 3", statute="200.000", level="Violation", date=date(2001, 1, 1), disposition=None,
+            ambiguous_charge_id="X0002-2",
+            name="assault 3",
+            statute="200.000",
+            level="Violation",
+            date=date(2001, 1, 1),
+            disposition=None,
         ),
     ),
 )
@@ -118,6 +123,11 @@ def test_add_disposition():
         "username",
         "password",
         (),
-        {"X0001": {"action": "edit", "charges": {"2": {"disposition": {"date": "1/1/2001", "ruling": "Convicted"}}}}},
+        {
+            "X0001": {
+                "action": "edit",
+                "charges": {"X0001-2": {"disposition": {"date": "1/1/2001", "ruling": "Convicted"}}},
+            }
+        },
     )
     assert record.cases[0].charges[1].disposition.status == DispositionStatus.CONVICTED


### PR DESCRIPTION
This allows the frontend to display a question for unknown dispositions even after the user submits an answer in case they want to change their answer. Note the unknown dispositions are fetched out before the user edits are applied to the search results.