### PR TITLE
Use disposition_was_unknown field to display disposition questions

### DIFF
--- a/src/backend/expungeservice/record_creator.py
+++ b/src/backend/expungeservice/record_creator.py
@@ -170,12 +170,15 @@ class RecordCreator:
                 charge_edits: Dict[str, Any] = {}
                 for key, value in edits[charge.ambiguous_charge_id].items():
                     if key == "disposition":
-                        charge_edits["disposition"] = DispositionCreator.create(
-                            datetime.date(
-                                datetime.strptime(edits[charge.ambiguous_charge_id]["disposition"]["date"], "%m/%d/%Y")
-                            ),
-                            edits[charge.ambiguous_charge_id]["disposition"]["ruling"],
-                        )
+                        if value:
+                            charge_edits["disposition"] = DispositionCreator.create(
+                                datetime.date(
+                                    datetime.strptime(edits[charge.ambiguous_charge_id]["disposition"]["date"], "%m/%d/%Y")
+                                ),
+                                edits[charge.ambiguous_charge_id]["disposition"]["ruling"],
+                            )
+                        else:
+                            charge_edits["disposition"] = None
                     elif key in ("date", "probation_revoked"):
                         charge_edits[key] = datetime.date(datetime.strptime(value, "%m/%d/%Y"))
                     else:

--- a/src/frontend/src/components/RecordSearch/Record/Case.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Case.tsx
@@ -5,6 +5,7 @@ import currencyFormat from '../../../service/currency-format';
 
 interface Props {
   case: CaseData;
+  dispositionWasUnknown: string[];
 }
 
 export default class Cases extends React.Component<Props> {
@@ -41,7 +42,7 @@ export default class Cases extends React.Component<Props> {
             {birth_year}
           </div>
         </div>
-        <Charges charges={charges} />
+        <Charges charges={charges} dispositionWasUnknown={this.props.dispositionWasUnknown} />
       </div>
     );
   }

--- a/src/frontend/src/components/RecordSearch/Record/Cases.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Cases.tsx
@@ -4,6 +4,7 @@ import { CaseData } from './types';
 
 interface Props {
   cases: CaseData[];
+  dispositionWasUnknown: string[];
 }
 
 export default class Cases extends React.Component<Props> {
@@ -11,7 +12,7 @@ export default class Cases extends React.Component<Props> {
     const allCases = this.props.cases.map((caseInstance, index) => {
       return (
         <li key={index}>
-          <Case case={caseInstance} />
+          <Case case={caseInstance} dispositionWasUnknown={this.props.dispositionWasUnknown} />
         </li>
       );
     });

--- a/src/frontend/src/components/RecordSearch/Record/Charge.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Charge.tsx
@@ -4,9 +4,11 @@ import TimeEligibility from './TimeEligibility';
 import TypeEligibility from './TypeEligibility';
 import Question from './Question';
 import { ChargeData } from './types';
+import DispositionQuestion from "./DispositionQuestion";
 
 interface Props {
   charge: ChargeData;
+  showDispositionQuestion: boolean;
 }
 
 export default class Charge extends React.Component<Props> {
@@ -62,6 +64,14 @@ export default class Charge extends React.Component<Props> {
       }
     };
 
+    const dispositionQuestionRender = () => {
+      if (this.props.showDispositionQuestion) {
+        return (
+          <DispositionQuestion />
+        )
+      }
+    };
+
     return (
       <div className="br3 ma2 bg-white">
         <Eligibility expungement_result={expungement_result} />
@@ -87,6 +97,7 @@ export default class Charge extends React.Component<Props> {
           </div>
         </div>
         <Question ambiguous_charge_id= {ambiguous_charge_id}/>
+        {dispositionQuestionRender()}
       </div>
     );
   }

--- a/src/frontend/src/components/RecordSearch/Record/Charge.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Charge.tsx
@@ -14,6 +14,7 @@ interface Props {
 export default class Charge extends React.Component<Props> {
   render() {
     const {
+      case_number,
       ambiguous_charge_id,
       date,
       disposition,
@@ -67,7 +68,7 @@ export default class Charge extends React.Component<Props> {
     const dispositionQuestionRender = () => {
       if (this.props.showDispositionQuestion) {
         return (
-          <DispositionQuestion />
+          <DispositionQuestion case_number={case_number} ambiguous_charge_id={ambiguous_charge_id} disposition={disposition}/>
         )
       }
     };

--- a/src/frontend/src/components/RecordSearch/Record/Charges.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Charges.tsx
@@ -4,14 +4,16 @@ import { ChargeData } from './types';
 
 interface Props {
   charges: ChargeData[];
+  dispositionWasUnknown: string[];
 }
 
 export default class Charges extends React.Component<Props> {
   render() {
     const charges = this.props.charges.map((charge: ChargeData, i) => {
+      const showDispositionQuestion = this.props.dispositionWasUnknown.includes(charge.ambiguous_charge_id);
       return (
         <li key={i}>
-          <Charge charge={charge} />
+          <Charge charge={charge} showDispositionQuestion={showDispositionQuestion} />
         </li>
       );
     });

--- a/src/frontend/src/components/RecordSearch/Record/DispositionQuestion.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/DispositionQuestion.tsx
@@ -19,14 +19,14 @@ interface State {
 }
 
 export default class DispositionQuestion extends React.Component<Props, State> {
-
   state: State  = {
     status: "Open",
     conviction_date: "",
     probation_revoked_date: "",
     missingFields: false,
     invalidDate: false
-  }
+  };
+
   componentDidMount() {
     this.setState({
       status: (this.props.disposition ? this.props.disposition.status : "Open") ,
@@ -43,18 +43,19 @@ export default class DispositionQuestion extends React.Component<Props, State> {
 
   handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    this.validateForm().then( () => {
-      if (!this.state.missingFields  && !this.state.invalidDate) {
+    this.validateForm().then(() => {
+      if (!this.state.missingFields && !this.state.invalidDate) {
         store.dispatch(
           answerDisposition(
             this.props.case_number,
             this.props.ambiguous_charge_id,
             this.state.status,
-            (this.state.status === "Convicted" || this.state.status === "revoked" ? this.state.conviction_date : "1/1/2020"), // The date for a dismissal doesn't matter, but the backend expects something so here we are.
-             this.state.probation_revoked_date)
+            this.state.conviction_date || "1/1/2020", // The date for a dismissal doesn't matter, but the backend expects something so here we are.
+            this.state.probation_revoked_date
+          )
         )
       }
-    })
+    });
   };
 
   validateForm = () => {
@@ -66,16 +67,15 @@ export default class DispositionQuestion extends React.Component<Props, State> {
         missingFields = this.state.conviction_date === "" || this.state.probation_revoked_date === "";
       }
 
-      let invalidDate = ( this.state.status === "Convicted" || this.state.status === "revoked") &&
+      let invalidDate = (this.state.status === "Convicted" || this.state.status === "revoked") &&
         (this.state.conviction_date.length !== 0 && !moment(this.state.conviction_date, 'M/D/YYYY', true).isValid()) ||
-        (this.state.probation_revoked_date.length !== 0 && !moment(this.state.probation_revoked_date, 'M/D/YYYY', true).isValid())
-      ;
+        (this.state.probation_revoked_date.length !== 0 && !moment(this.state.probation_revoked_date, 'M/D/YYYY', true).isValid());
       this.setState(
         {
           missingFields: missingFields ,
           invalidDate: invalidDate
         },
-      resolve
+        resolve
       );
     });
   };
@@ -89,20 +89,20 @@ export default class DispositionQuestion extends React.Component<Props, State> {
             {"state: " + JSON.stringify(this.state)}
             <div className="radio">
                 <div className="dib">
-                    <input id="dis" name="status" type="radio" value="Dismissed" checked={this.state.status==="Dismissed"} onChange={this.handleChange} />
-                    <label htmlFor="dis">Dismissed</label>
+                    <input id={this.props.ambiguous_charge_id + "-dis"} name="status" type="radio" value="Dismissed" checked={this.state.status==="Dismissed"} onChange={this.handleChange} />
+                    <label htmlFor={this.props.ambiguous_charge_id + "-dis"}>Dismissed</label>
                 </div>
                 <div className="dib">
-                    <input id="con" name="status" type="radio" value="Convicted" checked={this.state.status==="Convicted"} onChange={this.handleChange} />
-                    <label htmlFor="con">Convicted</label>
+                    <input id={this.props.ambiguous_charge_id + "-con"} name="status" type="radio" value="Convicted" checked={this.state.status==="Convicted"} onChange={this.handleChange} />
+                    <label htmlFor={this.props.ambiguous_charge_id + "-con"}>Convicted</label>
                 </div>
                 <div className="dib">
-                    <input id="rev" name="status" type="radio" value="revoked" checked={this.state.status==="revoked"} onChange={this.handleChange} />
-                    <label htmlFor="rev">Probation Revoked</label>
+                    <input id={this.props.ambiguous_charge_id + "-rev"} name="status" type="radio" value="revoked" checked={this.state.status==="revoked"} onChange={this.handleChange} />
+                    <label htmlFor={this.props.ambiguous_charge_id + "-rev"}>Probation Revoked</label>
                 </div>
                 <div className="dib">
-                    <input id="open" name="status" type="radio" value="Open" checked={this.state && this.state.status==="Open"} onChange={this.handleChange} />
-                    <label htmlFor="open">Open</label>
+                    <input id={this.props.ambiguous_charge_id + "-open"} name="status" type="radio" value="Open" checked={this.state && this.state.status==="Open"} onChange={this.handleChange} />
+                    <label htmlFor={this.props.ambiguous_charge_id + "-open"}>Open</label>
                 </div>
             </div>
             <div className={this.state && (this.state.status === "Convicted" || this.state.status === "revoked") ? "" : "visually-hidden"}>
@@ -120,7 +120,6 @@ export default class DispositionQuestion extends React.Component<Props, State> {
             <div role="alert">
               <p className={(this.state && this.state.invalidDate ? "" : "visually-hidden " ) + "dib bg-washed-red fw6 br3 pa3 mt3"}>The date format must be MM/DD/YYYY</p>
             </div>
-
         </fieldset>
       </form>
     )

--- a/src/frontend/src/components/RecordSearch/Record/DispositionQuestion.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/DispositionQuestion.tsx
@@ -1,21 +1,83 @@
 import React from 'react';
 import {answerDisposition} from '../../../redux/search/actions';
 import {connect} from 'react-redux';
+import store from '../../../redux/store';
+import moment from 'moment';
 
 interface Props {
-  answerDisposition: Function;
+  case_number: string;
+  ambiguous_charge_id: string;
+  disposition: any;
 }
 
-class DispositionQuestion extends React.Component<Props> {
+interface State {
+  status: string;
+  conviction_date: string;
+  probation_revoked_date: string;
+  missingFields: boolean;
+  invalidDate: boolean
+}
 
-  // TODO: Make display of labels interactive based on radio answer
-  //handleRadioChange = (e: React.BaseSyntheticEvent) => {
-  //};
+export default class DispositionQuestion extends React.Component<Props, State> {
 
-  // TODO: Pass through disposition answer
+  state: State  = {
+    status: "Open",
+    conviction_date: "",
+    probation_revoked_date: "",
+    missingFields: false,
+    invalidDate: false
+  }
+  componentDidMount() {
+    this.setState({
+      status: (this.props.disposition ? this.props.disposition.status : "Open") ,
+      conviction_date: (this.props.disposition ? this.props.disposition.date : ""),
+      }
+    )
+  }
+
+  handleChange = (e: React.BaseSyntheticEvent) => {
+    this.setState<any>({
+      [e.target.name]: e.target.value
+    });
+  };
+
   handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    this.props.answerDisposition();
+    this.validateForm().then( () => {
+      if (!this.state.missingFields  && !this.state.invalidDate) {
+        store.dispatch(
+          answerDisposition(
+            this.props.case_number,
+            this.props.ambiguous_charge_id,
+            this.state.status,
+            (this.state.status === "Convicted" || this.state.status === "revoked" ? this.state.conviction_date : "1/1/2020"), // The date for a dismissal doesn't matter, but the backend expects something so here we are.
+             this.state.probation_revoked_date)
+        )
+      }
+    })
+  };
+
+  validateForm = () => {
+    return new Promise(resolve => {
+      let missingFields = false;
+      if (this.state.status === "Convicted") {
+        missingFields = this.state.conviction_date === "";
+      } else if (this.state.status === "revoked") {
+        missingFields = this.state.conviction_date === "" || this.state.probation_revoked_date === "";
+      }
+
+      let invalidDate = ( this.state.status === "Convicted" || this.state.status === "revoked") &&
+        (this.state.conviction_date.length !== 0 && !moment(this.state.conviction_date, 'M/D/YYYY', true).isValid()) ||
+        (this.state.probation_revoked_date.length !== 0 && !moment(this.state.probation_revoked_date, 'M/D/YYYY', true).isValid())
+      ;
+      this.setState(
+        {
+          missingFields: missingFields ,
+          invalidDate: invalidDate
+        },
+      resolve
+      );
+    });
   };
 
   render() {
@@ -23,40 +85,44 @@ class DispositionQuestion extends React.Component<Props> {
       <form className="w-100 bt bw3 b--light-purple pa3 pb1" onSubmit={this.handleSubmit}>
         <fieldset className="relative mb4">
             <legend className="fw7 mb2">What is the disposition?</legend>
+            {"props: " + JSON.stringify(this.props)}
+            {"state: " + JSON.stringify(this.state)}
             <div className="radio">
                 <div className="dib">
-                    <input id="dis" name="disposition" type="radio" value="dis" />
+                    <input id="dis" name="status" type="radio" value="Dismissed" checked={this.state.status==="Dismissed"} onChange={this.handleChange} />
                     <label htmlFor="dis">Dismissed</label>
                 </div>
                 <div className="dib">
-                    <input id="con" name="disposition" type="radio" value="con" />
+                    <input id="con" name="status" type="radio" value="Convicted" checked={this.state.status==="Convicted"} onChange={this.handleChange} />
                     <label htmlFor="con">Convicted</label>
                 </div>
                 <div className="dib">
-                    <input checked id="rev" name="disposition" type="radio" value="rev" />
+                    <input id="rev" name="status" type="radio" value="revoked" checked={this.state.status==="revoked"} onChange={this.handleChange} />
                     <label htmlFor="rev">Probation Revoked</label>
                 </div>
                 <div className="dib">
-                    <input id="open" name="disposition" type="radio" value="open" />
+                    <input id="open" name="status" type="radio" value="Open" checked={this.state && this.state.status==="Open"} onChange={this.handleChange} />
                     <label htmlFor="open">Open</label>
                 </div>
             </div>
-            <label className="db fw6 mt3 mb1" htmlFor="n">Date Convicted <span className="f6 fw4">mm/dd/yyyy</span></label>
-            <input className="w5 br2 b--black-20 pa3" id="n" type="text" />
-            <label className="db fw6 mt3 mb1" htmlFor="n">Date Probation Revoked <span className="f6 fw4">mm/dd/yyyy</span></label>
-            <input className="w5 br2 b--black-20 pa3" id="n" type="text" />
+            <div className={this.state && (this.state.status === "Convicted" || this.state.status === "revoked") ? "" : "visually-hidden"}>
+              <label className="db fw6 mt3 mb1" htmlFor="n">Date Convicted <span className="f6 fw4">mm/dd/yyyy</span></label>
+              <input onChange={this.handleChange} className="w5 br2 b--black-20 pa3" id="n" type="text" name="conviction_date"/>
+            </div>
+            <div className={this.state && this.state.status === "revoked" ? "" : "visually-hidden"}>
+              <label className="db fw6 mt3 mb1" htmlFor="n">Date Probation Revoked <span className="f6 fw4">mm/dd/yyyy</span></label>
+              <input onChange={this.handleChange} className="w5 br2 b--black-20 pa3" id="n" type="text" name="probation_revoked_date"/>
+            </div>
             <button className="db bg-blue white bg-animate hover-bg-dark-blue fw6 br2 pv3 ph4 mt3">Submit</button>
-            <div role="alert"></div>
+            <div role="alert">
+              <p className={(this.state && this.state.missingFields ? "" : "visually-hidden " ) + "dib bg-washed-red fw6 br3 pa3 mt3"}>Please complete all fields</p>
+            </div>
+            <div role="alert">
+              <p className={(this.state && this.state.invalidDate ? "" : "visually-hidden " ) + "dib bg-washed-red fw6 br3 pa3 mt3"}>The date format must be MM/DD/YYYY</p>
+            </div>
+
         </fieldset>
       </form>
     )
   }
 }
-
-export default connect(
-  null,
-  {
-    answerDisposition: answerDisposition
-  }
-)(DispositionQuestion);
-

--- a/src/frontend/src/components/RecordSearch/Record/DispositionQuestion.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/DispositionQuestion.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import {answerDisposition} from '../../../redux/search/actions';
+import {connect} from 'react-redux';
+
+interface Props {
+  answerDisposition: Function;
+}
+
+class DispositionQuestion extends React.Component<Props> {
+
+  // TODO: Make display of labels interactive based on radio answer
+  //handleRadioChange = (e: React.BaseSyntheticEvent) => {
+  //};
+
+  // TODO: Pass through disposition answer
+  handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    this.props.answerDisposition();
+  };
+
+  render() {
+    return (
+      <form className="w-100 bt bw3 b--light-purple pa3 pb1" onSubmit={this.handleSubmit}>
+        <fieldset className="relative mb4">
+            <legend className="fw7 mb2">What is the disposition?</legend>
+            <div className="radio">
+                <div className="dib">
+                    <input id="dis" name="disposition" type="radio" value="dis" />
+                    <label htmlFor="dis">Dismissed</label>
+                </div>
+                <div className="dib">
+                    <input id="con" name="disposition" type="radio" value="con" />
+                    <label htmlFor="con">Convicted</label>
+                </div>
+                <div className="dib">
+                    <input checked id="rev" name="disposition" type="radio" value="rev" />
+                    <label htmlFor="rev">Probation Revoked</label>
+                </div>
+                <div className="dib">
+                    <input id="open" name="disposition" type="radio" value="open" />
+                    <label htmlFor="open">Open</label>
+                </div>
+            </div>
+            <label className="db fw6 mt3 mb1" htmlFor="n">Date Convicted <span className="f6 fw4">mm/dd/yyyy</span></label>
+            <input className="w5 br2 b--black-20 pa3" id="n" type="text" />
+            <label className="db fw6 mt3 mb1" htmlFor="n">Date Probation Revoked <span className="f6 fw4">mm/dd/yyyy</span></label>
+            <input className="w5 br2 b--black-20 pa3" id="n" type="text" />
+            <button className="db bg-blue white bg-animate hover-bg-dark-blue fw6 br2 pv3 ph4 mt3">Submit</button>
+            <div role="alert"></div>
+        </fieldset>
+      </form>
+    )
+  }
+}
+
+export default connect(
+  null,
+  {
+    answerDisposition: answerDisposition
+  }
+)(DispositionQuestion);
+

--- a/src/frontend/src/components/RecordSearch/Record/DispositionQuestion.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/DispositionQuestion.tsx
@@ -84,9 +84,7 @@ export default class DispositionQuestion extends React.Component<Props, State> {
     return (
       <form className="w-100 bt bw3 b--light-purple pa3 pb1" onSubmit={this.handleSubmit}>
         <fieldset className="relative mb4">
-            <legend className="fw7 mb2">What is the disposition?</legend>
-            {"props: " + JSON.stringify(this.props)}
-            {"state: " + JSON.stringify(this.state)}
+            <legend className="fw7 mb2">Choose a disposition</legend>
             <div className="radio">
                 <div className="dib">
                     <input id={this.props.ambiguous_charge_id + "-dis"} name="status" type="radio" value="Dismissed" checked={this.state.status==="Dismissed"} onChange={this.handleChange} />

--- a/src/frontend/src/components/RecordSearch/Record/index.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/index.tsx
@@ -6,6 +6,7 @@ import QuestionsBanner from './QuestionsBanner';
 
 interface Props {
   record: RecordData;
+  dispositionWasUnknown: string[];
 }
 
 export default class Record extends React.Component<Props> {
@@ -41,7 +42,7 @@ export default class Record extends React.Component<Props> {
           ) : null }
         <QuestionsBanner/>
         {this.props.record.cases ? (
-          <Cases cases={this.props.record.cases} />
+          <Cases cases={this.props.record.cases} dispositionWasUnknown={this.props.dispositionWasUnknown} />
         ) : null}
       </section>
       </>

--- a/src/frontend/src/components/RecordSearch/Record/types.ts
+++ b/src/frontend/src/components/RecordSearch/Record/types.ts
@@ -1,4 +1,5 @@
 export interface ChargeData {
+  case_number: string;
   ambiguous_charge_id: string;
   statute: string;
   expungement_result: any;

--- a/src/frontend/src/components/RecordSearch/index.tsx
+++ b/src/frontend/src/components/RecordSearch/index.tsx
@@ -16,6 +16,7 @@ type Props = {
   searchRecord: Function;
   clearRecord: Function;
   record?: RecordData;
+  dispositionWasUnknown?: string[];
 };
 
 class RecordSearch extends Component<Props> {
@@ -36,7 +37,7 @@ class RecordSearch extends Component<Props> {
         {this.props.record &&
         ((this.props.record.cases &&
         this.props.record.cases.length > 0) || this.props.record.errors) ? (
-          <Record record={this.props.record} />
+          <Record record={this.props.record} dispositionWasUnknown={this.props.dispositionWasUnknown ? this.props.dispositionWasUnknown : []} />
         ) : (
           <Status />
         )}
@@ -62,7 +63,8 @@ class RecordSearch extends Component<Props> {
 
 const mapStateToProps = (state: AppState) => {
   return {
-    record: state.search.record
+    record: state.search.record,
+    dispositionWasUnknown: state.search.dispositionWasUnknown
   };
 };
 

--- a/src/frontend/src/redux/search/actions.ts
+++ b/src/frontend/src/redux/search/actions.ts
@@ -7,7 +7,8 @@ import {
   RECORD_LOADING,
   SearchResponse,
   CLEAR_RECORD,
-  SELECT_ANSWER
+  SELECT_ANSWER,
+  ANSWER_DISPOSITION
 } from './types';
 import {AliasData} from '../../components/RecordSearch/SearchPanel/types'
 import {RecordData} from '../../components/RecordSearch/Record/types'
@@ -24,7 +25,8 @@ function storeSearchResponse(data: SearchResponse, dispatch: Dispatch) {
     dispatch({
       type: DISPLAY_RECORD,
       record: record,
-      questions: receivedRecord.questions
+      questions: receivedRecord.questions,
+      dispositionWasUnknown: receivedRecord.disposition_was_unknown
     });
   } else {
     alert('Response data has unexpected format.');
@@ -91,5 +93,15 @@ export function selectAnswer(
       .catch((error: AxiosError<SearchResponse>) => {
         alert(error.message);
       });
+  };
+}
+
+// TODO: Hit backend endpoint
+export function answerDisposition(): any {
+  return (dispatch: Dispatch) => {
+    alert("Answered a disposition question.");
+    dispatch({
+      type: ANSWER_DISPOSITION,
+    });
   };
 }

--- a/src/frontend/src/redux/search/actions.ts
+++ b/src/frontend/src/redux/search/actions.ts
@@ -100,7 +100,7 @@ export function answerDisposition(
       type: ANSWER_DISPOSITION,
       case_number: case_number,
       ambiguous_charge_id: ambiguous_charge_id,
-      edits: {"disposition": ruling === "Open" ? null : {"date": date, "ruling": ruling}}
+      disposition_edit: ruling === "Open" ? null : {"date": date, "ruling": ruling}
     });
     return buildAndSendSearchRequest(dispatch);
   };

--- a/src/frontend/src/redux/search/reducer.ts
+++ b/src/frontend/src/redux/search/reducer.ts
@@ -40,12 +40,12 @@ export function searchReducer(
       }
       return {...state, questions: questions, loading: true};
     case ANSWER_DISPOSITION:
-      let all_edits = JSON.parse(JSON.stringify(state.edits));
-      if (!all_edits[action.case_number]) {
-        all_edits[action.case_number] = {"charges":{}, "action": "edit"};
-      }
-      all_edits[action.case_number]["charges"][action.ambiguous_charge_id]=action.edits;
-      return {...state, edits: all_edits, loading: true};
+      const edits = JSON.parse(JSON.stringify(state.edits));
+      edits[action.case_number] = edits[action.case_number] || {"action": "edit"};
+      edits[action.case_number]["charges"] = edits[action.case_number]["charges"] || {};
+      edits[action.case_number]["charges"][action.ambiguous_charge_id] = edits[action.case_number]["charges"][action.ambiguous_charge_id] || {};
+      edits[action.case_number]["charges"][action.ambiguous_charge_id]["disposition"] = action.disposition_edit;
+      return {...state, edits: edits, loading: true};
     default:
       return state;
   }

--- a/src/frontend/src/redux/search/reducer.ts
+++ b/src/frontend/src/redux/search/reducer.ts
@@ -3,15 +3,17 @@ import {
   RECORD_LOADING,
   CLEAR_RECORD,
   SELECT_ANSWER,
+  ANSWER_DISPOSITION,
   SearchRecordState,
-  SearchRecordActionType, ANSWER_DISPOSITION
+  SearchRecordActionType
 } from './types';
 import {QuestionsData} from '../../components/RecordSearch/Record/types'
 
 const initalState: SearchRecordState = {
   loading: false,
   aliases: [],
-  dispositionWasUnknown: []
+  dispositionWasUnknown: [],
+  edits: {}
 };
 
 export function searchReducer(
@@ -38,7 +40,12 @@ export function searchReducer(
       }
       return {...state, questions: questions, loading: true};
     case ANSWER_DISPOSITION:
-      return {...state, loading: true};
+      let all_edits = JSON.parse(JSON.stringify(state.edits));
+      if (!all_edits[action.case_number]) {
+        all_edits[action.case_number] = {"charges":{}, "action": "edit"};
+      }
+      all_edits[action.case_number]["charges"][action.ambiguous_charge_id]=action.edits;
+      return {...state, edits: all_edits, loading: true};
     default:
       return state;
   }

--- a/src/frontend/src/redux/search/reducer.ts
+++ b/src/frontend/src/redux/search/reducer.ts
@@ -4,13 +4,14 @@ import {
   CLEAR_RECORD,
   SELECT_ANSWER,
   SearchRecordState,
-  SearchRecordActionType
+  SearchRecordActionType, ANSWER_DISPOSITION
 } from './types';
 import {QuestionsData} from '../../components/RecordSearch/Record/types'
 
 const initalState: SearchRecordState = {
   loading: false,
-  aliases: []
+  aliases: [],
+  dispositionWasUnknown: []
 };
 
 export function searchReducer(
@@ -23,7 +24,8 @@ export function searchReducer(
         ...state,
         record: action.record,
         questions: action.questions,
-        loading: false
+        loading: false,
+        dispositionWasUnknown: action.dispositionWasUnknown
       };
     case RECORD_LOADING:
       return {...state, record: {}, aliases: JSON.parse(JSON.stringify(action.aliases)), questions: {}, loading: true};
@@ -35,6 +37,8 @@ export function searchReducer(
         questions[action.ambiguous_charge_id].answer = action.answer;
       }
       return {...state, questions: questions, loading: true};
+    case ANSWER_DISPOSITION:
+      return {...state, loading: true};
     default:
       return state;
   }

--- a/src/frontend/src/redux/search/types.ts
+++ b/src/frontend/src/redux/search/types.ts
@@ -15,18 +15,21 @@ export interface RecordEndpointData {
   errors: string[];
   summary: RecordSummaryData;
   questions: QuestionsData;
+  disposition_was_unknown: string[];
 }
 
 export const DISPLAY_RECORD = 'DISPLAY_RECORD';
 export const RECORD_LOADING = 'RECORD_LOADING';
 export const CLEAR_RECORD = 'CLEAR_RECORD';
 export const SELECT_ANSWER = 'SELECT_ANSWER';
+export const ANSWER_DISPOSITION = 'ANSWER_DISPOSITION';
 
 export interface SearchRecordState {
   loading: boolean;
   aliases: AliasData[];
   record?: RecordData;
-  questions?: QuestionsData
+  questions?: QuestionsData;
+  dispositionWasUnknown: string[];
 }
 
 interface SearchRecordAction {
@@ -37,12 +40,17 @@ interface SearchRecordAction {
   aliases: AliasData[];
   record: RecordData;
   questions: QuestionsData;
+  dispositionWasUnknown: string[];
 }
 
 interface QuestionsAction {
-  ambiguous_charge_id: string,
-  type: typeof SELECT_ANSWER
-  answer: string
+  ambiguous_charge_id: string;
+  type: typeof SELECT_ANSWER;
+  answer: string;
 }
 
-export type SearchRecordActionType = SearchRecordAction | QuestionsAction;
+interface AnswerDispositionAction {
+  type: typeof ANSWER_DISPOSITION;
+}
+
+export type SearchRecordActionType = SearchRecordAction | QuestionsAction | AnswerDispositionAction;

--- a/src/frontend/src/redux/search/types.ts
+++ b/src/frontend/src/redux/search/types.ts
@@ -54,8 +54,7 @@ interface AnswerDispositionAction {
   type: typeof ANSWER_DISPOSITION;
   case_number: string;
   ambiguous_charge_id: string;
-  edits: any;
-
+  disposition_edit: any; // TODO: Properly type
 }
 
 export type SearchRecordActionType = SearchRecordAction | QuestionsAction | AnswerDispositionAction;

--- a/src/frontend/src/redux/search/types.ts
+++ b/src/frontend/src/redux/search/types.ts
@@ -29,6 +29,7 @@ export interface SearchRecordState {
   aliases: AliasData[];
   record?: RecordData;
   questions?: QuestionsData;
+  edits?: any;
   dispositionWasUnknown: string[];
 }
 
@@ -51,6 +52,10 @@ interface QuestionsAction {
 
 interface AnswerDispositionAction {
   type: typeof ANSWER_DISPOSITION;
+  case_number: string;
+  ambiguous_charge_id: string;
+  edits: any;
+
 }
 
 export type SearchRecordActionType = SearchRecordAction | QuestionsAction | AnswerDispositionAction;


### PR DESCRIPTION
Related to #687 

Uses HTML mock ups by @hmarcks 

~~Currently the date input fields always show up. More React work will be needed to only show them after the radio button answer.~~

Screenshot from an example user's charge:

![Screen Shot 2020-04-30 at 8 00 45 AM](https://user-images.githubusercontent.com/6329898/80726051-c6137180-8ab8-11ea-8d10-5de058b0e432.png)

Probation revoked and the loading spinner still need work.
