### PR TITLE
Move probation_revoked from CaseSummary to each child charge

### DIFF
--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -66,15 +66,13 @@ class Expunger:
                     )
                 )
 
-            if charge.convicted():
-                probation_revoked_date = charge.case(cases).summary.probation_revoked
-                if probation_revoked_date:
-                    eligibility_dates.append(
-                        (
-                            probation_revoked_date + relativedelta(years=10),
-                            "Time-ineligible under 137.225(1)(c) (Probation Revoked). Inspect further if the case has multiple convictions on the case.",
-                        )
+            if charge.convicted() and charge.probation_revoked:
+                eligibility_dates.append(
+                    (
+                        charge.probation_revoked + relativedelta(years=10),
+                        "Time-ineligible under 137.225(1)(c) (Probation Revoked). Inspect further if the case has multiple convictions on the case.",
                     )
+                )
 
             if most_recent_blocking_conviction:
                 conviction_string = "other conviction" if charge.convicted() else "conviction"

--- a/src/backend/expungeservice/models/case.py
+++ b/src/backend/expungeservice/models/case.py
@@ -17,7 +17,6 @@ class CaseSummary:
     current_status: str
     case_detail_link: str
     balance_due_in_cents: int = 0
-    probation_revoked: Optional[date_class] = None
 
     def get_balance_due(self):
         return self.balance_due_in_cents / 100

--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -21,6 +21,7 @@ class OeciCharge:
     level: str
     date: date_class
     disposition: Optional[Disposition]
+    probation_revoked: Optional[date_class]
 
 
 @dataclass(frozen=True)

--- a/src/backend/expungeservice/record_creator.py
+++ b/src/backend/expungeservice/record_creator.py
@@ -111,6 +111,7 @@ class RecordCreator:
                 "level": oeci_charge.level,
                 "date": oeci_charge.date,
                 "disposition": oeci_charge.disposition,
+                "probation_revoked": oeci_charge.probation_revoked,
                 "case_number": oeci_case.summary.case_number,
                 "violation_type": oeci_case.summary.violation_type,
                 "birth_year": oeci_case.summary.birth_year,
@@ -143,8 +144,8 @@ class RecordCreator:
         if "summary" in edits.keys():
             case_summary_edits: Dict[str, Any] = {}
             for key, value in edits["summary"].items():
-                if key in ("date", "probation_revoked"):
-                    case_summary_edits[key] = datetime.date(datetime.strptime(value, "%m/%d/%Y"))
+                if key == "date":
+                    case_summary_edits["date"] = datetime.date(datetime.strptime(value, "%m/%d/%Y"))
                 elif key == "balance_due":
                     case_summary_edits["balance_due_in_cents"] = CaseCreator.compute_balance_due_in_cents(value)
                 elif key == "birth_year":
@@ -175,8 +176,8 @@ class RecordCreator:
                             ),
                             edits[charge.ambiguous_charge_id]["disposition"]["ruling"],
                         )
-                    elif key == "date":
-                        charge_edits["date"] = datetime.date(datetime.strptime(value, "%m/%d/%Y"))
+                    elif key in ("date", "probation_revoked"):
+                        charge_edits[key] = datetime.date(datetime.strptime(value, "%m/%d/%Y"))
                     else:
                         charge_edits[key] = value
                 edited_charges.append(replace(charge, **charge_edits))

--- a/src/backend/expungeservice/serializer.py
+++ b/src/backend/expungeservice/serializer.py
@@ -47,7 +47,6 @@ class ExpungeModelEncoder(flask.json.JSONEncoder):
             "violation_type": case.violation_type,
             "current_status": case.current_status,
             "balance_due": case.get_balance_due(),
-            "probation_revoked": case.probation_revoked,
             "case_detail_link": case.case_detail_link,
         }
 

--- a/src/backend/tests/endpoints/test_disambiguate.py
+++ b/src/backend/tests/endpoints/test_disambiguate.py
@@ -47,6 +47,7 @@ DUII_SEARCH_RESPONSE = {
                         "id": "CASEJD1-1-0",
                         "level": "Misdemeanor Class A",
                         "name": "DUII",
+                        "probation_revoked": None,
                         "statute": "813010",
                         "type_name": "Diverted DUII ⬥ Dismissed Criminal Charge",
                     }
@@ -56,7 +57,6 @@ DUII_SEARCH_RESPONSE = {
                 "date": "Sep 5, 2008",
                 "location": "Multnomah",
                 "name": "DOE, JOHN",
-                "probation_revoked": None,
                 "violation_type": "Misdemeanor",
             }
         ],
@@ -123,6 +123,7 @@ DIVERTED_RESPONSE = {
                         "id": "CASEJD1-1-0",
                         "level": "Misdemeanor Class A",
                         "name": "DUII",
+                        "probation_revoked": None,
                         "statute": "813010",
                         "type_name": "Diverted DUII",
                     }
@@ -132,7 +133,6 @@ DIVERTED_RESPONSE = {
                 "date": "Sep 5, 2008",
                 "location": "Multnomah",
                 "name": "DOE, JOHN",
-                "probation_revoked": None,
                 "violation_type": "Misdemeanor",
             }
         ],

--- a/src/backend/tests/test_edit_results.py
+++ b/src/backend/tests/test_edit_results.py
@@ -31,6 +31,7 @@ case_1 = OeciCase(
             disposition=Disposition(
                 date=date(2001, 1, 1), ruling="Convicted", status=DispositionStatus.CONVICTED, amended=False,
             ),
+            probation_revoked=None,
         ),
         OeciCharge(
             ambiguous_charge_id="X0001-2",
@@ -39,6 +40,7 @@ case_1 = OeciCase(
             level="Felony Class C",
             date=date(2001, 1, 1),
             disposition=None,
+            probation_revoked=None,
         ),
     ),
 )
@@ -65,6 +67,7 @@ case_2 = OeciCase(
             disposition=Disposition(
                 date=date(2001, 1, 1), ruling="Convicted", status=DispositionStatus.CONVICTED, amended=False,
             ),
+            probation_revoked=None,
         ),
         OeciCharge(
             ambiguous_charge_id="X0002-2",
@@ -73,6 +76,7 @@ case_2 = OeciCase(
             level="Violation",
             date=date(2001, 1, 1),
             disposition=None,
+            probation_revoked=None,
         ),
     ),
 )


### PR DESCRIPTION
This doubles down on (makes more explicit) our shaky assumption that probation revoked applies to all charges in a case. However, this will simplify the logic the frontend needs to perform to fill in missing dispositions with a probation revoked status.