### PR TITLE
Updates login attributes

### DIFF
--- a/src/frontend/src/components/LogIn/index.tsx
+++ b/src/frontend/src/components/LogIn/index.tsx
@@ -92,8 +92,9 @@ class LogIn extends React.Component<Props, State> {
             </label>
             <input
               id="email"
-              name="email"
+              name="login"
               type="email"
+              autoComplete="email"
               className="w-100 mb4 pa3 br2 b--black-20"
               required={true}
               aria-describedby={
@@ -115,8 +116,9 @@ class LogIn extends React.Component<Props, State> {
             </label>
             <input
               id="password"
-              name="password"
+              name="login"
               type="password"
+              autoComplete="current-password"
               className="w-100 mb4 pa3 br2 b--black-20"
               required={true}
               aria-describedby={

--- a/src/frontend/src/components/OeciLogin/index.tsx
+++ b/src/frontend/src/components/OeciLogin/index.tsx
@@ -105,13 +105,15 @@ class OeciLogin extends React.Component<Props, State> {
                 expungement.
               </p>
               <div className="mt4">
-                <label htmlFor="name" className="db mb1 fw6">
+                <label htmlFor="userId" className="db mb1 fw6">
                   User ID
                 </label>
                 <input
                   id="userId"
-                  className="w-100 mb4 pa3 br2 b--black-20"
+                  name="oecilogin"
                   type="text"
+                  autoComplete="username"
+                  className="w-100 mb4 pa3 br2 b--black-20"
                   required
                   aria-describedby={
                     this.state.missingUserId ? 'inputs_msg' : undefined
@@ -124,9 +126,11 @@ class OeciLogin extends React.Component<Props, State> {
                 Password
               </label>
               <input
-                className="w-100 mb4 pa3 br2 b--black-20"
-                type="password"
                 id="password"
+                name="oecilogin"
+                type="password"
+                autoComplete="current-password"
+                className="w-100 mb4 pa3 br2 b--black-20"
                 required
                 aria-describedby={
                   this.state.missingPassword ? 'inputs_msg' : undefined


### PR DESCRIPTION
Issue #1085 

The OECI login form has mismatching values for the `for` and `id` attributes. Perhaps this will fix the issue where the browser is not saving my credentials. Will also add `autocomplete` and `name` attributes.