### PR TITLE
Answering the unknown Disposition question is more Reactive

### DIFF
--- a/src/frontend/src/components/RecordSearch/Record/Charge.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Charge.tsx
@@ -27,7 +27,7 @@ export default class Charge extends React.Component<Props> {
     const dispositionEvent = (disposition: any, date: any) => {
       let dispositionEvent;
       if (disposition === null) {
-        dispositionEvent = "Missing";
+        dispositionEvent = "Unknown";
       }  else {
         dispositionEvent = disposition.status;
         if (disposition.status === "Convicted") {

--- a/src/frontend/src/components/RecordSearch/Record/DispositionQuestion.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/DispositionQuestion.tsx
@@ -153,11 +153,11 @@ class DispositionQuestion extends React.Component<Props, State> {
                     <label htmlFor={this.props.ambiguous_charge_id + "-unknown"}>Unknown</label>
                 </div>
             </div>
-            <div className={this.state && this.state.submitPending ? "" : "visually-hidden"}>
+            <div className={this.state && (this.state.status === "Convicted" || this.state.status === "revoked") ? "" : "visually-hidden"}>
               <label className="db fw6 mt3 mb1" htmlFor="n">Date Convicted <span className="f6 fw4">mm/dd/yyyy</span></label>
               <input value={this.state.conviction_date} onChange={this.handleDateFieldChange} className="w5 br2 b--black-20 pa3" id="n" type="text" name="conviction_date"/>
             </div>
-            <div className={this.state && this.state.submitPending && this.state.status === "revoked" ? "" : "visually-hidden"}>
+            <div className={this.state && this.state.status === "revoked" ? "" : "visually-hidden"}>
               <label className="db fw6 mt3 mb1" htmlFor="n">Date Probation Revoked <span className="f6 fw4">mm/dd/yyyy</span></label>
               <input value={this.state.probation_revoked_date} onChange={this.handleDateFieldChange} className="w5 br2 b--black-20 pa3" id="n" type="text" name="probation_revoked_date"/>
             </div>

--- a/src/frontend/src/components/RecordSearch/Record/DispositionQuestion.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/DispositionQuestion.tsx
@@ -17,7 +17,7 @@ interface State {
   probation_revoked_date: string;
   missingFields: boolean;
   invalidDate: boolean;
-  submitPending: boolean;
+  submitClickPending: boolean;
 }
 
 class DispositionQuestion extends React.Component<Props, State> {
@@ -27,7 +27,7 @@ class DispositionQuestion extends React.Component<Props, State> {
     probation_revoked_date: "",
     missingFields: false,
     invalidDate: false,
-    submitPending: false
+    submitClickPending: false
   };
 
   componentDidMount() {
@@ -40,46 +40,46 @@ class DispositionQuestion extends React.Component<Props, State> {
 
   handleDismissedClick = () => {
     this.setState<any>({
-      "status": "Dismissed",
-      "conviction_date": "",
-      "probation_revoked_date": "",
-      "missingFields": false,
-      "invalidDate": false,
-      "submitPending": false
+      status: "Dismissed",
+      conviction_date: "",
+      probation_revoked_date: "",
+      missingFields: false,
+      invalidDate: false,
+      submitClickPending: false
     }, this.dispatchAnswer);
   };
 
   handleConvictedClick = () => {
     this.setState<any>({
-      "status": "Convicted",
-      "probation_revoked_date": "",
-      "missingFields": false,
-      "invalidDate": false,
-      "submitPending": true
+      status: "Convicted",
+      probation_revoked_date: "",
+      missingFields: false,
+      invalidDate: false,
+      submitClickPending: true
     });
   };
 
   handleRevokedClick = () => {
     this.setState<any>({
-      "status": "revoked",
-      "submitPending" : true
+      status: "revoked",
+      submitClickPending : true
     });
   };
 
   handleUnknownClick = () => {
     this.setState<any>({
-      "status": "Unknown",
-      "submitPending": false,
-      "conviction_date": "",
-      "probation_revoked_date": "",
-      "missingFields": false,
-      "invalidDate": false
+      status: "Unknown",
+      submitClickPending: false,
+      conviction_date: "",
+      probation_revoked_date: "",
+      missingFields: false,
+      invalidDate: false
     }, this.dispatchAnswer);
   };
 
   handleDateFieldChange = (e: React.BaseSyntheticEvent) => {
     this.setState<any>({
-      "submitPending": true,
+      submitClickPending: true,
       [e.target.name]: e.target.value,
     });
   };
@@ -89,7 +89,7 @@ class DispositionQuestion extends React.Component<Props, State> {
     this.validateForm().then(() => {
       if (!this.state.missingFields && !this.state.invalidDate) {
         this.setState<any>({
-          "submitPending" : false
+          submitClickPending : false
         });
         this.dispatchAnswer();
       }
@@ -162,7 +162,7 @@ class DispositionQuestion extends React.Component<Props, State> {
               <input value={this.state.probation_revoked_date} onChange={this.handleDateFieldChange} className="w5 br2 b--black-20 pa3" id="n" type="text" name="probation_revoked_date"/>
             </div>
             {
-              this.state.submitPending ?
+              this.state.submitClickPending ?
                 <button className="db bg-blue white bg-animate hover-bg-dark-blue fw6 br2 pv3 ph4 mt3">Submit</button> :
                 null
             }

--- a/src/frontend/src/components/RecordSearch/Record/DispositionQuestion.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/DispositionQuestion.tsx
@@ -16,28 +16,70 @@ interface State {
   conviction_date: string;
   probation_revoked_date: string;
   missingFields: boolean;
-  invalidDate: boolean
+  invalidDate: boolean;
+  submitPending: boolean;
 }
 
 class DispositionQuestion extends React.Component<Props, State> {
   state: State  = {
-    status: "Open",
+    status: "Unknown",
     conviction_date: "",
     probation_revoked_date: "",
     missingFields: false,
-    invalidDate: false
+    invalidDate: false,
+    submitPending: false
   };
 
   componentDidMount() {
     this.setState({
-      status: (this.props.disposition ? this.props.disposition.status : "Open") ,
+      status: (this.props.disposition ? this.props.disposition.status : "Unknown") ,
       conviction_date: (this.props.disposition ? this.props.disposition.date : ""),
       }
     )
   }
 
-  handleChange = (e: React.BaseSyntheticEvent) => {
+  handleDismissedClick = () => {
     this.setState<any>({
+      ["status"]: "Dismissed",
+      ["conviction_date"]: "",
+      ["probation_revoked_date"]: "",
+      ["missingFields"]: false,
+      ["invalidDate"]: false,
+      ["submitPending"]: false
+    }, this.dispatchAnswer);
+  };
+
+  handleConvictedClick = () => {
+    this.setState<any>({
+      ["status"]: "Convicted",
+      ["probation_revoked_date"]: "",
+      ["missingFields"]: false,
+      ["invalidDate"]: false,
+      ["submitPending"] : true
+    });
+  };
+
+  handleRevokedClick = () => {
+    this.setState<any>({
+      ["status"]: "revoked",
+      ["submitPending"] : true
+    });
+  };
+
+  handleUnknownClick = () => {
+    this.setState<any>({
+      ["status"]: "Unknown",
+      ["submitPending"] : false,
+      ["conviction_date"]: "",
+      ["probation_revoked_date"]: "",
+      ["missingFields"]: false,
+      ["invalidDate"]: false
+    }, this.dispatchAnswer);
+  };
+
+  handleDateFieldChange = (e: React.BaseSyntheticEvent) => {
+    this.setState<any>({
+      ["submitPending"]: true,
       [e.target.name]: e.target.value
     });
   };
@@ -46,17 +88,24 @@ class DispositionQuestion extends React.Component<Props, State> {
     e.preventDefault();
     this.validateForm().then(() => {
       if (!this.state.missingFields && !this.state.invalidDate) {
-        store.dispatch(
-          answerDisposition(
-            this.props.case_number,
-            this.props.ambiguous_charge_id,
-            this.state.status,
-            this.state.conviction_date || "1/1/2020", // The date for a dismissal doesn't matter, but the backend expects something so here we are.
-            this.state.probation_revoked_date
-          )
-        )
+        this.setState<any>({
+          ["submitPending"] : false
+        });
+        this.dispatchAnswer();
       }
     });
+  };
+
+  dispatchAnswer = () => {
+    store.dispatch(
+      answerDisposition(
+        this.props.case_number,
+        this.props.ambiguous_charge_id,
+        this.state.status,
+        this.state.conviction_date || "1/1/2020", // The date for a dismissal doesn't matter, but the backend expects something so here we are.
+        this.state.probation_revoked_date
+      )
+    )
   };
 
   validateForm = () => {
@@ -88,34 +137,43 @@ class DispositionQuestion extends React.Component<Props, State> {
             <legend className="fw7 mb2">Choose a disposition</legend>
             <div className="radio">
                 <div className="dib">
-                    <input id={this.props.ambiguous_charge_id + "-dis"} name="status" type="radio" value="Dismissed" checked={this.state.status==="Dismissed"} onChange={this.handleChange} />
+                    <input id={this.props.ambiguous_charge_id + "-dis"} name="status" type="radio" value="Dismissed" checked={this.state.status==="Dismissed"} onChange={this.handleDismissedClick} />
                     <label htmlFor={this.props.ambiguous_charge_id + "-dis"}>Dismissed</label>
                 </div>
                 <div className="dib">
-                    <input id={this.props.ambiguous_charge_id + "-con"} name="status" type="radio" value="Convicted" checked={this.state.status==="Convicted"} onChange={this.handleChange} />
+                    <input id={this.props.ambiguous_charge_id + "-con"} name="status" type="radio" value="Convicted" checked={this.state.status==="Convicted"} onChange={this.handleConvictedClick} />
                     <label htmlFor={this.props.ambiguous_charge_id + "-con"}>Convicted</label>
                 </div>
                 <div className="dib">
-                    <input id={this.props.ambiguous_charge_id + "-rev"} name="status" type="radio" value="revoked" checked={this.state.status==="revoked"} onChange={this.handleChange} />
+                    <input id={this.props.ambiguous_charge_id + "-rev"} name="status" type="radio" value="revoked" checked={this.state.status==="revoked"} onChange={this.handleRevokedClick} />
                     <label htmlFor={this.props.ambiguous_charge_id + "-rev"}>Probation Revoked</label>
                 </div>
                 <div className="dib">
-                    <input id={this.props.ambiguous_charge_id + "-open"} name="status" type="radio" value="Open" checked={this.state && this.state.status==="Open"} onChange={this.handleChange} />
-                    <label htmlFor={this.props.ambiguous_charge_id + "-open"}>Open</label>
+                    <input id={this.props.ambiguous_charge_id + "-unknown"} name="status" type="radio" value="Unknown" checked={this.state && this.state.status==="Unknown"} onChange={this.handleUnknownClick} />
+                    <label htmlFor={this.props.ambiguous_charge_id + "-unknown"}>Unknown</label>
                 </div>
             </div>
             <div className={this.state && (this.state.status === "Convicted" || this.state.status === "revoked") ? "" : "visually-hidden"}>
               <label className="db fw6 mt3 mb1" htmlFor="n">Date Convicted <span className="f6 fw4">mm/dd/yyyy</span></label>
-              <input onChange={this.handleChange} className="w5 br2 b--black-20 pa3" id="n" type="text" name="conviction_date"/>
+              <input value={this.state.conviction_date} onChange={this.handleDateFieldChange} className="w5 br2 b--black-20 pa3" id="n" type="text" name="conviction_date"/>
             </div>
             <div className={this.state && this.state.status === "revoked" ? "" : "visually-hidden"}>
               <label className="db fw6 mt3 mb1" htmlFor="n">Date Probation Revoked <span className="f6 fw4">mm/dd/yyyy</span></label>
-              <input onChange={this.handleChange} className="w5 br2 b--black-20 pa3" id="n" type="text" name="probation_revoked_date"/>
+              <input value={this.state.probation_revoked_date} onChange={this.handleDateFieldChange} className="w5 br2 b--black-20 pa3" id="n" type="text" name="probation_revoked_date"/>
             </div>
-            {this.props.loading ?
-              <button className="loading-btn db bg-blue white bg-animate hover-bg-dark-blue fw6 br2 pv3 ph4 mt3">Submit</button> :
-              <button className="db bg-blue white bg-animate hover-bg-dark-blue fw6 br2 pv3 ph4 mt3">Submit</button>
-              }
+            {
+              this.state.submitPending ?
+                <button className="db bg-blue white bg-animate hover-bg-dark-blue fw6 br2 pv3 ph4 mt3">Submit</button> :
+                null
+            }
+            {
+              this.props.loading ?
+                <div className="radio-spinner absolute" role="status">
+                  <span className="spinner spinner--sm mr1"></span>
+                  <span className="f6 fw5">Updating&#8230;</span>
+                </div> :
+                null
+            }
             <div role="alert">
               <p className={(this.state && this.state.missingFields ? "" : "visually-hidden " ) + "dib bg-washed-red fw6 br3 pa3 mt3"}>Please complete all fields</p>
             </div>

--- a/src/frontend/src/components/RecordSearch/Record/DispositionQuestion.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/DispositionQuestion.tsx
@@ -40,47 +40,47 @@ class DispositionQuestion extends React.Component<Props, State> {
 
   handleDismissedClick = () => {
     this.setState<any>({
-      ["status"]: "Dismissed",
-      ["conviction_date"]: "",
-      ["probation_revoked_date"]: "",
-      ["missingFields"]: false,
-      ["invalidDate"]: false,
-      ["submitPending"]: false
+      "status": "Dismissed",
+      "conviction_date": "",
+      "probation_revoked_date": "",
+      "missingFields": false,
+      "invalidDate": false,
+      "submitPending": false
     }, this.dispatchAnswer);
   };
 
   handleConvictedClick = () => {
     this.setState<any>({
-      ["status"]: "Convicted",
-      ["probation_revoked_date"]: "",
-      ["missingFields"]: false,
-      ["invalidDate"]: false,
-      ["submitPending"] : true
+      "status": "Convicted",
+      "probation_revoked_date": "",
+      "missingFields": false,
+      "invalidDate": false,
+      "submitPending": true
     });
   };
 
   handleRevokedClick = () => {
     this.setState<any>({
-      ["status"]: "revoked",
-      ["submitPending"] : true
+      "status": "revoked",
+      "submitPending" : true
     });
   };
 
   handleUnknownClick = () => {
     this.setState<any>({
-      ["status"]: "Unknown",
-      ["submitPending"] : false,
-      ["conviction_date"]: "",
-      ["probation_revoked_date"]: "",
-      ["missingFields"]: false,
-      ["invalidDate"]: false
+      "status": "Unknown",
+      "submitPending": false,
+      "conviction_date": "",
+      "probation_revoked_date": "",
+      "missingFields": false,
+      "invalidDate": false
     }, this.dispatchAnswer);
   };
 
   handleDateFieldChange = (e: React.BaseSyntheticEvent) => {
     this.setState<any>({
-      ["submitPending"]: true,
-      [e.target.name]: e.target.value
+      "submitPending": true,
+      [e.target.name]: e.target.value,
     });
   };
 
@@ -89,7 +89,7 @@ class DispositionQuestion extends React.Component<Props, State> {
     this.validateForm().then(() => {
       if (!this.state.missingFields && !this.state.invalidDate) {
         this.setState<any>({
-          ["submitPending"] : false
+          "submitPending" : false
         });
         this.dispatchAnswer();
       }
@@ -153,11 +153,11 @@ class DispositionQuestion extends React.Component<Props, State> {
                     <label htmlFor={this.props.ambiguous_charge_id + "-unknown"}>Unknown</label>
                 </div>
             </div>
-            <div className={this.state && (this.state.status === "Convicted" || this.state.status === "revoked") ? "" : "visually-hidden"}>
+            <div className={this.state && this.state.submitPending ? "" : "visually-hidden"}>
               <label className="db fw6 mt3 mb1" htmlFor="n">Date Convicted <span className="f6 fw4">mm/dd/yyyy</span></label>
               <input value={this.state.conviction_date} onChange={this.handleDateFieldChange} className="w5 br2 b--black-20 pa3" id="n" type="text" name="conviction_date"/>
             </div>
-            <div className={this.state && this.state.status === "revoked" ? "" : "visually-hidden"}>
+            <div className={this.state && this.state.submitPending && this.state.status === "revoked" ? "" : "visually-hidden"}>
               <label className="db fw6 mt3 mb1" htmlFor="n">Date Probation Revoked <span className="f6 fw4">mm/dd/yyyy</span></label>
               <input value={this.state.probation_revoked_date} onChange={this.handleDateFieldChange} className="w5 br2 b--black-20 pa3" id="n" type="text" name="probation_revoked_date"/>
             </div>

--- a/src/frontend/src/redux/search/actions.ts
+++ b/src/frontend/src/redux/search/actions.ts
@@ -97,7 +97,7 @@ export function answerDisposition(
   probation_revoked_date: string): any {
   return (dispatch: Dispatch) => {
     const disposition = () => {
-      if (ruling === "Open") {
+      if (ruling === "Unknown") {
         return;
       } else if (ruling === "revoked") {
         return {"date": date, "ruling": "Convicted"};


### PR DESCRIPTION
 * The "Open" selection and "Missing" Disposition in charge info are both renamed to "Unknown"
 * Clicking Dismissed or Unknown triggers immediate update because no more info is needed. The Submit button doesn't appear when these are selected. 
 * Error tags disappear when the user clicks away from Probation Revoked to Convicted. The behavior here *could* get more fine-grained if we wanted to, especially when clicking on and off the Convicted option.
 * The submit button disappears after the user does a correct submit, and reappears if the user changes a field
 * The "updating" spinner is used here while loading any changes.