### PR TITLE
Clear probation revoked

### DIFF
--- a/src/backend/expungeservice/record_creator.py
+++ b/src/backend/expungeservice/record_creator.py
@@ -180,7 +180,8 @@ class RecordCreator:
                         else:
                             charge_edits["disposition"] = None
                     elif key in ("date", "probation_revoked"):
-                        charge_edits[key] = datetime.date(datetime.strptime(value, "%m/%d/%Y"))
+                        if value:
+                            charge_edits[key] = datetime.date(datetime.strptime(value, "%m/%d/%Y"))
                     else:
                         charge_edits[key] = value
                 edited_charges.append(replace(charge, **charge_edits))

--- a/src/frontend/src/redux/search/reducer.ts
+++ b/src/frontend/src/redux/search/reducer.ts
@@ -45,9 +45,8 @@ export function searchReducer(
       edits[action.case_number]["charges"] = edits[action.case_number]["charges"] || {};
       edits[action.case_number]["charges"][action.ambiguous_charge_id] = edits[action.case_number]["charges"][action.ambiguous_charge_id] || {};
       edits[action.case_number]["charges"][action.ambiguous_charge_id]["disposition"] = action.disposition_edit;
-      if (action.probation_revoked_edit) {
-        edits[action.case_number]["charges"][action.ambiguous_charge_id]["probation_revoked"] = action.probation_revoked_edit;
-      }
+      edits[action.case_number]["charges"][action.ambiguous_charge_id]["probation_revoked"] = action.probation_revoked_edit;
+
       return {...state, edits: edits, loading: true};
     default:
       return state;


### PR DESCRIPTION
Bugfix: currently, if you submit a Probation Revoked disposition answer, then change that answer to Convicted, the Probation Revoked date persists in Redux and the time eligibility is incorrect.

Deleting a key in Redux is annoying:
https://medium.com/better-programming/deleting-an-item-in-a-nested-redux-state-3de0cb3943da

But overwriting it with "" is easy.

This fix required making the backend handle a date field when it is an empty string (it gets skipped).
