### PR TITLE
check manu/del crimes for keywords "iii" and " iv"

### DIFF
--- a/src/backend/expungeservice/charge_classifier.py
+++ b/src/backend/expungeservice/charge_classifier.py
@@ -155,12 +155,12 @@ class ChargeClassifier:
     @staticmethod
     def _manufacture_delivery(name, level, statute):
         if any([manu_del_keyword in name for manu_del_keyword in ["delivery", "manu/del", "manufactur"]]):
-            if any([schedule_2_keyword in name for schedule_2_keyword in ["2", "heroin", "cocaine", "meth"]]):
+            if any([schedule_2_keyword in name for schedule_2_keyword in ["2", "ii", "heroin", "cocaine", "meth"]]):
                 if level == "Felony Unclassified":
                     question_string = "Was the charge for an A Felony or B Felony?"
                     options = ["A Felony", "B Felony"]
                     return AmbiguousChargeTypeWithQuestion([FelonyClassA, FelonyClassB], question_string, options)
-            elif "3" in name or "4" in name:
+            if any([schedule_3_keyword in name for schedule_3_keyword in ["3", "iii", "4", " iv"]]) :
                 return ChargeClassifier._classification_by_level(level, statute)
             else:
                 # The name contains either a "1" or no schedule number, and is possibly a marijuana charge.


### PR DESCRIPTION
Checks for " iv" (with a leading space) because the string "iv" is in the word "delivery", making a false positive. 

And the other schedule keywords don't have associated tests, so... :shrug: lazy option.

closes #1096 