### PR TITLE
New charge type MarijuanaViolation

### DIFF
--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -43,13 +43,6 @@ class Expunger:
                             "One year from date of conviction (137.226)",
                         )
                     )
-                elif isinstance(charge, MarijuanaViolation):
-                    eligibility_dates.append(
-                        (
-                            charge.disposition.date,  # type: ignore
-                            "Eligible immediately (475B.401)",
-                        )
-                    )
                 else:
                     eligibility_dates.append(
                         (
@@ -106,7 +99,12 @@ class Expunger:
                 else:
                     eligibility_dates.append((charge.disposition.date + relativedelta(years=20), "Twenty years from date of class B felony conviction (137.225(5)(a)(A)(i))"))  # type: ignore
 
-            date_will_be_eligible, reason = max(eligibility_dates)
+            if isinstance(charge, MarijuanaViolation):
+                    date_will_be_eligible = charge.disposition.date  # type: ignore
+                    reason = "Eligible immediately (475B.401)"
+            else:
+                date_will_be_eligible, reason = max(eligibility_dates)
+
             if date_will_be_eligible and date.today() >= date_will_be_eligible:
                 time_eligibility = TimeEligibility(
                     status=EligibilityStatus.ELIGIBLE,

--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -10,7 +10,7 @@ from expungeservice.models.case import Case
 from expungeservice.models.charge import Charge
 from expungeservice.models.charge_types.felony_class_b import FelonyClassB
 from expungeservice.models.charge_types.juvenile_charge import JuvenileCharge
-from expungeservice.models.charge_types.marijuana_eligible import MarijuanaUnder21
+from expungeservice.models.charge_types.marijuana_eligible import MarijuanaUnder21, MarijuanaViolation
 from expungeservice.models.charge_types.traffic_violation import TrafficViolation
 from expungeservice.models.disposition import DispositionStatus
 from expungeservice.models.expungement_result import EligibilityStatus, TimeEligibility
@@ -41,6 +41,13 @@ class Expunger:
                         (
                             charge.disposition.date + relativedelta(years=1),  # type: ignore
                             "One year from date of conviction (137.226)",
+                        )
+                    )
+                elif isinstance(charge, MarijuanaViolation):
+                    eligibility_dates.append(
+                        (
+                            charge.disposition.date,  # type: ignore
+                            "Eligible immediately (475B.401)",
                         )
                     )
                 else:

--- a/src/backend/expungeservice/models/charge_types/marijuana_eligible.py
+++ b/src/backend/expungeservice/models/charge_types/marijuana_eligible.py
@@ -34,3 +34,18 @@ class MarijuanaUnder21(Charge):
             raise ValueError("Dismissed criminal charges should have been caught by another class.")
         elif self.convicted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.226")
+
+
+@dataclass(frozen=True)
+class MarijuanaViolation(Charge):
+    type_name: str = "Marijuana Violation"
+    expungement_rules: str = """Under 475B.401, convictions for possession of less than an ounce of marijuana are always eligible, regardless of any time eligibility restrictions that would normally apply.
+    This charge type is identifiable as any marijuana charge whose level is Violation."""
+
+    def _type_eligibility(self):
+        if self.dismissed():
+            return TypeEligibility(
+                EligibilityStatus.INELIGIBLE, reason="Dismissed violations are ineligible by omission from statute"
+            )
+        elif self.convicted():
+            return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 475B.401")

--- a/src/backend/expungeservice/models/charge_types/sex_crimes.py
+++ b/src/backend/expungeservice/models/charge_types/sex_crimes.py
@@ -62,6 +62,7 @@ class RomeoAndJulietNMASexCrime(Charge):
     type_name: str = "137.225(6)(f) related sex crime"
     expungement_rules: str = ("""In some cases, a statutory rape charge may be eligible for a young offender. Please contact michael@qiu-qiulaw.com for manual analysis.""")
 
+
     def _type_eligibility(self):
         if self.dismissed():
             raise ValueError("Dismissed criminal charges should have been caught by another class.")

--- a/src/backend/expungeservice/models/charge_types/sex_crimes.py
+++ b/src/backend/expungeservice/models/charge_types/sex_crimes.py
@@ -62,7 +62,6 @@ class RomeoAndJulietNMASexCrime(Charge):
     type_name: str = "137.225(6)(f) related sex crime"
     expungement_rules: str = ("""In some cases, a statutory rape charge may be eligible for a young offender. Please contact michael@qiu-qiulaw.com for manual analysis.""")
 
-
     def _type_eligibility(self):
         if self.dismissed():
             raise ValueError("Dismissed criminal charges should have been caught by another class.")

--- a/src/backend/tests/models/charge_types/test_marijuana_violation.py
+++ b/src/backend/tests/models/charge_types/test_marijuana_violation.py
@@ -1,0 +1,30 @@
+from expungeservice.models.expungement_result import EligibilityStatus
+from expungeservice.models.charge_types.marijuana_eligible import MarijuanaViolation
+from tests.factories.charge_factory import ChargeFactory
+from tests.models.test_charge import Dispositions
+
+
+def test_marijuana_violation_conviction():
+    marijuana_violation = ChargeFactory.create(
+        name="Possession of Marijuana < 1 Ounce",
+        statute="4758643",
+        level="Violation Unclassified",
+        disposition=Dispositions.CONVICTED,
+    )
+
+    assert isinstance(marijuana_violation, MarijuanaViolation)
+    assert marijuana_violation.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert marijuana_violation.type_eligibility.reason == "Eligible under 475B.401"
+
+
+def test_marijuana_violation_dismissal():
+    marijuana_violation = ChargeFactory.create(
+        name="Unlawful Possession of less than One Ounce of Marijuana",
+        statute="4758643C",
+        level="Violation Unclassified",
+        disposition=Dispositions.DISMISSED,
+    )
+
+    assert isinstance(marijuana_violation, MarijuanaViolation)
+    assert marijuana_violation.type_eligibility.status is EligibilityStatus.INELIGIBLE
+    assert marijuana_violation.type_eligibility.reason == "Dismissed violations are ineligible by omission from statute"


### PR DESCRIPTION
Closes #1055 

Design decision here was to name this type MarijuanaViolation instead of something like MarijuanaPossessionUnder1Ounce. The options here are a bit awkward because:

The expungement statute that applies [475B.401](https://www.oregonlegislature.gov/bills_laws/ors/ors475b.html) uses the "under an ounce" as the qualifying condition. But @michaelzhang43  suggests we identify this charge type by the level. This relies on the fact that a Marijuana Violation is always for a possession <1 ounce charge. 
The examples I found of this charge had the names:
- "Unlawful Possession of less than One Ounce of Marijuana" 
- "Possession of Marijuana < 1 Ounce"

Checking just for Violation level is a simpler and presumably more robust identifier. Also this charge type follows the normal rules for a violation Dismissal (ineligible). 

Marking this as a Draft in order to make an additional unit test (that I only just thought of) to verify that the "immediately eligible" time rule applies even with a prior conviction. 