### PR TITLE
Add links to scrapped case detail pages from OECI

### DIFF
--- a/src/backend/expungeservice/crawler/crawler.py
+++ b/src/backend/expungeservice/crawler/crawler.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from requests import Session
 
 from expungeservice.crawler.request import Payload, URL
+from expungeservice.crawler.util import LRUCache
 from expungeservice.models.case import CaseCreator, Case, OeciCase, CaseSummary
 from expungeservice.models.charge import OeciCharge
 from expungeservice.models.disposition import DispositionCreator
@@ -28,7 +29,7 @@ class OECIUnavailable(Exception):
 
 
 class Crawler:
-    cached_links = {}
+    cached_links = LRUCache(1000)
 
     @staticmethod
     def attempt_login(session: Session, username, password) -> str:
@@ -49,7 +50,7 @@ class Crawler:
             Crawler.cached_links[link] = response
             return response
         else:
-            return Crawler.cached_links.get(link)
+            return Crawler.cached_links[link]
 
     @staticmethod
     def search(

--- a/src/backend/expungeservice/crawler/util.py
+++ b/src/backend/expungeservice/crawler/util.py
@@ -1,0 +1,25 @@
+# Adapted from https://www.kunxi.org/2014/05/lru-cache-in-python/
+
+import collections
+
+
+class LRUCache:
+    def __init__(self, capacity):
+        self.capacity = capacity
+        self.cache: collections.OrderedDict = collections.OrderedDict()
+
+    def __getitem__(self, key):
+        try:
+            value = self.cache.pop(key)
+            self.cache[key] = value
+            return value
+        except KeyError:
+            return None
+
+    def __setitem__(self, key, value):
+        try:
+            self.cache.pop(key)
+        except KeyError:
+            if len(self.cache) >= self.capacity:
+                self.cache.popitem(last=False)
+        self.cache[key] = value

--- a/src/backend/expungeservice/endpoints/case_detail_page.py
+++ b/src/backend/expungeservice/endpoints/case_detail_page.py
@@ -1,0 +1,30 @@
+from os import path
+from pathlib import Path
+
+from flask.views import MethodView
+from flask_login import login_required
+
+from expungeservice.crawler.crawler import Crawler
+
+
+class CaseDetailPage(MethodView):
+    @login_required
+    def get(self, id):
+        url = f"https://publicaccess.courts.oregon.gov/PublicAccessLogin/CaseDetail.aspx?CaseID={id}"
+        html = Crawler.fetch_link(url)
+        if html:
+            return html.text
+        else:
+            return f"Case detail page with ID of {id} does not exist."
+
+
+class CaseDetailPageCSS(MethodView):
+    def get(self):
+        return Path(path.join(path.dirname(__file__), "resources", "oeci.css")).read_text()
+
+
+def register(app):
+    app.add_url_rule("/api/case_detail_page/<int:id>", view_func=CaseDetailPage.as_view("case_detail_page"))
+    app.add_url_rule(
+        "/api/case_detail_page/CSS/PublicAccess.css", view_func=CaseDetailPageCSS.as_view("case_detail_page_css")
+    )

--- a/src/backend/expungeservice/endpoints/resources/oeci.css
+++ b/src/backend/expungeservice/endpoints/resources/oeci.css
@@ -1,0 +1,292 @@
+BODY
+{
+    MARGIN: 3px;
+    FONT-FAMILY: arial
+}
+TH.ssSearchResultHeader
+{
+    BORDER-TOP: black 1px solid;
+    OVERFLOW: hidden;
+    BORDER-BOTTOM: black 1px solid;
+    TEXT-ALIGN: left;
+}
+TH.ssSearchResultHeaderTop
+{
+	BORDER-TOP: black 1px solid;
+	OVERFLOW: hidden;
+  TEXT-ALIGN: left;
+}
+TH.ssSearchResultHeaderBottom
+{
+	BORDER-BOTTOM: black 1px solid;
+	OVERFLOW: hidden;
+  TEXT-ALIGN: left;
+}
+TH
+{
+    OVERFLOW: hidden
+}
+TH.ssTableHeader
+{
+  text-align: left;
+}
+TH.ssTableHeaderLabel
+{
+  TEXT-ALIGN: right;
+  FONT-WEIGHT: lighter;
+}
+TH.ssTableHeaderLabelLeft
+{
+  TEXT-ALIGN: left;
+  FONT-WEIGHT: lighter;
+}
+TD
+{
+	OVERFLOW: hidden;
+}
+a.ssLaunchHyperLink
+{
+    FONT-SIZE: 10pt;
+    COLOR: #ffffff
+}
+DIV.ssBlackNavBarText
+{
+    FONT-WEIGHT: bold;
+    FONT-SIZE: 8pt;
+    COLOR: #dfdfdf
+}
+A.ssBlackNavBarHyperlink
+{
+    FONT-SIZE: 8pt;
+    COLOR: #ffffff
+}
+A.ssSearchHyperlink
+{
+    FONT-WEIGHT: bold;
+    FONT-SIZE: 10pt;
+    CURSOR: hand;
+    COLOR: cornflowerblue;
+    TEXT-DECORATION: underline
+}
+P.ssCopyright
+{
+    PADDING-RIGHT: 0px;
+    PADDING-LEFT: 0px;
+    FONT-SIZE: 8pt;
+    PADDING-BOTTOM: 15px;
+    COLOR: #dfdfdf;
+    PADDING-TOP: 15px
+}
+SPAN.ssHyperLinkSpacer
+{
+    PADDING-RIGHT: 15px;
+    PADDING-LEFT: 15px;
+    FONT-SIZE: 8pt;
+    PADDING-BOTTOM: 0px;
+    COLOR: #dfdfdf;
+    PADDING-TOP: 0px
+}
+TABLE
+{
+    FONT-SIZE: 8pt;
+    COLOR: #000000;
+
+}
+DIV.ssCaseDetailSectionTitle
+{
+    BORDER-TOP: black 1px solid;
+    MARGIN-TOP: 20px;
+    FONT-WEIGHT: bold;
+    FONT-SIZE: 8pt;
+    MARGIN-BOTTOM: 10px;
+    WIDTH: 100%;
+    BORDER-BOTTOM: black 1px solid;
+    FONT-FAMILY: Times;
+    TEXT-ALIGN: center;
+    FONT-VARIANT: small-caps;
+    white-space: normal;
+    width: 100%;
+}
+DIV.ssTextFooter
+{
+    BORDER-TOP: black 1px solid;
+    MARGIN-TOP: 20px;
+    FONT-WEIGHT: bold;
+    FONT-SIZE: 8pt;
+    MARGIN-BOTTOM: 10px;
+    WIDTH: 100%;
+    TEXT-ALIGN: center;
+}
+DIV.ssCaseDetailROA
+{
+    FONT-WEIGHT: bold;
+    FONT-SIZE: 14pt;
+    WIDTH: 100%;
+    FONT-FAMILY: Times;
+    TEXT-ALIGN: center;
+    FONT-VARIANT: small-caps
+}
+DIV.ssCaseDetailCaseNbr
+{
+    FONT-WEIGHT: bold;
+    FONT-SIZE: 10pt;
+    PADDING-BOTTOM: 20px;
+    WIDTH: 100%;
+    FONT-FAMILY: Times;
+    TEXT-ALIGN: center;
+    FONT-VARIANT: small-caps
+}
+TH.ssEventsAndOrdersSubTitle
+{
+    FONT-WEIGHT: bold;
+    FONT-SIZE: 8pt;
+    PADDING-BOTTOM: 3px;
+    FONT-FAMILY: Times;
+    TEXT-ALIGN: left;
+}
+LABEL.ssLogin
+{
+    FONT-SIZE: 8pt;
+    COLOR: #003d00
+}
+P.ssLoginError
+{
+    FONT-SIZE: 8pt;
+    COLOR: red
+}
+DIV.ssErrorOccured
+{
+    FONT-SIZE: 8pt;
+    COLOR: red
+}
+P.LoginMessage
+{
+    FONT-WEIGHT: bolder;
+    FONT-SIZE: 9pt;
+    COLOR: #6699cc
+}
+
+TD.ssLabel
+{
+    PADDING-RIGHT: 8px;
+    COLOR: #000080;
+    TEXT-ALIGN: right;
+    FONT-SIZE: 12px;
+}
+
+.ssRequiredLabel
+{
+    COLOR: Red;
+    TEXT-ALIGN: Center;
+    FONT-SIZE: 12px;
+    float:none;
+    font-weight:bold;
+}
+
+.ssRequiredText
+{
+    TEXT-ALIGN: Center;
+    FONT-SIZE: 112px;
+    float:none;
+}
+
+SPAN.ssJailingDetail
+{
+    BORDER-TOP: black 1px solid;
+    BORDER-BOTTOM: black 1px solid;
+    BORDER-LEFT: black 1px solid;
+    BORDER-RIGHT: black 1px solid;
+    MARGIN-BOTTOM: 10px;
+    MARGIN-LEFT: 10px;
+    MARGIN-RIGHT: 10px;
+    WIDTH: 100%;
+}
+
+DIV.ssJailingDetailTitle
+{
+    MARGIN-TOP: 10px;
+    MARGIN-BOTTOM: 10px;
+    MARGIN-LEFT: 10px;
+    MARGIN-RIGHT: 10px;
+    WIDTH: 100%;
+    PADDING-LEFT: 5px;
+    PADDING-RIGHT: 5px;
+}
+
+DIV.ssIncidentDetailTitle
+{
+    MARGIN-TOP: 10px;
+    MARGIN-BOTTOM: 10px;
+    MARGIN-LEFT: 10px;
+    MARGIN-RIGHT: 10px;
+    WIDTH: 100%;
+    PADDING-LEFT: 5px;
+    PADDING-RIGHT: 5px;
+    FONT-SIZE: 20px;
+}
+
+TD.ssIncidentDetailTitle
+{
+    FONT-SIZE: 20px;
+}
+
+DIV.ssLaunchProductTitle
+{
+	background-color: #EEEEEE;
+	FONT-SIZE: 16px;
+	color: Olive;
+	padding-left: 8px;
+	margin-bottom: 5px;
+}
+.ssInactiveText
+{
+  COLOR: gray;
+  FONT-STYLE: italic
+}
+
+TD.ssMessageText
+{
+  FONT-SIZE: 10pt;
+  FONT-WEIGHT: bold;
+  COLOR: #996578;
+  TEXT-ALIGN: center;
+}
+
+TD.ssSiteFooterRule
+{
+  BORDER-BOTTOM: solid 3px #000000
+}
+
+
+.ssSiteFooter
+{
+ HEIGHT: 1px;
+ VERTICAL-ALIGN: bottom;
+
+}
+
+
+TD.ssHeaderTitleBanner
+{
+	BACKGROUND-COLOR: #ffffff;
+	TEXT-ALIGN: center;
+	HEIGHT: 65px;
+	FONT-SIZE: x-large;
+	FONT-WEIGHT: bold;
+	COLOR: #6699cc;
+}
+
+TD.ssBlackNavBarLocation
+{
+  PADDING-RIGHT: 10px;
+  COLOR: #ffffff;
+  WHITE-SPACE: nowrap;
+  FONT-FAMILY: arial;
+  FONT-SIZE: 8pt;
+}
+.ButtonSection
+{
+  width: 90%;
+  margin-right: 15%;
+  text-align: right;
+}

--- a/src/frontend/src/components/RecordSearch/Record/Case.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Case.tsx
@@ -20,6 +20,7 @@ export default class Cases extends React.Component<Props> {
       location,
       current_status
     } = this.props.case;
+    const prefix = window.location.href.includes("localhost") ? "http://localhost:5000" : ""; // Hack so we do not have to use nginx for dev
     const case_detail_base = "https://publicaccess.courts.oregon.gov/PublicAccessLogin/CaseDetail.aspx?CaseID=";
     const link_id = case_detail_link.substring(case_detail_base.length);
     return (
@@ -27,7 +28,7 @@ export default class Cases extends React.Component<Props> {
         <div className="cf pv2 br3 br--top shadow-case">
           <div className="fl ph3 pv1">
             <div className="fw7">Case </div>
-            <a href={"/api/case_detail_page/" + link_id} target="_blank">{case_number}</a>
+            <a href={prefix + "/api/case_detail_page/" + link_id} target="_blank">{case_number}</a>
           </div>
           <div className="fl ph3 pv1">
             <div className="fw7">Status </div>

--- a/src/frontend/src/components/RecordSearch/Record/Case.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Case.tsx
@@ -14,17 +14,20 @@ export default class Cases extends React.Component<Props> {
       name,
       case_number,
       birth_year,
+      case_detail_link,
       balance_due,
       charges,
       location,
       current_status
     } = this.props.case;
+    const case_detail_base = "https://publicaccess.courts.oregon.gov/PublicAccessLogin/CaseDetail.aspx?CaseID=";
+    const link_id = case_detail_link.substring(case_detail_base.length);
     return (
       <div id={case_number} className="mb3">
         <div className="cf pv2 br3 br--top shadow-case">
           <div className="fl ph3 pv1">
             <div className="fw7">Case </div>
-            {case_number}
+            <a href={"/api/case_detail_page/" + link_id} target="_blank">{case_number}</a>
           </div>
           <div className="fl ph3 pv1">
             <div className="fw7">Status </div>


### PR DESCRIPTION
Unfortunately, navigating directly to the OECI link even while logged in does not work. Since we already fetch the case detail page while searching, we can just expose that under our own URL.