### PR TITLE
Add support for unknown/missing disposition

### DIFF
--- a/src/backend/expungeservice/charge_creator.py
+++ b/src/backend/expungeservice/charge_creator.py
@@ -18,7 +18,7 @@ class ChargeCreator:
         statute = ChargeCreator._strip_non_alphanumeric_chars(kwargs["statute"])
         section = ChargeCreator._set_section(statute)
         birth_year = kwargs.get("birth_year")
-        disposition = kwargs.get("disposition")
+        disposition = kwargs["disposition"]
         ambiguous_charge_type_with_questions = ChargeClassifier(
             violation_type, name, statute, level, section, birth_year, disposition
         ).classify()

--- a/src/backend/expungeservice/crawler/crawler.py
+++ b/src/backend/expungeservice/crawler/crawler.py
@@ -123,20 +123,20 @@ class Crawler:
     def _build_oeci_charge(charge_id, ambiguous_charge_id, charge_dict, case_parser_data) -> OeciCharge:
         probation_revoked = case_parser_data.probation_revoked
         charge_dict["date"] = datetime.date(datetime.strptime(charge_dict["date"], "%m/%d/%Y"))
-        if case_parser_data.hashed_dispo_data.get(charge_id):
-            disposition = Crawler._build_disposition(case_parser_data, charge_id)
-            return OeciCharge(
-                ambiguous_charge_id, disposition=disposition, probation_revoked=probation_revoked, **charge_dict
-            )
-        else:
-            return OeciCharge(ambiguous_charge_id, disposition=None, probation_revoked=probation_revoked, **charge_dict)
+        disposition = Crawler._build_disposition(case_parser_data, charge_id)
+        return OeciCharge(
+            ambiguous_charge_id, disposition=disposition, probation_revoked=probation_revoked, **charge_dict
+        )
 
     @staticmethod
     def _build_disposition(case_parser_data, charge_id):
-        disposition_data = case_parser_data.hashed_dispo_data[charge_id]
-        date = datetime.date(
-            datetime.strptime(disposition_data.get("date"), "%m/%d/%Y")
-        )  # TODO: Log error if format is not correct
-        ruling = disposition_data.get("ruling")
-        disposition = DispositionCreator.create(date, ruling, "amended" in disposition_data["event"].lower())
+        disposition_data = case_parser_data.hashed_dispo_data.get(charge_id)
+        if disposition_data:
+            date = datetime.date(
+                datetime.strptime(disposition_data.get("date"), "%m/%d/%Y")
+            )  # TODO: Log error if format is not correct
+            ruling = disposition_data.get("ruling")
+            disposition = DispositionCreator.create(date, ruling, "amended" in disposition_data["event"].lower())
+        else:
+            disposition = DispositionCreator.create(datetime.today(), "missing")
         return disposition

--- a/src/backend/expungeservice/generator.py
+++ b/src/backend/expungeservice/generator.py
@@ -43,7 +43,7 @@ def _build_charge_strategy(charge_class: Type[Charge], case: CaseSummary) -> Sea
     return builds(
         charge_class,
         case_number=just(case.case_number),
-        disposition=one_of(none(), disposition),
+        disposition=disposition,
         date=dates(max_value=date(9000, 12, 31)),
         probation_revoked=one_of(none(), dates(max_value=date(9000, 12, 31))),
     )

--- a/src/backend/expungeservice/models/charge_types/felony_class_c.py
+++ b/src/backend/expungeservice/models/charge_types/felony_class_c.py
@@ -20,8 +20,8 @@ Class C felony dismissals are always eligible under 137.225(1)(b)."""
             raise ValueError("Dismissed criminal charges should have been caught by another class.")
         elif self.convicted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.225(5)(b)")
-        elif not self.disposition or self.disposition.status == DispositionStatus.UNRECOGNIZED:
+        elif self.disposition.status in [DispositionStatus.UNKNOWN, DispositionStatus.UNRECOGNIZED]:
             return TypeEligibility(
                 EligibilityStatus.ELIGIBLE,
                 reason="Eligible under 137.225(5)(b) for convictions or under 137.225(1)(b) for dismissals",
-            )
+            )  # TODO: Double check

--- a/src/backend/expungeservice/models/charge_types/marijuana_eligible.py
+++ b/src/backend/expungeservice/models/charge_types/marijuana_eligible.py
@@ -17,7 +17,7 @@ class MarijuanaEligible(Charge):
             raise ValueError("Dismissed criminal charges should have been caught by another class.")
         elif self.convicted():
             return TypeEligibility(EligibilityStatus.ELIGIBLE, reason="Eligible under 137.226")
-        elif not self.disposition or self.disposition.status == DispositionStatus.UNRECOGNIZED:
+        elif self.disposition.status in [DispositionStatus.UNRECOGNIZED, DispositionStatus.UNKNOWN]:
             return TypeEligibility(
                 EligibilityStatus.ELIGIBLE,
                 reason="Always eligible under 137.226 (for convictions) or 137.225(1)(b) (for dismissals)",

--- a/src/backend/expungeservice/models/charge_types/parking_ticket.py
+++ b/src/backend/expungeservice/models/charge_types/parking_ticket.py
@@ -22,7 +22,7 @@ class ParkingTicket(Charge):
             return TypeEligibility(EligibilityStatus.INELIGIBLE, reason="Ineligible under 137.225(7)(a)")
         elif self.dismissed():
             return TypeEligibility(EligibilityStatus.INELIGIBLE, reason="Ineligible by omission from statute")
-        elif not self.disposition or self.disposition.status == DispositionStatus.UNRECOGNIZED:
+        elif self.disposition.status in [DispositionStatus.UNRECOGNIZED, DispositionStatus.UNKNOWN]:
             return TypeEligibility(
                 EligibilityStatus.INELIGIBLE,
                 reason="Always ineligible under 137.225(7)(a) (for convictions) or by omission from statute (for dismissals)",

--- a/src/backend/expungeservice/models/disposition.py
+++ b/src/backend/expungeservice/models/disposition.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime
 from enum import Enum
 
 
@@ -8,6 +8,7 @@ class DispositionStatus(str, Enum):
     DISMISSED = "Dismissed"
     NO_COMPLAINT = "No Complaint"
     DIVERTED = "Diverted"
+    UNKNOWN = "Unknown"
     UNRECOGNIZED = "Unrecognized"
 
 
@@ -20,6 +21,10 @@ class Disposition:
 
 
 class DispositionCreator:
+    @staticmethod
+    def empty():
+        return Disposition(datetime.today(), "missing", DispositionStatus.UNKNOWN)
+
     @staticmethod
     def create(date: date, ruling: str, amended: bool = False) -> Disposition:
         status = DispositionCreator.__build_status(ruling)
@@ -52,18 +57,16 @@ class DispositionCreator:
             "removed from charging instrument",
             "plea lesser charge",
         ]
-
+        missing_rulings = ["missing", "conditional discharge", "deferred"]
         if any([rule in ruling for rule in conviction_rulings]):
             return DispositionStatus.CONVICTED
-
         elif any([rule in ruling for rule in dismissal_rulings]):
             return DispositionStatus.DISMISSED
-
         elif "diverted" in ruling:
             return DispositionStatus.DIVERTED
-
         elif "no complaint" in ruling:
             return DispositionStatus.NO_COMPLAINT
-
+        elif any([rule == ruling for rule in missing_rulings]):
+            return DispositionStatus.UNKNOWN
         else:
             return DispositionStatus.UNRECOGNIZED

--- a/src/backend/expungeservice/record_creator.py
+++ b/src/backend/expungeservice/record_creator.py
@@ -256,7 +256,7 @@ class RecordCreator:
         unknown_dispositions = []
         for case in cases:
             for charge in case.charges:
-                if not charge.disposition or charge.disposition == DispositionStatus.UNRECOGNIZED:
+                if charge.disposition.status in [DispositionStatus.UNRECOGNIZED, DispositionStatus.UNKNOWN]:
                     unknown_dispositions.append(charge.ambiguous_charge_id)
         return unknown_dispositions
 

--- a/src/backend/tests/crawler/test_crawler.py
+++ b/src/backend/tests/crawler/test_crawler.py
@@ -1,6 +1,8 @@
 import unittest
 
 from datetime import datetime
+
+from expungeservice.models.disposition import DispositionStatus
 from tests.factories.crawler_factory import CrawlerFactory
 from tests.fixtures.case_details import CaseDetails
 from tests.fixtures.john_doe import JohnDoe
@@ -34,12 +36,12 @@ def test_search_function():
     assert record.cases[1].charges[0].disposition.ruling == "Dismissed"
     assert record.cases[1].charges[0].disposition.date == datetime.date(datetime.strptime("04/30/1992", "%m/%d/%Y"))
 
-    assert record.cases[0].charges[0].disposition is None
-    assert record.cases[0].charges[0].disposition is None
-    assert record.cases[0].charges[1].disposition is None
-    assert record.cases[0].charges[1].disposition is None
-    assert record.cases[0].charges[2].disposition is None
-    assert record.cases[0].charges[2].disposition is None
+    assert record.cases[0].charges[0].disposition.status == DispositionStatus.UNKNOWN
+    assert record.cases[0].charges[0].disposition.status == DispositionStatus.UNKNOWN
+    assert record.cases[0].charges[1].disposition.status == DispositionStatus.UNKNOWN
+    assert record.cases[0].charges[1].disposition.status == DispositionStatus.UNKNOWN
+    assert record.cases[0].charges[2].disposition.status == DispositionStatus.UNKNOWN
+    assert record.cases[0].charges[2].disposition.status == DispositionStatus.UNKNOWN
 
 
 def test_a_blank_search_response():

--- a/src/backend/tests/factories/charge_factory.py
+++ b/src/backend/tests/factories/charge_factory.py
@@ -3,7 +3,7 @@ from datetime import date as date_class
 from expungeservice.models.ambiguous import AmbiguousCharge
 from expungeservice.models.charge import Charge
 from expungeservice.charge_creator import ChargeCreator
-from expungeservice.models.disposition import Disposition, DispositionCreator
+from expungeservice.models.disposition import Disposition, DispositionCreator, DispositionStatus
 
 
 class ChargeFactory:
@@ -17,7 +17,7 @@ class ChargeFactory:
         statute="164.125",
         level="Misdemeanor Class A",
         date: date_class = None,
-        disposition: Disposition = None,
+        disposition: Disposition = DispositionCreator.empty(),
         violation_type="Offense Misdemeanor",
     ) -> Charge:
         charges = cls._build_ambiguous_charge(case_number, date, disposition, level, name, statute, violation_type)
@@ -32,7 +32,7 @@ class ChargeFactory:
         statute="164.125",
         level="Misdemeanor Class A",
         date: date_class = None,
-        disposition: Disposition = None,
+        disposition: Disposition = DispositionCreator.empty(),
         violation_type="Offense Misdemeanor",
     ) -> AmbiguousCharge:
         return cls._build_ambiguous_charge(case_number, date, disposition, level, name, statute, violation_type)
@@ -40,7 +40,7 @@ class ChargeFactory:
     @classmethod
     def _build_ambiguous_charge(cls, case_number, date, disposition, level, name, statute, violation_type):
         cls.charge_count += 1
-        if disposition and not date:
+        if disposition.status != DispositionStatus.UNKNOWN and not date:
             updated_date = disposition.date
         elif date:
             updated_date = date

--- a/src/backend/tests/models/charge_types/test_felony_class_c.py
+++ b/src/backend/tests/models/charge_types/test_felony_class_c.py
@@ -1,5 +1,6 @@
 from expungeservice.models.charge_types.dismissed_charge import DismissedCharge
 from expungeservice.models.charge_types.felony_class_c import FelonyClassC
+from expungeservice.models.disposition import DispositionCreator
 from expungeservice.models.expungement_result import EligibilityStatus
 
 from tests.factories.charge_factory import ChargeFactory
@@ -28,7 +29,10 @@ def test_felony_c_dismissal():
 
 def test_felony_c_no_disposition():
     charge = ChargeFactory.create(
-        name="Theft in the first degree", statute="164.055", level="Felony Class C", disposition=None
+        name="Theft in the first degree",
+        statute="164.055",
+        level="Felony Class C",
+        disposition=DispositionCreator.empty(),
     )
 
     assert isinstance(charge, FelonyClassC)

--- a/src/backend/tests/models/charge_types/test_juvenile_charge.py
+++ b/src/backend/tests/models/charge_types/test_juvenile_charge.py
@@ -1,3 +1,4 @@
+from expungeservice.models.disposition import DispositionCreator
 from expungeservice.models.expungement_result import EligibilityStatus
 from expungeservice.models.charge_types.juvenile_charge import JuvenileCharge
 
@@ -31,7 +32,7 @@ def test_juvenile_charge_convicted():
 def test_juvenile_charge_no_disposition():
     case = CaseSummaryFactory.create(type_status=["Juvenile Delinquency: Misdemeanor", "Closed"])
     juvenile_charge = ChargeFactory.create(
-        case_number=case.case_number, disposition=None, violation_type=case.violation_type
+        case_number=case.case_number, disposition=DispositionCreator.empty(), violation_type=case.violation_type
     )
 
     assert isinstance(juvenile_charge, JuvenileCharge)

--- a/src/backend/tests/models/charge_types/test_manufacture_delivery.py
+++ b/src/backend/tests/models/charge_types/test_manufacture_delivery.py
@@ -1,3 +1,4 @@
+from expungeservice.models.disposition import DispositionCreator
 from expungeservice.models.expungement_result import EligibilityStatus
 from expungeservice.record_merger import RecordMerger
 from tests.factories.charge_factory import ChargeFactory
@@ -16,7 +17,7 @@ def test_manufacture_delivery_dismissed():
 
 def test_manufacture_delivery_missing_disposition():
     charges = ChargeFactory.create_ambiguous_charge(
-        name="Manufacture/Delivery", statute="4759922b", level="Felony Class A", disposition=None
+        name="Manufacture/Delivery", statute="4759922b", level="Felony Class A", disposition=DispositionCreator.empty()
     )
     type_eligibility = RecordMerger.merge_type_eligibilities(charges)
 

--- a/src/backend/tests/models/charge_types/test_marijuana_eligible.py
+++ b/src/backend/tests/models/charge_types/test_marijuana_eligible.py
@@ -1,4 +1,5 @@
 from expungeservice.models.charge_types.dismissed_charge import DismissedCharge
+from expungeservice.models.disposition import DispositionCreator
 from expungeservice.models.expungement_result import EligibilityStatus
 from expungeservice.models.charge_types.marijuana_eligible import MarijuanaEligible
 from tests.factories.charge_factory import ChargeFactory
@@ -32,7 +33,10 @@ def test_marijuana_eligible_convicted():
 
 def test_marijuana_eligible_missing_dispo():
     marijuana_eligible_charge = ChargeFactory.create(
-        name="Delivery of Marijuana to Minor", statute="4758604A", level="Felony Class A", disposition=None
+        name="Delivery of Marijuana to Minor",
+        statute="4758604A",
+        level="Felony Class A",
+        disposition=DispositionCreator.empty(),
     )
 
     assert isinstance(marijuana_eligible_charge, MarijuanaEligible)

--- a/src/backend/tests/models/charge_types/test_midemeanor.py
+++ b/src/backend/tests/models/charge_types/test_midemeanor.py
@@ -1,3 +1,4 @@
+from expungeservice.models.disposition import DispositionCreator
 from expungeservice.models.expungement_result import EligibilityStatus
 from expungeservice.models.charge_types.misdemeanor import Misdemeanor
 from tests.factories.charge_factory import ChargeFactory
@@ -6,7 +7,10 @@ from tests.models.test_charge import Dispositions
 
 def test_misdemeanor_missing_disposition():
     misdemeanor_charge = ChargeFactory.create(
-        name="Criminal Trespass in the Second Degree", statute="164.245", level="Misdemeanor Class C", disposition=None
+        name="Criminal Trespass in the Second Degree",
+        statute="164.245",
+        level="Misdemeanor Class C",
+        disposition=DispositionCreator.empty(),
     )
 
     assert isinstance(misdemeanor_charge, Misdemeanor)

--- a/src/backend/tests/models/charge_types/test_parking_ticket.py
+++ b/src/backend/tests/models/charge_types/test_parking_ticket.py
@@ -1,5 +1,6 @@
 from datetime import date as date_class
 
+from expungeservice.models.disposition import DispositionCreator
 from expungeservice.models.expungement_result import EligibilityStatus
 from expungeservice.models.charge_types.parking_ticket import ParkingTicket
 
@@ -52,7 +53,7 @@ def test_parking_ticket_no_disposition():
         statute="109",
         level="Violation Unclassified",
         date=date_class(1901, 1, 1),
-        disposition=None,
+        disposition=DispositionCreator.empty(),
         violation_type=case.violation_type,
     )
 

--- a/src/backend/tests/models/charge_types/test_traffic_offenses.py
+++ b/src/backend/tests/models/charge_types/test_traffic_offenses.py
@@ -9,6 +9,7 @@ Rules for 800 Level charges are as follows:
 800 level convictions of any kind are not type eligible
 """
 from expungeservice.models.charge_types.dismissed_charge import DismissedCharge
+from expungeservice.models.disposition import DispositionCreator
 from expungeservice.models.expungement_result import EligibilityStatus
 from expungeservice.models.charge_types.traffic_violation import TrafficViolation
 from expungeservice.models.charge_types.duii import Duii, DivertedDuii
@@ -71,7 +72,9 @@ def test_dismissed_infraction_is_not_type_eligible():
 
 
 def test_no_dispo_violation_is_not_type_eligible():
-    charge = ChargeFactory.create(statute="801.000", level="Class C Traffic Violation", disposition=None)
+    charge = ChargeFactory.create(
+        statute="801.000", level="Class C Traffic Violation", disposition=DispositionCreator.empty()
+    )
 
     assert charge.type_eligibility.status is EligibilityStatus.INELIGIBLE
     assert (

--- a/src/backend/tests/models/charge_types/test_unclassified.py
+++ b/src/backend/tests/models/charge_types/test_unclassified.py
@@ -1,4 +1,5 @@
 from expungeservice.models.charge_types.unclassified_charge import UnclassifiedCharge
+from expungeservice.models.disposition import DispositionCreator
 from expungeservice.models.expungement_result import EligibilityStatus
 from tests.factories.charge_factory import ChargeFactory
 from tests.models.test_charge import Dispositions
@@ -52,7 +53,7 @@ def test_convicted_disposition():
 
 def test_no_disposition():
     unclassified_dispo_none = ChargeFactory.create(
-        name="Unknown", statute="333.333", level="Felony Class F", disposition=None,
+        name="Unknown", statute="333.333", level="Felony Class F", disposition=DispositionCreator.empty(),
     )
 
     assert isinstance(unclassified_dispo_none, UnclassifiedCharge)

--- a/src/backend/tests/models/test_disposition_status.py
+++ b/src/backend/tests/models/test_disposition_status.py
@@ -36,7 +36,7 @@ def test_all_disposition_statuses_are_either_convicted_or_dismissed():
         # which happens to always be a valid string for that dispo status.
         charge = replace(pre_charge, disposition=DispositionCreator.create(today, status.value))
 
-        if status == DispositionStatus.UNRECOGNIZED:
+        if status in [DispositionStatus.UNRECOGNIZED, DispositionStatus.UNKNOWN]:
             assert not charge.convicted()
             assert not charge.dismissed()
         else:

--- a/src/backend/tests/test_edit_results.py
+++ b/src/backend/tests/test_edit_results.py
@@ -5,7 +5,7 @@ from expungeservice.models.case import OeciCase, CaseSummary
 from expungeservice.models.charge import OeciCharge
 from expungeservice.models.charge_types.misdemeanor import Misdemeanor
 from expungeservice.models.record import Record
-from expungeservice.models.disposition import Disposition, DispositionStatus
+from expungeservice.models.disposition import Disposition, DispositionStatus, DispositionCreator
 from expungeservice.record_creator import RecordCreator
 
 
@@ -40,7 +40,7 @@ case_1 = OeciCase(
             statute="200.000",
             level="Felony Class C",
             date=date(2001, 1, 1),
-            disposition=None,
+            disposition=DispositionCreator.empty(),
             probation_revoked=None,
         ),
     ),
@@ -76,7 +76,7 @@ case_2 = OeciCase(
             statute="200.000",
             level="Violation",
             date=date(2001, 1, 1),
-            disposition=None,
+            disposition=DispositionCreator.empty(),
             probation_revoked=None,
         ),
     ),
@@ -97,7 +97,7 @@ def test_no_op():
     )
     assert len(record.cases) == 2
     assert len(record.cases[0].charges) == 2
-    assert record.cases[0].charges[1].disposition == None
+    assert record.cases[0].charges[1].disposition.status == DispositionStatus.UNKNOWN
 
 
 def test_edit_some_fields_on_case():

--- a/src/frontend/src/components/RecordSearch/Record/Charge.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Charge.tsx
@@ -26,18 +26,16 @@ export default class Charge extends React.Component<Props> {
 
     const dispositionEvent = (disposition: any, date: any) => {
       let dispositionEvent;
-      if (disposition === null) {
+      dispositionEvent = disposition.status;
+      if (disposition.status === "Convicted") {
+        dispositionEvent += " - " + disposition.date;
+      } else if (disposition.status === "Unrecognized") {
+        dispositionEvent += " (\"" + disposition.ruling + "\")";
+      } else if (disposition.status === "Unknown") {
         dispositionEvent = "Unknown";
-      }  else {
-        dispositionEvent = disposition.status;
-        if (disposition.status === "Convicted") {
-          dispositionEvent += " - " + disposition.date;
-        } else if (disposition.status === "Unrecognized") {
-          dispositionEvent += " (\"" + disposition.ruling + "\")";
-        }
-        if (disposition.amended) {
-          dispositionEvent += " (Amended)"
-        }
+      }
+      if (disposition.amended) {
+        dispositionEvent += " (Amended)"
       }
       return dispositionEvent;
     };

--- a/src/frontend/src/components/RecordSearch/Record/DispositionQuestion.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/DispositionQuestion.tsx
@@ -32,7 +32,7 @@ class DispositionQuestion extends React.Component<Props, State> {
 
   componentDidMount() {
     this.setState({
-      status: (this.props.disposition ? this.props.disposition.status : "Unknown") ,
+      status: this.props.disposition.status,
       conviction_date: (this.props.disposition ? this.props.disposition.date : ""),
       }
     )

--- a/src/frontend/src/components/RecordSearch/Record/types.ts
+++ b/src/frontend/src/components/RecordSearch/Record/types.ts
@@ -6,7 +6,7 @@ export interface ChargeData {
   name: string;
   type_name: string;
   date: string;
-  disposition?: {
+  disposition: {
     ruling: string;
     date: string;
   };


### PR DESCRIPTION
Relative to https://github.com/codeforpdx/recordexpungPDX/pull/1160

OECI charges will no longer have an optional Disposition. The previous value of None will become a DispositionStatus.UNKNOWN with a date of today as the disposition is unknown/missing/deferred as of today. This interpretation fits in nicely with how some existing charges have dispositions of "conditional discharge" or "deferred", which both mean that the disposition is missing as of today and will be input in the future. In any case, the disposition date for a DispositionStatus of UNKNOWN is never used.