### PR TITLE
Sync charge summary panel contents with details below

### DIFF
--- a/src/backend/expungeservice/models/expungement_result.py
+++ b/src/backend/expungeservice/models/expungement_result.py
@@ -17,6 +17,7 @@ class ChargeEligibilityStatus(str, Enum):
     WILL_BE_ELIGIBLE = "Will be eligible"
     POSSIBLY_WILL_BE_ELIGIBLE = "Possibly will be eligible"
     INELIGIBLE = "Ineligible"
+    NEEDS_MORE_ANALYSIS = "Needs more analysis"
 
 
 @dataclass(frozen=True)

--- a/src/backend/expungeservice/models/expungement_result.py
+++ b/src/backend/expungeservice/models/expungement_result.py
@@ -6,18 +6,18 @@ from typing import Optional
 
 class EligibilityStatus(str, Enum):
     ELIGIBLE = "Eligible"
-    NEEDS_MORE_ANALYSIS = "Needs more analysis"
+    NEEDS_MORE_ANALYSIS = "Needs More Analysis"
     INELIGIBLE = "Ineligible"
 
 
 class ChargeEligibilityStatus(str, Enum):
     UNKNOWN = "Unknown"
-    ELIGIBLE_NOW = "Eligible now"
-    POSSIBLY_ELIGIBILE = "Possibly eligible"
-    WILL_BE_ELIGIBLE = "Will be eligible"
-    POSSIBLY_WILL_BE_ELIGIBLE = "Possibly will be eligible"
+    ELIGIBLE_NOW = "Eligible Now"
+    POSSIBLY_ELIGIBILE = "Possibly Eligible"
+    WILL_BE_ELIGIBLE = "Will Be Eligible"
+    POSSIBLY_WILL_BE_ELIGIBLE = "Possibly Will Be Eligible"
     INELIGIBLE = "Ineligible"
-    NEEDS_MORE_ANALYSIS = "Needs more analysis"
+    NEEDS_MORE_ANALYSIS = "Needs More Analysis"
 
 
 @dataclass(frozen=True)

--- a/src/backend/expungeservice/models/record_summary.py
+++ b/src/backend/expungeservice/models/record_summary.py
@@ -15,7 +15,7 @@ class RecordSummary:
     record: Record
     questions: Dict[str, QuestionSummary]
     total_charges: int
-    eligible_charges_by_date: List[Tuple[str, List[Tuple[str, str]]]]
+    eligible_charges_by_date: Dict[str, List[Tuple[str, str]]]  # TODO: Change to OrderedDict in Python 3.7.2+
     county_balances: List[CountyBalance]
 
     @property

--- a/src/backend/expungeservice/models/record_summary.py
+++ b/src/backend/expungeservice/models/record_summary.py
@@ -15,7 +15,6 @@ class RecordSummary:
     record: Record
     questions: Dict[str, QuestionSummary]
     total_charges: int
-    cases_sorted: Dict[str, List[str]]
     eligible_charges_by_date: List[Tuple[str, List[Tuple[str, str]]]]
     county_balances: List[CountyBalance]
 
@@ -25,4 +24,4 @@ class RecordSummary:
 
     @property
     def total_cases(self):
-        return sum([len(cases) for cases in self.cases_sorted.values()])
+        return len(self.record.cases)

--- a/src/backend/expungeservice/pdf/markdown_serializer.py
+++ b/src/backend/expungeservice/pdf/markdown_serializer.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Dict
 
 
@@ -40,43 +41,62 @@ class MarkdownSerializer:
 
     @staticmethod
     def _gen_eligible_charges_block(record):
-        eligible_charges = [charge_tuple[1] for charge_tuple in record["summary"]["eligible_charges_by_date"][0][1]]
+        eligible_charges = record["summary"]["eligible_charges_by_date"].get("Eligible now")
         if eligible_charges:
-            listed_charges = " - " + " \n - ".join(eligible_charges)
+            charges = [charge_tuple[1] for charge_tuple in eligible_charges]
+            listed_charges = " - " + " \n - ".join(charges)
         else:
             listed_charges = "This client is not currently eligible to expunge any charges."
         return "## Charges Eligible Now  \n" + listed_charges + "  \n"
 
     @staticmethod
     def _gen_ineligible_charges_block(record):
-        ineligible_charges = [charge_tuple[1] for charge_tuple in record["summary"]["eligible_charges_by_date"][-2][1]]
+        ineligible_charges = record["summary"]["eligible_charges_by_date"].get("Ineligible")
         if ineligible_charges:
-            ineligible_charges_string = " - " + "  \n - ".join(ineligible_charges)
-            return f"## Ineligible Charges  \nThese convictions are not eligible for expungement at any time under the current law.  \n\n{ineligible_charges_string}  \n"
+            charges = [charge_tuple[1] for charge_tuple in ineligible_charges]
+            charges_string = " - " + "  \n - ".join(charges)
+            return f"## Ineligible Charges  \nThese convictions are not eligible for expungement at any time under the current law.  \n\n{charges_string}  \n"
         else:
             return ""
 
     @staticmethod
     def _gen_future_eligible_block(record):
-        future_eligible_charges = record["summary"]["eligible_charges_by_date"][1:-2]
-        text_block = "## Future Eligible Charges  \nThe following charges (dismissed and convicted) are eligible at the designated dates.  \n"
+        eligible_charges_by_date = record["summary"]["eligible_charges_by_date"]
+        future_eligible_charges = [
+            (key, eligible_charges_by_date[key])
+            for key in eligible_charges_by_date.keys()
+            if key not in ["Eligible now", "Ineligible", "Needs more analysis"]
+        ]
         if future_eligible_charges:
-            for section in future_eligible_charges:
-                charges = [charge_tuple[1] for charge_tuple in section[1]]
+            text_block = "## Future Eligible Charges  \nThe following charges (dismissed and convicted) are eligible at the designated dates.  \n"
+            for label, section in sorted(future_eligible_charges, key=MarkdownSerializer._sort_future_eligible):
+                charges = [charge_tuple[1] for charge_tuple in section]
                 listed_charges = " - " + "  \n - ".join(charges)
-                text_block += "### Eligible " + section[0] + "  \n" + listed_charges + "  \n\n"
+                text_block += "### " + label + "  \n" + listed_charges + "  \n\n"
             return text_block
         else:
             return ""
 
     @staticmethod
+    def _sort_future_eligible(group):
+        label = group[0]
+        split = label.split(" ")
+        for date_parts in zip(split, split[1:], split[2:]):
+            date_string = " ".join(date_parts)
+            try:
+                date = datetime.strptime(date_string, "%b %d, %Y")
+                return date.isoformat()
+            except ValueError:
+                pass
+        return label
+
+    @staticmethod
     def _gen_needs_more_analysis_block(record):
-        needs_more_analysis_charges = [
-            charge_tuple[1] for charge_tuple in record["summary"]["eligible_charges_by_date"][-1][1]
-        ]
-        text_block = "## Charges Needing More Analysis  \nAdditionally, this client has charges for which the online records do not contain enough information to determine eligibility. If the client is curious about the eligibility of these charges, please have them contact michael@qiu-qiulaw.com.  \n\n"
+        needs_more_analysis_charges = record["summary"]["eligible_charges_by_date"].get("Needs more analysis")
         if needs_more_analysis_charges:
-            listed_charges = " - " + "  \n - ".join(needs_more_analysis_charges)
+            charges = [charge_tuple[1] for charge_tuple in needs_more_analysis_charges]
+            text_block = "## Charges Needing More Analysis  \nAdditionally, this client has charges for which the online records do not contain enough information to determine eligibility. If the client is curious about the eligibility of these charges, please have them contact michael@qiu-qiulaw.com.  \n\n"
+            listed_charges = " - " + "  \n - ".join(charges)
             text_block += listed_charges + "  \n\n"
             return text_block
         else:

--- a/src/backend/expungeservice/pdf/markdown_serializer.py
+++ b/src/backend/expungeservice/pdf/markdown_serializer.py
@@ -41,7 +41,7 @@ class MarkdownSerializer:
 
     @staticmethod
     def _gen_eligible_charges_block(record):
-        eligible_charges = record["summary"]["eligible_charges_by_date"].get("Eligible now")
+        eligible_charges = record["summary"]["eligible_charges_by_date"].get("Eligible Now")
         if eligible_charges:
             charges = [charge_tuple[1] for charge_tuple in eligible_charges]
             listed_charges = " - " + " \n - ".join(charges)
@@ -65,7 +65,7 @@ class MarkdownSerializer:
         future_eligible_charges = [
             (key, eligible_charges_by_date[key])
             for key in eligible_charges_by_date.keys()
-            if key not in ["Eligible now", "Ineligible", "Needs more analysis"]
+            if key not in ["Eligible Now", "Ineligible", "Needs More Analysis"]
         ]
         if future_eligible_charges:
             text_block = "## Future Eligible Charges  \nThe following charges (dismissed and convicted) are eligible at the designated dates.  \n"
@@ -92,7 +92,7 @@ class MarkdownSerializer:
 
     @staticmethod
     def _gen_needs_more_analysis_block(record):
-        needs_more_analysis_charges = record["summary"]["eligible_charges_by_date"].get("Needs more analysis")
+        needs_more_analysis_charges = record["summary"]["eligible_charges_by_date"].get("Needs More Analysis")
         if needs_more_analysis_charges:
             charges = [charge_tuple[1] for charge_tuple in needs_more_analysis_charges]
             text_block = "## Charges Needing More Analysis  \nAdditionally, this client has charges for which the online records do not contain enough information to determine eligibility. If the client is curious about the eligibility of these charges, please have them contact michael@qiu-qiulaw.com.  \n\n"

--- a/src/backend/expungeservice/record_creator.py
+++ b/src/backend/expungeservice/record_creator.py
@@ -45,7 +45,8 @@ class RecordCreator:
             if overflow_error:
                 return Record((), tuple(overflow_error)), {}
             else:
-                record = RecordCreator.analyze_ambiguous_record(ambiguous_record)
+                charge_ids_with_question = [question.ambiguous_charge_id for question in questions]
+                record = RecordCreator._analyze_ambiguous_record(ambiguous_record, charge_ids_with_question)
                 questions_as_dict = dict(list(map(lambda q: (q.ambiguous_charge_id, q), questions)))
                 return record, questions_as_dict
 
@@ -105,14 +106,16 @@ class RecordCreator:
             return ambiguous_record, []
 
     @staticmethod
-    def analyze_ambiguous_record(ambiguous_record: AmbiguousRecord):
+    def _analyze_ambiguous_record(ambiguous_record: AmbiguousRecord, charge_ids_with_question: List[str]):
         charge_id_to_time_eligibilities = []
         ambiguous_record_with_errors = []
         for record in ambiguous_record:
             charge_id_to_time_eligibility = Expunger.run(record)
             charge_id_to_time_eligibilities.append(charge_id_to_time_eligibility)
             ambiguous_record_with_errors.append(record)
-        record = RecordMerger.merge(ambiguous_record_with_errors, charge_id_to_time_eligibilities)
+        record = RecordMerger.merge(
+            ambiguous_record_with_errors, charge_id_to_time_eligibilities, charge_ids_with_question
+        )
         sorted_record = RecordCreator.sort_record(record)
         return replace(sorted_record, errors=tuple(ErrorChecker.check(sorted_record)))
 

--- a/src/backend/expungeservice/record_summarizer.py
+++ b/src/backend/expungeservice/record_summarizer.py
@@ -24,7 +24,11 @@ class RecordSummarizer:
         def group(charge: Charge):
             return charge.expungement_result.charge_eligibility.label  # type: ignore
 
-        visible_charges = [charge for charge in record.charges if not charge.charge_type.hidden_in_record_summary()]
+        SHOW_ALL_CHARGES_THRESHOLD = 20
+        if len(record.charges) <= SHOW_ALL_CHARGES_THRESHOLD:
+            visible_charges = record.charges
+        else:
+            visible_charges = [charge for charge in record.charges if not charge.charge_type.hidden_in_record_summary()]
         eligible_charges_by_date: Dict[str, List[Tuple[str, str]]] = {}
         for label, charges in groupby(sorted(visible_charges, key=group), key=group):
             charges_tuples = [(charge.ambiguous_charge_id, charge.to_one_line()) for charge in charges]

--- a/src/backend/expungeservice/record_summarizer.py
+++ b/src/backend/expungeservice/record_summarizer.py
@@ -1,22 +1,13 @@
-from expungeservice.models.expungement_result import ChargeEligibilityStatus
+from collections import OrderedDict
+from itertools import groupby
+
+from expungeservice.models.charge import Charge
 from expungeservice.models.record import QuestionSummary
 from expungeservice.models.record_summary import RecordSummary, CountyBalance
 from typing import Dict, List, Tuple
-from expungeservice.util import DateWithFuture as date
 
 
 class RecordSummarizer:
-    @staticmethod
-    def filter_charge_names_by_eligibility(charges, eligibility):
-        return [
-            (c.ambiguous_charge_id, c.to_one_line())
-            for c in charges
-            if (
-                c.expungement_result.charge_eligibility.status == eligibility
-                and not c.charge_type.hidden_in_record_summary()
-            )
-        ]
-
     @staticmethod
     def summarize(record, questions: Dict[str, QuestionSummary]) -> RecordSummary:
         county_balances: Dict[str, float] = {}
@@ -29,38 +20,15 @@ class RecordSummarizer:
         for county, balance in county_balances.items():
             county_balances_list.append(CountyBalance(county, round(balance, 2)))
         total_charges = len(record.charges)
-        eligible_charges_now = RecordSummarizer.filter_charge_names_by_eligibility(
-            record.charges, ChargeEligibilityStatus.ELIGIBLE_NOW
-        )
-        eligible_charges_by_date: List[Tuple[str, List[Tuple[str, str]]]] = [("Eligible now", eligible_charges_now)]
-        will_be_eligible_charges: Dict[date, List[Tuple[str, str]]] = {}
-        needs_more_analysis_charges: List[Tuple[str, str]] = []  # TODO: This list may be incomplete
-        for charge in record.charges:
-            charge_string = charge.to_one_line()
-            if charge.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.WILL_BE_ELIGIBLE:
-                if charge.expungement_result.time_eligibility.unique_date:
-                    date_eligible = charge.expungement_result.time_eligibility.date_will_be_eligible
-                    if will_be_eligible_charges.get(date_eligible):
-                        will_be_eligible_charges[date_eligible].append((charge.ambiguous_charge_id, charge_string))
-                    else:
-                        will_be_eligible_charges[date_eligible] = [(charge.ambiguous_charge_id, charge_string)]
-                else:
-                    needs_more_analysis_charges.append((charge.ambiguous_charge_id, charge_string))
-            elif charge.expungement_result.charge_eligibility.status in [
-                ChargeEligibilityStatus.POSSIBLY_ELIGIBILE,
-                ChargeEligibilityStatus.POSSIBLY_WILL_BE_ELIGIBLE,
-                ChargeEligibilityStatus.UNKNOWN,
-            ]:
-                needs_more_analysis_charges.append((charge.ambiguous_charge_id, charge_string))
-        for date_value in sorted(will_be_eligible_charges):
-            eligible_charges_by_date.append(
-                ("Eligible " + date_value.strftime("%b %-d, %Y"), will_be_eligible_charges[date_value])
-            )
-        ineligible_charges = RecordSummarizer.filter_charge_names_by_eligibility(
-            record.charges, ChargeEligibilityStatus.INELIGIBLE
-        )
-        eligible_charges_by_date.append(("Ineligible", ineligible_charges))
-        eligible_charges_by_date.append(("Need more analysis", needs_more_analysis_charges))
+
+        def group(charge: Charge):
+            return charge.expungement_result.charge_eligibility.label  # type: ignore
+
+        visible_charges = [charge for charge in record.charges if not charge.charge_type.hidden_in_record_summary()]
+        eligible_charges_by_date: Dict[str, List[Tuple[str, str]]] = {}
+        for label, charges in groupby(sorted(visible_charges, key=group), key=group):
+            charges_tuples = [(charge.ambiguous_charge_id, charge.to_one_line()) for charge in charges]
+            eligible_charges_by_date[label] = charges_tuples
 
         return RecordSummary(
             record=record,

--- a/src/backend/expungeservice/serializer.py
+++ b/src/backend/expungeservice/serializer.py
@@ -14,7 +14,6 @@ class ExpungeModelEncoder(flask.json.JSONEncoder):
             **{
                 "summary": {
                     "total_charges": record_summary.total_charges,
-                    "cases_sorted": record_summary.cases_sorted,
                     "eligible_charges_by_date": record_summary.eligible_charges_by_date,
                     "county_balances": record_summary.county_balances,
                     "total_balance_due": record_summary.total_balance_due,

--- a/src/backend/expungeservice/util.py
+++ b/src/backend/expungeservice/util.py
@@ -89,7 +89,7 @@ class DateWithFuture:
             years = f"{self.relative.years} year(s) " if self.relative.years else ""
             months = f"{self.relative.months} month(s) " if self.relative.months else ""
             days = f"{self.relative.days - 1} day(s) " if self.relative.days - 1 > 0 else ""
-            return years + months + days + " from conviction of open case(s)"
+            return years + months + days + " From Conviction Of Open Charge"
         else:
             return self.date.strftime(fmt)
 

--- a/src/backend/tests/models/test_expungement_result.py
+++ b/src/backend/tests/models/test_expungement_result.py
@@ -15,7 +15,7 @@ def test_eligible():
     charge_eligibility = RecordMerger.compute_charge_eligibility(type_eligibility, [time_eligibility])
 
     assert charge_eligibility.status == ChargeEligibilityStatus.ELIGIBLE_NOW
-    assert charge_eligibility.label == "Eligible now"
+    assert charge_eligibility.label == "Eligible Now"
 
 
 def test_will_be_eligible():
@@ -100,7 +100,7 @@ def test_type_eligible_but_time_eligibility_missing():
     charge_eligibility = RecordMerger.compute_charge_eligibility(type_eligibility, [])
 
     assert charge_eligibility.status == ChargeEligibilityStatus.UNKNOWN
-    assert charge_eligibility.label == "Possibly eligible but time analysis is missing"
+    assert charge_eligibility.label == "Possibly Eligible But Time Analysis Is Missing"
 
 
 def test_possibly_type_eligible_but_time_eligibility_missing():
@@ -108,4 +108,4 @@ def test_possibly_type_eligible_but_time_eligibility_missing():
     charge_eligibility = RecordMerger.compute_charge_eligibility(type_eligibility, [])
 
     assert charge_eligibility.status == ChargeEligibilityStatus.UNKNOWN
-    assert charge_eligibility.label == "Possibly eligible but time analysis is missing"
+    assert charge_eligibility.label == "Possibly Eligible But Time Analysis Is Missing"

--- a/src/backend/tests/models/test_expungement_result.py
+++ b/src/backend/tests/models/test_expungement_result.py
@@ -15,7 +15,7 @@ def test_eligible():
     charge_eligibility = RecordMerger.compute_charge_eligibility(type_eligibility, [time_eligibility])
 
     assert charge_eligibility.status == ChargeEligibilityStatus.ELIGIBLE_NOW
-    assert charge_eligibility.label == "Eligible"
+    assert charge_eligibility.label == "Eligible now"
 
 
 def test_will_be_eligible():
@@ -38,7 +38,7 @@ def test_possibly_eligible():
     )
 
     assert charge_eligibility.status == ChargeEligibilityStatus.POSSIBLY_ELIGIBILE
-    assert charge_eligibility.label == "Possibly Eligible Now (review)"
+    assert charge_eligibility.label == "Possibly Eligible Now"
 
 
 def test_possibly_will_be_eligible():
@@ -52,7 +52,7 @@ def test_possibly_will_be_eligible():
     )
 
     assert charge_eligibility.status == ChargeEligibilityStatus.POSSIBLY_WILL_BE_ELIGIBLE
-    assert charge_eligibility.label == f"Possibly Eligible {Time.ONE_YEARS_FROM_NOW.strftime('%b %-d, %Y')} (review)"
+    assert charge_eligibility.label == f"Possibly Eligible {Time.ONE_YEARS_FROM_NOW.strftime('%b %-d, %Y')}"
 
 
 def test_multiple_will_be_eligible():

--- a/src/backend/tests/models/test_record_summarizer.py
+++ b/src/backend/tests/models/test_record_summarizer.py
@@ -98,54 +98,41 @@ def test_record_summarizer_multiple_cases():
     )
     expunger_result = Expunger.run(record)
 
-    merged_record = RecordMerger.merge([record], [expunger_result])
+    merged_record = RecordMerger.merge([record], [expunger_result], [])
     record_summary = RecordSummarizer.summarize(merged_record, {})
 
     assert record_summary.total_balance_due == 1000.00
     assert record_summary.total_cases == 5
     assert record_summary.total_charges == 6
-    assert record_summary.eligible_charges_by_date == [
-        (
-            "Eligible now",
-            [
-                (
-                    case_all_eligible.charges[0].ambiguous_charge_id,
-                    "Theft of dignity (CONVICTED) - Arrested Jan 1, 2010",
-                ),
-                (
-                    case_partially_eligible.charges[0].ambiguous_charge_id,
-                    "Theft of services (CONVICTED) - Arrested Jan 1, 2010",
-                ),
-            ],
-        ),
-        (
-            "Eligible Jan 1, 2030",
-            [
-                (
-                    case_possibly_eligible.charges[0].ambiguous_charge_id,
-                    "Theft of services (CONVICTED) - Arrested Jan 1, 2010",
-                )
-            ],
-        ),
-        (
-            "Ineligible",
-            [
-                (
-                    case_partially_eligible.charges[1].ambiguous_charge_id,
-                    "Theft of services (CONVICTED) - Arrested Jan 1, 2010",
-                ),
-                (
-                    case_all_ineligible.charges[0].ambiguous_charge_id,
-                    "Theft of services (CONVICTED) - Arrested Jan 1, 2010",
-                ),
-                (
-                    case_all_ineligible_2.charges[0].ambiguous_charge_id,
-                    "Theft of services (CONVICTED) - Arrested Jan 1, 2010",
-                ),
-            ],
-        ),
-        ("Need more analysis", []),
-    ]
+    assert record_summary.eligible_charges_by_date == {
+        "Eligible Jan 1, 2030": [
+            (
+                case_possibly_eligible.charges[0].ambiguous_charge_id,
+                "Theft of services (CONVICTED) - Arrested Jan 1, " "2010",
+            )
+        ],
+        "Eligible now": [
+            (case_all_eligible.charges[0].ambiguous_charge_id, "Theft of dignity (CONVICTED) - Arrested Jan 1, 2010"),
+            (
+                case_partially_eligible.charges[0].ambiguous_charge_id,
+                "Theft of services (CONVICTED) - Arrested Jan 1, 2010",
+            ),
+        ],
+        "Ineligible": [
+            (
+                case_partially_eligible.charges[1].ambiguous_charge_id,
+                "Theft of services (CONVICTED) - Arrested Jan 1, 2010",
+            ),
+            (
+                case_all_ineligible.charges[0].ambiguous_charge_id,
+                "Theft of services (CONVICTED) - Arrested Jan 1, 2010",
+            ),
+            (
+                case_all_ineligible_2.charges[0].ambiguous_charge_id,
+                "Theft of services (CONVICTED) - Arrested Jan 1, 2010",
+            ),
+        ],
+    }
 
     """
     assert record_summary.county_balances["Baker"] == 700.00
@@ -162,8 +149,4 @@ def test_record_summarizer_no_cases():
     assert record_summary.total_cases == 0
     assert record_summary.total_charges == 0
     assert record_summary.county_balances == []
-    assert record_summary.eligible_charges_by_date == [
-        ("Eligible now", []),
-        ("Ineligible", []),
-        ("Need more analysis", []),
-    ]
+    assert record_summary.eligible_charges_by_date == {}

--- a/src/backend/tests/models/test_record_summarizer.py
+++ b/src/backend/tests/models/test_record_summarizer.py
@@ -111,7 +111,7 @@ def test_record_summarizer_multiple_cases():
                 "Theft of services (CONVICTED) - Arrested Jan 1, " "2010",
             )
         ],
-        "Eligible now": [
+        "Eligible Now": [
             (case_all_eligible.charges[0].ambiguous_charge_id, "Theft of dignity (CONVICTED) - Arrested Jan 1, 2010"),
             (
                 case_partially_eligible.charges[0].ambiguous_charge_id,

--- a/src/backend/tests/models/test_record_summarizer.py
+++ b/src/backend/tests/models/test_record_summarizer.py
@@ -104,10 +104,6 @@ def test_record_summarizer_multiple_cases():
     assert record_summary.total_balance_due == 1000.00
     assert record_summary.total_cases == 5
     assert record_summary.total_charges == 6
-    assert record_summary.cases_sorted["fully_eligible"] == ["1"]
-    assert record_summary.cases_sorted["fully_ineligible"] == ["4", "5"]
-    assert record_summary.cases_sorted["partially_eligible"] == ["2"]
-    assert record_summary.cases_sorted["other"] == ["3"]
     assert record_summary.eligible_charges_by_date == [
         (
             "Eligible now",
@@ -165,10 +161,6 @@ def test_record_summarizer_no_cases():
     assert record_summary.total_balance_due == 0.00
     assert record_summary.total_cases == 0
     assert record_summary.total_charges == 0
-    assert record_summary.cases_sorted["fully_eligible"] == []
-    assert record_summary.cases_sorted["fully_ineligible"] == []
-    assert record_summary.cases_sorted["partially_eligible"] == []
-    assert record_summary.cases_sorted["other"] == []
     assert record_summary.county_balances == []
     assert record_summary.eligible_charges_by_date == [
         ("Eligible now", []),

--- a/src/backend/tests/pdf/test_markdown_serializer.py
+++ b/src/backend/tests/pdf/test_markdown_serializer.py
@@ -21,7 +21,7 @@ Name: JOHN  DOE
   
 ## Future Eligible Charges  
 The following charges (dismissed and convicted) are eligible at the designated dates.  
-### Eligible Eligible Nov 9, 2020  
+### Eligible Nov 9, 2020  
  - Possession of Cocaine (CONVICTED) - Arrested Jun 13, 2009  
 
   

--- a/src/backend/tests/serializer/test_serializer_generative.py
+++ b/src/backend/tests/serializer/test_serializer_generative.py
@@ -12,5 +12,5 @@ from expungeservice.serializer import ExpungeModelEncoder
 @given(build_record_strategy())
 def test_round_trip_various_records(record):
     expunger_result = Expunger.run(record)
-    updated_record = RecordMerger.merge([record], [expunger_result])
+    updated_record = RecordMerger.merge([record], [expunger_result], [])
     json.loads(json.dumps(updated_record, cls=ExpungeModelEncoder))

--- a/src/backend/tests/test_friendly_rule.py
+++ b/src/backend/tests/test_friendly_rule.py
@@ -38,13 +38,13 @@ def test_eligible_mrc_with_single_arrest():
         merged_record.cases[0].charges[0].expungement_result.charge_eligibility.status  # type: ignore
         == ChargeEligibilityStatus.ELIGIBLE_NOW
     )
-    assert merged_record.cases[0].charges[0].expungement_result.charge_eligibility.label == "Eligible now"  # type: ignore
+    assert merged_record.cases[0].charges[0].expungement_result.charge_eligibility.label == "Eligible Now"  # type: ignore
 
     assert (
         merged_record.cases[0].charges[1].expungement_result.charge_eligibility.status  # type: ignore
         == ChargeEligibilityStatus.ELIGIBLE_NOW
     )
-    assert merged_record.cases[0].charges[1].expungement_result.charge_eligibility.label == "Eligible now"  # type: ignore
+    assert merged_record.cases[0].charges[1].expungement_result.charge_eligibility.label == "Eligible Now"  # type: ignore
 
 
 def test_arrest_is_unaffected_if_conviction_eligibility_is_older():

--- a/src/backend/tests/test_friendly_rule.py
+++ b/src/backend/tests/test_friendly_rule.py
@@ -33,18 +33,18 @@ def test_eligible_mrc_with_single_arrest():
     assert expunger_result[three_yr_mrc.ambiguous_charge_id].reason == "Eligible now"
     assert expunger_result[three_yr_mrc.ambiguous_charge_id].date_will_be_eligible == date.today()
 
-    merged_record = RecordMerger.merge([record], [expunger_result])
+    merged_record = RecordMerger.merge([record], [expunger_result], [])
     assert (
         merged_record.cases[0].charges[0].expungement_result.charge_eligibility.status  # type: ignore
         == ChargeEligibilityStatus.ELIGIBLE_NOW
     )
-    assert merged_record.cases[0].charges[0].expungement_result.charge_eligibility.label == "Eligible"  # type: ignore
+    assert merged_record.cases[0].charges[0].expungement_result.charge_eligibility.label == "Eligible now"  # type: ignore
 
     assert (
         merged_record.cases[0].charges[1].expungement_result.charge_eligibility.status  # type: ignore
         == ChargeEligibilityStatus.ELIGIBLE_NOW
     )
-    assert merged_record.cases[0].charges[1].expungement_result.charge_eligibility.label == "Eligible"  # type: ignore
+    assert merged_record.cases[0].charges[1].expungement_result.charge_eligibility.label == "Eligible now"  # type: ignore
 
 
 def test_arrest_is_unaffected_if_conviction_eligibility_is_older():

--- a/src/backend/tests/test_util.py
+++ b/src/backend/tests/test_util.py
@@ -51,4 +51,4 @@ def test_futures_are_equivalent():
 
 def test_strftime():
     assert DateWithFuture(2020, 5, 24).strftime("%b %-d, %Y") == "May 24, 2020"
-    assert DateWithFuture.future().strftime("%b %-d, %Y") == " from conviction of open case(s)"
+    assert DateWithFuture.future().strftime("%b %-d, %Y") == " From Conviction Of Open Charge"

--- a/src/frontend/src/components/RecordSearch/Record/Charge.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Charge.tsx
@@ -51,7 +51,7 @@ export default class Charge extends React.Component<Props> {
       if (
            (
              expungement_result.type_eligibility.status === "Eligible" ||
-             expungement_result.type_eligibility.status === "Needs more analysis"
+             expungement_result.type_eligibility.status === "Needs More Analysis"
            )
            &&
            expungement_result.time_eligibility) {

--- a/src/frontend/src/components/RecordSearch/Record/Eligibility.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Eligibility.tsx
@@ -19,13 +19,15 @@ export default class Eligibility extends React.Component<Props> {
       case "Eligible now":
         return "green bg-washed-green";
       case "Possibly eligible":
-        return "purple bg-washed-purple"
+        return "purple bg-washed-purple";
       case "Will be eligible":
-        return "dark-blue bg-washed-blue"
+        return "dark-blue bg-washed-blue";
       case "Possibly will be eligible":
-        return "purple bg-washed-purple"
+        return "purple bg-washed-purple";
       case "Ineligible":
-        return "red bg-washed-red"
+        return "red bg-washed-red";
+      case "Needs more analysis":
+        return "purple bg-washed-purple";
     }
   };
 

--- a/src/frontend/src/components/RecordSearch/Record/Eligibility.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Eligibility.tsx
@@ -16,17 +16,17 @@ export default class Eligibility extends React.Component<Props> {
     switch (charge_eligibility_status) {
       case "Unknown":
         return "purple bg-washed-purple";
-      case "Eligible now":
+      case "Eligible Now":
         return "green bg-washed-green";
-      case "Possibly eligible":
+      case "Possibly Eligible":
         return "purple bg-washed-purple";
-      case "Will be eligible":
+      case "Will Be Eligible":
         return "dark-blue bg-washed-blue";
-      case "Possibly will be eligible":
+      case "Possibly Will Be Eligible":
         return "purple bg-washed-purple";
       case "Ineligible":
         return "red bg-washed-red";
-      case "Needs more analysis":
+      case "Needs More Analysis":
         return "purple bg-washed-purple";
     }
   };

--- a/src/frontend/src/components/RecordSearch/Record/RecordSummary/ChargesList.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/RecordSummary/ChargesList.tsx
@@ -13,6 +13,7 @@ export default class ChargesList extends React.Component<Props> {
       .map((([eligibilityDate, chargesNames]: [string, any]) => {
       const listItems = this.buildListItems(chargesNames);
       const labelColor = (eligibilityDate==="Eligible Now" ? "green" : eligibilityDate==="Ineligible" ? "red" : eligibilityDate==="Needs More Analysis" ? "purple" : "dark-blue");
+      const SHOW_ALL_CHARGES_THRESHOLD = 20;
       return (
         <div key={eligibilityDate}>
           <div className="mb1">
@@ -20,7 +21,7 @@ export default class ChargesList extends React.Component<Props> {
             <span> {(chargesNames.length > 0 ? `(${chargesNames.length})` : "" )} </span>
           </div>
           <p className="f6 mb2">{
-            eligibilityDate==="Ineligible" ? "Excludes traffic violations, which are always ineligible" :
+            eligibilityDate==="Ineligible" && this.props.totalCharges > SHOW_ALL_CHARGES_THRESHOLD ? "Excludes traffic violations, which are always ineligible" :
             eligibilityDate==="Needs More Analysis" ? "These charges need clarification before an accurate analysis can be determined" :
             ""}</p>
           <ul className="list mb3">

--- a/src/frontend/src/components/RecordSearch/Record/RecordSummary/ChargesList.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/RecordSummary/ChargesList.tsx
@@ -12,7 +12,7 @@ export default class ChargesList extends React.Component<Props> {
       .sort((a, b) => this.extractLabel(a).localeCompare(this.extractLabel(b)))
       .map((([eligibilityDate, chargesNames]: [string, any]) => {
       const listItems = this.buildListItems(chargesNames);
-      const labelColor = (eligibilityDate==="Eligible now" ? "green" : eligibilityDate==="Ineligible" ? "red" : eligibilityDate==="Needs more analysis" ? "purple" : "dark-blue");
+      const labelColor = (eligibilityDate==="Eligible Now" ? "green" : eligibilityDate==="Ineligible" ? "red" : eligibilityDate==="Needs More Analysis" ? "purple" : "dark-blue");
       return (
         <div key={eligibilityDate}>
           <div className="mb1">
@@ -21,7 +21,7 @@ export default class ChargesList extends React.Component<Props> {
           </div>
           <p className="f6 mb2">{
             eligibilityDate==="Ineligible" ? "Excludes traffic violations, which are always ineligible" :
-            eligibilityDate==="Needs more analysis" ? "These charges need clarification before an accurate analysis can be determined" :
+            eligibilityDate==="Needs More Analysis" ? "These charges need clarification before an accurate analysis can be determined" :
             ""}</p>
           <ul className="list mb3">
              {listItems}
@@ -60,11 +60,11 @@ export default class ChargesList extends React.Component<Props> {
     }
 
     switch (label) {
-      case "Needs more analysis":
+      case "Needs More Analysis":
         return "zzz";
       case "Ineligible":
         return "zz";
-      case "Eligible now":
+      case "Eligible Now":
         return "";
       default:
         const label_split = label.split(" ");

--- a/src/frontend/src/components/RecordSearch/Record/RecordSummary/ChargesList.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/RecordSummary/ChargesList.tsx
@@ -1,37 +1,33 @@
 import React from 'react';
 
 interface Props {
-  eligibleChargesByDate: string[];
+  eligibleChargesByDate: { [label: string]: any[]; };
   totalCases: number;
   totalCharges: number;
 }
 
 export default class ChargesList extends React.Component<Props> {
   render() {
-    const summarizedCharges = this.props.eligibleChargesByDate.map(((chargeGroup:any, index:number) => {
-      const eligibilityDate = chargeGroup[0];
-      const chargesNames = chargeGroup[1];
+    const summarizedCharges = Object.entries(this.props.eligibleChargesByDate)
+      .sort((a, b) => this.extractLabel(a).localeCompare(this.extractLabel(b)))
+      .map((([eligibilityDate, chargesNames]: [string, any]) => {
       const listItems = this.buildListItems(chargesNames);
-      const labelColor = (eligibilityDate==="Eligible now" ? "green" : eligibilityDate==="Ineligible" ? "red" : eligibilityDate==="Need more analysis" ? "purple" : "dark-blue");
-      if (eligibilityDate==="Need more analysis" && listItems.length == 0) {
-        return (<></>);
-      } else {
-        return (
-          <div key={index}>
-            <div className="mb1">
-              <span className={"fw7 ttc mb2 " + labelColor}> {eligibilityDate} </span>
-              <span> {(chargesNames.length > 0 ? `(${chargesNames.length})` : "" )} </span>
-            </div>
-            <p className="f6 mb2">{
-              eligibilityDate==="Ineligible" ? "Excludes traffic violations, which are always ineligible" :
-              eligibilityDate==="Need more analysis" ? "These charges need clarification before an accurate analysis can be determined" :
-              ""}</p>
-            <ul className="list mb3">
-             {listItems.length > 0 ? listItems : "None"}
-            </ul>
+      const labelColor = (eligibilityDate==="Eligible now" ? "green" : eligibilityDate==="Ineligible" ? "red" : eligibilityDate==="Needs more analysis" ? "purple" : "dark-blue");
+      return (
+        <div key={eligibilityDate}>
+          <div className="mb1">
+            <span className={"fw7 ttc mb2 " + labelColor}> {eligibilityDate} </span>
+            <span> {(chargesNames.length > 0 ? `(${chargesNames.length})` : "" )} </span>
           </div>
-        )
-      }
+          <p className="f6 mb2">{
+            eligibilityDate==="Ineligible" ? "Excludes traffic violations, which are always ineligible" :
+            eligibilityDate==="Needs more analysis" ? "These charges need clarification before an accurate analysis can be determined" :
+            ""}</p>
+          <ul className="list mb3">
+             {listItems}
+          </ul>
+        </div>
+      )
     }));
 
     return (
@@ -43,12 +39,43 @@ export default class ChargesList extends React.Component<Props> {
     );
   }
 
-  buildListItems(chargesNames: string[]) {
-    const listItems = chargesNames.map(((chargeName: string, index:number) => {
+  buildListItems(chargesNames: any[]) {
+    const listItems = chargesNames.map((([id, chargeName]: [string, string], index:number) => {
         return (
-            <li key={"chargeItem" + index} className="bt b--light-gray pt1 mb2"><a href={"#" + chargeName[0]} className="link hover-blue">{chargeName[1]}</a></li>
+            <li key={"chargeItem" + index} className="bt b--light-gray pt1 mb2"><a href={"#" + id} className="link hover-blue">{chargeName}</a></li>
         )
       }));
     return listItems;
+  }
+
+  // TODO: This is kind of a hack
+  extractLabel([label, _]: [string, any[]]): string {
+    // Adapted from https://stackoverflow.com/a/62283763/2750819
+    function* zip(array: any, n: number): any {
+      let i = 0;
+      while (i + n <= array.length) {
+          yield array.slice(i, i + n);
+          i++;
+      }
+    }
+
+    switch (label) {
+      case "Needs more analysis":
+        return "zzz";
+      case "Ineligible":
+        return "zz";
+      case "Eligible now":
+        return "";
+      default:
+        const label_split = label.split(" ");
+        for (let date_parts of zip(label_split, 3)) {
+          const date_string = date_parts.join(" ");
+          const epoch = Date.parse(date_string);
+          if (!Object.is(epoch, NaN)) {
+            return new Date(epoch).toISOString();
+          }
+        }
+        return "z";
+    }
   }
 }

--- a/src/frontend/src/components/RecordSearch/Record/RecordSummary/index.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/RecordSummary/index.tsx
@@ -16,7 +16,6 @@ export default class RecordSummary extends React.Component<Props> {
   render() {
     const {
       total_charges,
-      cases_sorted,
       eligible_charges_by_date,
       county_balances,
       total_balance_due,

--- a/src/frontend/src/components/RecordSearch/Record/TypeEligibility.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/TypeEligibility.tsx
@@ -49,7 +49,7 @@ export default class RecordType extends React.Component<Props> {
 
     if (status === 'Eligible') {
       return eligible(reason);
-    } else if (status === 'Needs more analysis') {
+    } else if (status === 'Needs More Analysis') {
       return review;
     } else if (status === 'Ineligible') {
       return ineligible(reason);

--- a/src/frontend/src/components/RecordSearch/Record/types.ts
+++ b/src/frontend/src/components/RecordSearch/Record/types.ts
@@ -36,7 +36,7 @@ export interface RecordData {
 
 export interface RecordSummaryData {
   total_charges: number;
-  eligible_charges_by_date: any[];
+  eligible_charges_by_date: { [label: string]: any[]; };
   county_balances: CountyBalanceData[];
   total_balance_due: number;
   total_cases: number;

--- a/src/frontend/src/components/RecordSearch/Record/types.ts
+++ b/src/frontend/src/components/RecordSearch/Record/types.ts
@@ -36,7 +36,6 @@ export interface RecordData {
 
 export interface RecordSummaryData {
   total_charges: number;
-  cases_sorted: any;
   eligible_charges_by_date: any[];
   county_balances: CountyBalanceData[];
   total_balance_due: number;


### PR DESCRIPTION
This PR removes cases_sorted from RecordSummarizer as a refactoring. The label sorting should just be done in the backend eventually.