### PR TITLE
Change charge eligibility label text

### DIFF
--- a/src/backend/expungeservice/record_merger.py
+++ b/src/backend/expungeservice/record_merger.py
@@ -151,7 +151,7 @@ class RecordMerger:
                 for time_eligibility in at_least_will_be_eligibles
                 if time_eligibility.status != EligibilityStatus.ELIGIBLE
             ]
-            will_be_eligibles_string = " ⬥ ".join(will_be_eligibles)
+            will_be_eligibles_string = " or ".join(will_be_eligibles)
             if all(
                 [
                     time_eligibility.status == EligibilityStatus.ELIGIBLE
@@ -167,7 +167,7 @@ class RecordMerger:
             ):
                 return ChargeEligibility(
                     ChargeEligibilityStatus.POSSIBLY_WILL_BE_ELIGIBLE,
-                    f"Possibly Eligible Now ⬥ {will_be_eligibles_string}",
+                    f"Possibly Eligible Now or {will_be_eligibles_string}",
                 )
             else:
                 return ChargeEligibility(
@@ -182,12 +182,12 @@ class RecordMerger:
                     for time_eligibility in time_eligibilities
                     if time_eligibility.status != EligibilityStatus.ELIGIBLE
                 ]
-                eligible_date_string = " ⬥ ".join(will_be_eligibles)
+                eligible_date_string = " or ".join(will_be_eligibles)
                 if any(
                     [time_eligibility.status == EligibilityStatus.ELIGIBLE for time_eligibility in time_eligibilities]
                 ):
                     return ChargeEligibility(
-                        ChargeEligibilityStatus.WILL_BE_ELIGIBLE, f"Eligible Now ⬥ {eligible_date_string}"
+                        ChargeEligibilityStatus.WILL_BE_ELIGIBLE, f"Eligible Now or {eligible_date_string}"
                     )
                 else:
                     return ChargeEligibility(

--- a/src/backend/expungeservice/record_merger.py
+++ b/src/backend/expungeservice/record_merger.py
@@ -60,7 +60,8 @@ class RecordMerger:
                     )
                     if "open" in charge_eligibility.label.lower():
                         charge_eligibility = replace(
-                            charge_eligibility, label=f"If All Cases Are Closed, {charge_eligibility.label}"
+                            charge_eligibility,
+                            label=f"Eligibility Timeframe Dependent On Open Charge: {charge_eligibility.label}",
                         )
                 expungement_result = ExpungementResult(
                     type_eligibility=merged_type_eligibility,

--- a/src/backend/tests/models/test_expungement_result.py
+++ b/src/backend/tests/models/test_expungement_result.py
@@ -66,7 +66,7 @@ def test_multiple_will_be_eligible():
     )
 
     assert charge_eligibility.status == ChargeEligibilityStatus.WILL_BE_ELIGIBLE
-    assert charge_eligibility.label == f"Eligible Now ⬥ {Time.ONE_YEARS_FROM_NOW.strftime('%b %-d, %Y')}"
+    assert charge_eligibility.label == f"Eligible Now or {Time.ONE_YEARS_FROM_NOW.strftime('%b %-d, %Y')}"
 
 
 def test_ineligible():


### PR DESCRIPTION
- Use or instead of ⬥ in charge eligibility labels
- Change charge eligibility label prefix for open charges