### PR TITLE
Add wildcard validation to search form

### DIFF
--- a/src/frontend/src/components/RecordSearch/SearchPanel/index.tsx
+++ b/src/frontend/src/components/RecordSearch/SearchPanel/index.tsx
@@ -58,21 +58,18 @@ export default class SearchPanel extends React.Component<Props, State> {
           this.state.aliases[i].last_name.trim().length === 0
         ) {
           missingInputs = true;
-          break;
         }
         if (
           this.state.aliases[i].first_name.indexOf("*") > -1 &&
           !isValidWildcard(this.state.aliases[i].first_name, 2)
         ) {
           invalidFirstNameWildcard = true;
-          break;
         }
         if (
           this.state.aliases[i].last_name.indexOf("*") > -1 &&
           !isValidWildcard(this.state.aliases[i].last_name, 3)
         ) {
           invalidLastNameWildcard = true;
-          break;
         }
       }
       this.setState(

--- a/src/frontend/src/components/RecordSearch/SearchPanel/index.tsx
+++ b/src/frontend/src/components/RecordSearch/SearchPanel/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AliasData, AliasFieldNames } from "./types";
 import moment from "moment";
-import { isValidWildcard } from './validators';
+import { isValidWildcard } from "./validators";
 import Alias from "./Alias";
 import InvalidInputs from "../../InvalidInputs";
 
@@ -13,7 +13,8 @@ interface State {
   aliases: AliasData[];
   missingInputs: boolean;
   invalidDate: boolean;
-  invalidWildcard: boolean;
+  invalidFirstNameWildcard: boolean;
+  invalidLastNameWildcard: boolean;
 }
 
 export default class SearchPanel extends React.Component<Props, State> {
@@ -28,7 +29,8 @@ export default class SearchPanel extends React.Component<Props, State> {
     ],
     missingInputs: false,
     invalidDate: false,
-    invalidWildcard: false,
+    invalidFirstNameWildcard: false,
+    invalidLastNameWildcard: false,
   };
 
   handleSubmit = (e: React.FormEvent) => {
@@ -37,7 +39,8 @@ export default class SearchPanel extends React.Component<Props, State> {
       if (
         !this.state.missingInputs &&
         !this.state.invalidDate &&
-        !this.state.invalidWildcard
+        !this.state.invalidFirstNameWildcard &&
+        !this.state.invalidLastNameWildcard
       ) {
         this.props.searchRecord(this.state.aliases);
       }
@@ -47,7 +50,8 @@ export default class SearchPanel extends React.Component<Props, State> {
   validateForm = () => {
     return new Promise((resolve) => {
       let missingInputs: boolean = false;
-      let invalidWildcard: boolean = false;
+      let invalidFirstNameWildcard: boolean = false;
+      let invalidLastNameWildcard: boolean = false;
       for (let i: number = 0; i < this.state.aliases.length; i++) {
         if (
           this.state.aliases[i].first_name.trim().length === 0 ||
@@ -57,19 +61,25 @@ export default class SearchPanel extends React.Component<Props, State> {
           break;
         }
         if (
-          (this.state.aliases[i].first_name.indexOf('*') > -1 &&
-            !isValidWildcard(this.state.aliases[i].first_name, 'first')) ||
-          (this.state.aliases[i].last_name.indexOf('*') > -1 &&
-            !isValidWildcard(this.state.aliases[i].last_name, 'last'))
+          this.state.aliases[i].first_name.indexOf("*") > -1 &&
+          !isValidWildcard(this.state.aliases[i].first_name, 2)
         ) {
-            invalidWildcard = true;
-            break;
+          invalidFirstNameWildcard = true;
+          break;
+        }
+        if (
+          this.state.aliases[i].last_name.indexOf("*") > -1 &&
+          !isValidWildcard(this.state.aliases[i].last_name, 3)
+        ) {
+          invalidLastNameWildcard = true;
+          break;
         }
       }
       this.setState(
         {
           missingInputs,
-          invalidWildcard,
+          invalidFirstNameWildcard,
+          invalidLastNameWildcard,
           invalidDate:
             moment(
               this.state.aliases[0].birth_date,
@@ -167,11 +177,23 @@ export default class SearchPanel extends React.Component<Props, State> {
               </button>
             </div>
             <InvalidInputs
-              conditions={[this.state.missingInputs, this.state.invalidDate, this.state.invalidWildcard]}
+              conditions={[
+                this.state.missingInputs,
+                this.state.invalidDate,
+                this.state.invalidFirstNameWildcard,
+                this.state.invalidLastNameWildcard,
+              ]}
               contents={[
                 <span>First and last name are required.</span>,
                 <span>The date format must be MM/DD/YYYY.</span>,
-                <span>Wildcards must be at the end of the search term and contain 3 or more characters.</span>
+                <span>
+                  A wildcard in First Name field must be at the end and follow
+                  at least one letter.
+                </span>,
+                <span>
+                  A wildcard in the Last Name field must be at the end and
+                  follow at least two letters.
+                </span>,
               ]}
             />
           </form>

--- a/src/frontend/src/components/RecordSearch/SearchPanel/validators.ts
+++ b/src/frontend/src/components/RecordSearch/SearchPanel/validators.ts
@@ -1,8 +1,12 @@
-export function isValidWildcard(searchTerm: string, firstOrLast: 'first' | 'last'): boolean {
-  const requiredLength = firstOrLast === 'first' ? 2 : 3;
-
-  if (searchTerm.length < requiredLength) return false;
-  if (searchTerm.indexOf('*') < searchTerm.length - 1) return false;
-
-  return true;
+export function isValidWildcard(
+  searchTerm: string,
+  requiredLength: number
+): boolean {
+  if (searchTerm.length < requiredLength) {
+    return false;
+  } else if (searchTerm.indexOf("*") < searchTerm.length - 1) {
+    return false;
+  } else {
+    return true;
+  }
 }

--- a/src/frontend/src/components/RecordSearch/SearchPanel/validators.ts
+++ b/src/frontend/src/components/RecordSearch/SearchPanel/validators.ts
@@ -1,0 +1,8 @@
+export function isValidWildcard(searchTerm: string, firstOrLast: 'first' | 'last'): boolean {
+  const requiredLength = firstOrLast === 'first' ? 2 : 3;
+
+  if (searchTerm.length < requiredLength) return false;
+  if (searchTerm.indexOf('*') < searchTerm.length - 1) return false;
+
+  return true;
+}

--- a/src/frontend/src/test/components/RecordSearch/SearchPanel/validators.test.ts
+++ b/src/frontend/src/test/components/RecordSearch/SearchPanel/validators.test.ts
@@ -1,0 +1,23 @@
+import { isValidWildcard } from '../../../../components/RecordSearch/SearchPanel/validators';
+
+describe('#isValidWildcard', () => {
+  it('requires 1 characters for first name', () => {
+    expect(isValidWildcard('*', 'first')).toEqual(false);
+    expect(isValidWildcard('a*', 'first')).toEqual(true);
+  });
+
+  it('requires 2 characters for last name', () => {
+    expect(isValidWildcard('a*', 'last')).toEqual(false);
+    expect(isValidWildcard('ab*', 'last')).toEqual(true);
+  });
+
+  it('requires that wildcard is at end of word', () => {
+    expect(isValidWildcard('ab*c', 'last')).toEqual(false);
+  });
+
+  it('returns true for valid wildcards', () => {
+    expect(isValidWildcard('hello*', 'last')).toEqual(true);
+    expect(isValidWildcard('h*', 'first')).toEqual(true);
+  })
+});
+

--- a/src/frontend/src/test/components/RecordSearch/SearchPanel/validators.test.ts
+++ b/src/frontend/src/test/components/RecordSearch/SearchPanel/validators.test.ts
@@ -1,23 +1,22 @@
-import { isValidWildcard } from '../../../../components/RecordSearch/SearchPanel/validators';
+import { isValidWildcard } from "../../../../components/RecordSearch/SearchPanel/validators";
 
-describe('#isValidWildcard', () => {
-  it('requires 1 characters for first name', () => {
-    expect(isValidWildcard('*', 'first')).toEqual(false);
-    expect(isValidWildcard('a*', 'first')).toEqual(true);
+describe("#isValidWildcard", () => {
+  it("requires 1 characters for first name", () => {
+    expect(isValidWildcard("*", 2)).toEqual(false);
+    expect(isValidWildcard("a*", 2)).toEqual(true);
   });
 
-  it('requires 2 characters for last name', () => {
-    expect(isValidWildcard('a*', 'last')).toEqual(false);
-    expect(isValidWildcard('ab*', 'last')).toEqual(true);
+  it("requires 2 characters for last name", () => {
+    expect(isValidWildcard("a*", 3)).toEqual(false);
+    expect(isValidWildcard("ab*", 3)).toEqual(true);
   });
 
-  it('requires that wildcard is at end of word', () => {
-    expect(isValidWildcard('ab*c', 'last')).toEqual(false);
+  it("requires that wildcard is at end of word", () => {
+    expect(isValidWildcard("ab*c", 3)).toEqual(false);
   });
 
-  it('returns true for valid wildcards', () => {
-    expect(isValidWildcard('hello*', 'last')).toEqual(true);
-    expect(isValidWildcard('h*', 'first')).toEqual(true);
-  })
+  it("returns true for valid wildcards", () => {
+    expect(isValidWildcard("hello*", 3)).toEqual(true);
+    expect(isValidWildcard("h*", 2)).toEqual(true);
+  });
 });
-


### PR DESCRIPTION
Add validation for the name search fields such that:
* If a wildcard exists, it's at the end of the word
* For first name, the string must be at least 1 character long (not including the `*`)
* For last name, the string must be at least 3 characters long (not including the `*`)

Also adds a `test` dir inside `src` (where create-react-app wants it) in case we want to add more tests there. 

For https://github.com/codeforpdx/recordexpungPDX/issues/1209

Screenshot: 
![image](https://user-images.githubusercontent.com/544636/84547826-281ae580-acb9-11ea-89d1-37e74df0c012.png)
