### PR TITLE
Ensure print(record) produces an interpretable output

### DIFF
--- a/src/backend/expungeservice/models/disposition.py
+++ b/src/backend/expungeservice/models/disposition.py
@@ -11,6 +11,9 @@ class DispositionStatus(str, Enum):
     UNKNOWN = "Unknown"
     UNRECOGNIZED = "Unrecognized"
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}.{self.name}"
+
 
 @dataclass(frozen=True)
 class Disposition:

--- a/src/backend/expungeservice/models/expungement_result.py
+++ b/src/backend/expungeservice/models/expungement_result.py
@@ -9,6 +9,9 @@ class EligibilityStatus(str, Enum):
     NEEDS_MORE_ANALYSIS = "Needs More Analysis"
     INELIGIBLE = "Ineligible"
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}.{self.name}"
+
 
 class ChargeEligibilityStatus(str, Enum):
     UNKNOWN = "Unknown"
@@ -18,6 +21,9 @@ class ChargeEligibilityStatus(str, Enum):
     POSSIBLY_WILL_BE_ELIGIBLE = "Possibly Will Be Eligible"
     INELIGIBLE = "Ineligible"
     NEEDS_MORE_ANALYSIS = "Needs More Analysis"
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}.{self.name}"
 
 
 @dataclass(frozen=True)

--- a/src/backend/expungeservice/util.py
+++ b/src/backend/expungeservice/util.py
@@ -132,7 +132,7 @@ class DateWithFuture:
         return NotImplemented
 
     def __repr__(self):
-        return f"DateWithFuture{repr((self.date, self.relative))}"
+        return f"DateWithFuture(date={repr(self.date)}, relative={repr(self.relative)})"
 
     def __hash__(self):
         return hash((self.date, self.relative))


### PR DESCRIPTION
This will help us create mock records.