### PR TITLE
Add and Edit Case/Charge backend

### DIFF
--- a/src/backend/expungeservice/crawler/crawler.py
+++ b/src/backend/expungeservice/crawler/crawler.py
@@ -11,7 +11,7 @@ from expungeservice.util import DateWithFuture as date_class
 from expungeservice.crawler.request import Payload, URL
 from expungeservice.util import LRUCache
 from expungeservice.models.case import CaseCreator, OeciCase, CaseSummary
-from expungeservice.models.charge import OeciCharge
+from expungeservice.models.charge import OeciCharge, EditStatus
 from expungeservice.models.disposition import DispositionCreator
 from expungeservice.crawler.parsers.param_parser import ParamParser
 from expungeservice.crawler.parsers.node_parser import NodeParser
@@ -94,7 +94,9 @@ class Crawler:
                 charge_id, ambiguous_charge_id, charge_dict, case_parser_data, balance_due_in_cents
             )
             charges.append(charge)
-        updated_case_summary = replace(case_summary, balance_due_in_cents=balance_due_in_cents)
+        updated_case_summary = replace(
+            case_summary, balance_due_in_cents=balance_due_in_cents, edit_status=EditStatus.UNCHANGED
+        )
         return OeciCase(updated_case_summary, charges=tuple(charges))
 
     @staticmethod
@@ -134,6 +136,7 @@ class Crawler:
             disposition=disposition,
             probation_revoked=probation_revoked,
             balance_due_in_cents=balance_due_in_cents,
+            edit_status=EditStatus.UNCHANGED,
             **charge_dict,
         )
 

--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -30,12 +30,12 @@ class Expunger:
         cases = analyzable_record.cases
         for charge in analyzable_record.charges:
             eligibility_dates: List[Tuple[date, str]] = []
-            other_charges = [
+            other_blocking_charges = [
                 c
                 for c in analyzable_record.charges
                 if c.charge_type.blocks_other_charges and c.id != charge.id and charge.edit_status != EditStatus.DELETE
             ]
-            dismissals, convictions = Expunger._categorize_charges(other_charges)
+            dismissals, convictions = Expunger._categorize_charges(other_blocking_charges)
             most_recent_blocking_dismissal = Expunger._most_recent_different_case_dismissal(charge, dismissals)
             most_recent_blocking_conviction = Expunger._most_recent_convictions(convictions)
             other_convictions_all_traffic = Expunger._is_other_convictions_all_traffic(convictions)
@@ -94,7 +94,7 @@ class Expunger:
                 )
 
             if charge.convicted() and isinstance(charge.charge_type, FelonyClassB):
-                if Expunger._calculate_has_subsequent_charge(charge, other_charges):
+                if Expunger._calculate_has_subsequent_charge(charge, other_blocking_charges):
                     eligibility_dates.append(
                         (
                             date.max(),

--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -7,7 +7,7 @@ from dateutil.relativedelta import relativedelta
 from more_itertools import padnone, take
 
 from expungeservice.models.case import Case
-from expungeservice.models.charge import Charge
+from expungeservice.models.charge import Charge, EditStatus
 from expungeservice.models.charge_types.felony_class_b import FelonyClassB
 from expungeservice.models.charge_types.juvenile_charge import JuvenileCharge
 from expungeservice.models.charge_types.marijuana_eligible import MarijuanaUnder21, MarijuanaViolation
@@ -31,7 +31,9 @@ class Expunger:
         for charge in analyzable_record.charges:
             eligibility_dates: List[Tuple[date, str]] = []
             other_charges = [
-                c for c in analyzable_record.charges if c.charge_type.blocks_other_charges and c.id != charge.id
+                c
+                for c in analyzable_record.charges
+                if c.charge_type.blocks_other_charges and c.id != charge.id and charge.edit_status != EditStatus.DELETE
             ]
             dismissals, convictions = Expunger._categorize_charges(other_charges)
             most_recent_blocking_dismissal = Expunger._most_recent_different_case_dismissal(charge, dismissals)

--- a/src/backend/expungeservice/models/case.py
+++ b/src/backend/expungeservice/models/case.py
@@ -42,18 +42,21 @@ class OeciCase:
 
     @staticmethod
     def empty(case_number: str):
-        summary = CaseSummary(
-            name="",
-            birth_year=1900,
-            case_number=case_number,
-            citation_number="",
-            location="",
-            date=date_class.today(),
-            violation_type="",
-            current_status="",
-            case_detail_link="",
-            balance_due_in_cents=0,
-            edit_status=EditStatus.UNCHANGED,
+        return OeciCase(
+            CaseSummary(
+                name="",
+                birth_year=1900,
+                case_number=case_number,
+                citation_number="",
+                location="",
+                date=date_class.today(),
+                violation_type="",
+                current_status="",
+                case_detail_link="",
+                balance_due_in_cents=0,
+                edit_status=EditStatus.UNCHANGED,
+            ),
+            (),
         )
 
 

--- a/src/backend/expungeservice/models/case.py
+++ b/src/backend/expungeservice/models/case.py
@@ -4,6 +4,7 @@ from expungeservice.util import DateWithFuture as date_class
 from typing import Optional, Tuple
 
 from expungeservice.models.charge import OeciCharge, Charge
+from expungeservice.record_editor import EditStatus
 
 
 @dataclass(frozen=True)
@@ -18,6 +19,7 @@ class CaseSummary:
     current_status: str
     case_detail_link: str
     balance_due_in_cents: int
+    edit_status: EditStatus = EditStatus.UNCHANGED
 
     def get_balance_due(self):
         return self.balance_due_in_cents / 100

--- a/src/backend/expungeservice/models/case.py
+++ b/src/backend/expungeservice/models/case.py
@@ -3,8 +3,7 @@ from datetime import datetime
 from expungeservice.util import DateWithFuture as date_class
 from typing import Optional, Tuple
 
-from expungeservice.models.charge import OeciCharge, Charge
-from expungeservice.record_editor import EditStatus
+from expungeservice.models.charge import OeciCharge, Charge, EditStatus
 
 
 @dataclass(frozen=True)
@@ -19,7 +18,7 @@ class CaseSummary:
     current_status: str
     case_detail_link: str
     balance_due_in_cents: int
-    edit_status: EditStatus = EditStatus.UNCHANGED
+    edit_status: EditStatus
 
     def get_balance_due(self):
         return self.balance_due_in_cents / 100
@@ -40,6 +39,22 @@ class CaseSummary:
 class OeciCase:
     summary: CaseSummary
     charges: Tuple[OeciCharge, ...]
+
+    @staticmethod
+    def empty(case_number: str):
+        summary = CaseSummary(
+            name="",
+            birth_year=1900,
+            case_number=case_number,
+            citation_number="",
+            location="",
+            date=date_class.today(),
+            violation_type="",
+            current_status="",
+            case_detail_link="",
+            balance_due_in_cents=0,
+            edit_status=EditStatus.UNCHANGED,
+        )
 
 
 @dataclass(frozen=True)
@@ -71,6 +86,7 @@ class CaseCreator:
             current_status,
             case_detail_link,
             balance_due_in_cents,
+            EditStatus.UNCHANGED,
         )
 
     @staticmethod

--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from dateutil.relativedelta import relativedelta
+from enum import Enum
 
 from expungeservice.util import DateWithFuture as date_class
 from expungeservice.models.disposition import Disposition, DispositionStatus
@@ -11,7 +12,13 @@ from expungeservice.models.expungement_result import (
     TypeEligibility,
     EligibilityStatus,
 )
-from expungeservice.record_editor import EditStatus
+
+
+class EditStatus(str, Enum):
+    UNCHANGED = "UNCHANGED"
+    UPDATE = "UPDATE"
+    ADD = "ADD"
+    DELETE = "DELETE"
 
 
 class ChargeUtil:
@@ -35,6 +42,7 @@ class OeciCharge:
     disposition: Disposition
     probation_revoked: Optional[date_class]
     balance_due_in_cents: int
+    edit_status: EditStatus
 
 
 @dataclass(frozen=True)
@@ -59,7 +67,6 @@ class Charge(OeciCharge):
     case_number: str
     charge_type: ChargeType
     expungement_result: ExpungementResult = ExpungementResult()  # TODO: Remove default value
-    edit_status: EditStatus = EditStatus.UNCHANGED
 
     @property
     def type_eligibility(self) -> TypeEligibility:

--- a/src/backend/expungeservice/models/charge.py
+++ b/src/backend/expungeservice/models/charge.py
@@ -11,6 +11,7 @@ from expungeservice.models.expungement_result import (
     TypeEligibility,
     EligibilityStatus,
 )
+from expungeservice.record_editor import EditStatus
 
 
 class ChargeUtil:
@@ -58,6 +59,7 @@ class Charge(OeciCharge):
     case_number: str
     charge_type: ChargeType
     expungement_result: ExpungementResult = ExpungementResult()  # TODO: Remove default value
+    edit_status: EditStatus = EditStatus.UNCHANGED
 
     @property
     def type_eligibility(self) -> TypeEligibility:

--- a/src/backend/expungeservice/record_creator.py
+++ b/src/backend/expungeservice/record_creator.py
@@ -11,7 +11,7 @@ from expungeservice.crawler.crawler import Crawler, InvalidOECIUsernamePassword,
 from expungeservice.expunger import ErrorChecker, Expunger
 from expungeservice.models.ambiguous import AmbiguousCharge, AmbiguousCase, AmbiguousRecord
 from expungeservice.models.case import Case, OeciCase
-from expungeservice.models.charge import Charge
+from expungeservice.models.charge import Charge, EditStatus
 from expungeservice.record_editor import RecordEditor
 from expungeservice.record_merger import RecordMerger
 from expungeservice.models.record import Record, Alias, QuestionSummary, Question, Answer
@@ -40,7 +40,9 @@ class RecordCreator:
             user_edited_search_results, new_charges = RecordEditor.edit_search_results(
                 cases_with_unique_case_number, edits
             )
+
             ambiguous_cases, questions = RecordCreator._build_ambiguous_cases(user_edited_search_results, new_charges)
+
             ambiguous_record, overflow_error = RecordCreator._build_ambiguous_record(ambiguous_cases)
             if overflow_error:
                 return Record((), tuple(overflow_error)), {}
@@ -151,6 +153,7 @@ class RecordCreator:
                 "case_number": oeci_case.summary.case_number,
                 "violation_type": oeci_case.summary.violation_type,
                 "birth_year": oeci_case.summary.birth_year,
+                "edit_status": EditStatus(oeci_case.summary.edit_status),
             }
             if oeci_charge.disposition.status == DispositionStatus.UNKNOWN:
                 charge_dict.pop("disposition")

--- a/src/backend/expungeservice/record_creator.py
+++ b/src/backend/expungeservice/record_creator.py
@@ -153,7 +153,7 @@ class RecordCreator:
                 "case_number": oeci_case.summary.case_number,
                 "violation_type": oeci_case.summary.violation_type,
                 "birth_year": oeci_case.summary.birth_year,
-                "edit_status": EditStatus(oeci_case.summary.edit_status),
+                "edit_status": EditStatus(oeci_charge.edit_status),
             }
             if oeci_charge.disposition.status == DispositionStatus.UNKNOWN:
                 charge_dict.pop("disposition")

--- a/src/backend/expungeservice/record_editor.py
+++ b/src/backend/expungeservice/record_editor.py
@@ -10,6 +10,14 @@ from expungeservice.models.case import OeciCase, CaseCreator
 from expungeservice.models.charge import Charge, OeciCharge, ChargeType
 from expungeservice.models.charge_types.unclassified_charge import UnclassifiedCharge
 from expungeservice.models.disposition import DispositionCreator
+from enum import Enum
+
+
+class EditStatus(str, Enum):
+    UNCHANGED = "UNCHANGED"
+    EDITED = "EDITED"
+    ADDED = "ADDED"
+    DELETED = "DELETED"
 
 
 class RecordEditor:

--- a/src/backend/expungeservice/record_editor.py
+++ b/src/backend/expungeservice/record_editor.py
@@ -28,7 +28,7 @@ class RecordEditor:
                 new_charges_accumulator += new_charges
             elif edit["summary"]["edit_status"] in (EditStatus.UPDATE, EditStatus.DELETE):
                 case = next(
-                    (case for case in search_result_cases if case.summary.case_number == edit_action_case_number), None
+                    (case for case in search_result_cases if case.summary.case_number == edit_action_case_number)
                 )
                 edited_case, new_charges = RecordEditor._edit_case(case, edit)
                 edited_cases.append(edited_case)
@@ -98,8 +98,7 @@ class RecordEditor:
                 charges_with_charge_type.append(new_charge)
             elif edit["edit_status"] in (EditStatus.UPDATE, EditStatus.DELETE):
                 charge = next(
-                    (charge for charge in charges if charge.ambiguous_charge_id == edit_action_ambiguous_charge_id),
-                    None,
+                    (charge for charge in charges if charge.ambiguous_charge_id == edit_action_ambiguous_charge_id)
                 )
                 charge_edits = charges_edits[charge.ambiguous_charge_id]
                 charge_dict = RecordEditor._parse_charge_edits(edit)

--- a/src/backend/expungeservice/record_editor.py
+++ b/src/backend/expungeservice/record_editor.py
@@ -78,7 +78,7 @@ class RecordEditor:
         ]
         charges_with_charge_type = []
         for edit_action_ambiguous_charge_id, edit in charges_edits.items():
-            if edit["edit_status"] == EditStatus.ADD:
+            if edit.get("edit_status", None) == EditStatus.ADD:
                 charge_dict = RecordEditor._parse_charge_edits(edit)
                 charge_type_string = charge_dict.pop("charge_type", None)
                 charge_edits_with_defaults = {
@@ -96,7 +96,7 @@ class RecordEditor:
                 }
                 new_charge = from_dict(data_class=Charge, data=charge_edits_with_defaults)
                 charges_with_charge_type.append(new_charge)
-            elif edit["edit_status"] in (EditStatus.UPDATE, EditStatus.DELETE):
+            else:  # edit["edit_status"] is either UPDATE or DELETE
                 charge = next(
                     (charge for charge in charges if charge.ambiguous_charge_id == edit_action_ambiguous_charge_id)
                 )

--- a/src/backend/expungeservice/serializer.py
+++ b/src/backend/expungeservice/serializer.py
@@ -48,6 +48,7 @@ class ExpungeModelEncoder(flask.json.JSONEncoder):
             "current_status": case.current_status,
             "balance_due": case.get_balance_due(),
             "case_detail_link": case.case_detail_link,
+            "edit_status": case.edit_status,
         }
 
     def charge_to_json(self, charge):
@@ -63,6 +64,7 @@ class ExpungeModelEncoder(flask.json.JSONEncoder):
             "probation_revoked": charge.probation_revoked,
             "statute": charge.statute,
             "type_name": charge.charge_type.type_name,
+            "edit_status": charge.edit_status,
         }
 
     def default(self, o):

--- a/src/backend/tests/factories/charge_factory.py
+++ b/src/backend/tests/factories/charge_factory.py
@@ -1,6 +1,6 @@
 from expungeservice.util import DateWithFuture as date_class
 from expungeservice.models.ambiguous import AmbiguousCharge
-from expungeservice.models.charge import Charge
+from expungeservice.models.charge import Charge, EditStatus
 from expungeservice.charge_creator import ChargeCreator
 from expungeservice.models.disposition import Disposition, DispositionCreator, DispositionStatus
 
@@ -54,6 +54,7 @@ class ChargeFactory:
             "disposition": disposition,
             "violation_type": violation_type,
             "balance_due_in_cents": 0,
+            "edit_status": EditStatus.UNCHANGED,
         }
         charges = ChargeCreator.create(str(cls.charge_count), **kwargs)[0]
         return charges
@@ -79,6 +80,7 @@ class ChargeFactory:
             "disposition": disposition,
             "violation_type": violation_type,
             "balance_due_in_cents": 0,
+            "edit_status": EditStatus.UNCHANGED,
         }
 
         charges = ChargeCreator.create(str(cls.charge_count), **kwargs)[0]

--- a/src/backend/tests/test_edit_results.py
+++ b/src/backend/tests/test_edit_results.py
@@ -247,13 +247,12 @@ def test_add_disposition():
         {
             "X0001": {
                 "summary": {"edit_status": "UPDATE"},
-                "charges": {
-                    "X0001-2": {"edit_status": "UPDATE", "disposition": {"date": "1/1/2001", "ruling": "Convicted"}}
-                },
+                "charges": {"X0001-2": {"disposition": {"date": "1/1/2001", "ruling": "Convicted"}}},
             }
         },
     )
     assert record.cases[0].charges[1].disposition.status == DispositionStatus.CONVICTED
+    assert record.cases[0].charges[1].edit_status == EditStatus.UNCHANGED
 
 
 def test_edit_charge_type_of_charge():

--- a/src/backend/tests/test_edit_results.py
+++ b/src/backend/tests/test_edit_results.py
@@ -108,7 +108,7 @@ def test_edit_some_fields_on_case():
         "username",
         "password",
         (),
-        {"X0002": {"action": "edit", "summary": {"location": "ocean", "balance_due": "100", "date": "1/1/1001",}}},
+        {"X0002": {"action": "update", "summary": {"location": "ocean", "balance_due": "100", "date": "1/1/1001",}}},
     )
     assert len(record.cases) == 2
     assert record.cases[0].summary.location == "earth"
@@ -132,7 +132,7 @@ def test_add_disposition():
         (),
         {
             "X0001": {
-                "action": "edit",
+                "action": "update",
                 "charges": {"X0001-2": {"disposition": {"date": "1/1/2001", "ruling": "Convicted"}}},
             }
         },
@@ -146,7 +146,7 @@ def test_edit_charge_type_of_charge():
         "username",
         "password",
         (),
-        {"X0001": {"action": "edit", "charges": {"X0001-2": {"charge_type": "Misdemeanor"}},}},
+        {"X0001": {"action": "update", "charges": {"X0001-2": {"charge_type": "Misdemeanor"}},}},
     )
     assert isinstance(record.cases[0].charges[1].charge_type, Misdemeanor)
 
@@ -159,7 +159,7 @@ def test_add_new_charge():
         (),
         {
             "X0001": {
-                "action": "edit",
+                "action": "update",
                 "charges": {
                     "X0001-3": {
                         "charge_type": "Misdemeanor",

--- a/src/backend/tests/test_edit_results.py
+++ b/src/backend/tests/test_edit_results.py
@@ -172,6 +172,7 @@ def test_add_case():
                 },
                 "charges": {
                     "5-1": {
+                        "edit_status": "ADD",
                         "charge_type": "FelonyClassC",
                         "date": "1/1/2001",
                         "disposition": {"date": "2/1/2020", "ruling": "Convicted"},
@@ -217,7 +218,7 @@ def test_update_case_with_add_and_update_and_delete_charges():
                     },
                     "X0001-2": {"edit_status": "DELETE"},
                     "X0001-3": {
-                        # "edit_status": "ADD",
+                        "edit_status": "ADD",
                         "charge_type": "FelonyClassC",
                         "date": "1/1/1900",
                         "disposition": {"date": "2/1/1910", "ruling": "Convicted"},
@@ -246,7 +247,9 @@ def test_add_disposition():
         {
             "X0001": {
                 "summary": {"edit_status": "UPDATE"},
-                "charges": {"X0001-2": {"disposition": {"date": "1/1/2001", "ruling": "Convicted"}}},
+                "charges": {
+                    "X0001-2": {"edit_status": "UPDATE", "disposition": {"date": "1/1/2001", "ruling": "Convicted"}}
+                },
             }
         },
     )
@@ -259,7 +262,12 @@ def test_edit_charge_type_of_charge():
         "username",
         "password",
         (),
-        {"X0001": {"summary": {"edit_status": "UPDATE"}, "charges": {"X0001-2": {"charge_type": "Misdemeanor"}},}},
+        {
+            "X0001": {
+                "summary": {"edit_status": "UPDATE"},
+                "charges": {"X0001-2": {"edit_status": "UPDATE", "charge_type": "Misdemeanor"}},
+            }
+        },
     )
     assert isinstance(record.cases[0].charges[1].charge_type, Misdemeanor)
 
@@ -275,6 +283,7 @@ def test_add_new_charge():
                 "summary": {"edit_status": "UPDATE"},
                 "charges": {
                     "X0001-3": {
+                        "edit_status": "ADD",
                         "charge_type": "Misdemeanor",
                         "date": "1/1/2001",
                         "disposition": {"date": "2/1/2020", "ruling": "Convicted"},

--- a/src/backend/tests/test_edit_results.py
+++ b/src/backend/tests/test_edit_results.py
@@ -1,13 +1,15 @@
 from typing import List, Any, Callable, Tuple
 from expungeservice.util import DateWithFuture as date
-
+import json
 from expungeservice.models.case import OeciCase, CaseSummary
-from expungeservice.models.charge import OeciCharge
+from expungeservice.models.charge import OeciCharge, EditStatus
 from expungeservice.models.charge_types.misdemeanor import Misdemeanor
+from expungeservice.models.charge_types.felony_class_b import FelonyClassB
 from expungeservice.models.record import Record
 from expungeservice.models.disposition import Disposition, DispositionStatus, DispositionCreator
+from expungeservice.models.expungement_result import ChargeEligibilityStatus, EligibilityStatus
 from expungeservice.record_creator import RecordCreator
-
+from expungeservice.serializer import ExpungeModelEncoder
 
 case_1 = OeciCase(
     CaseSummary(
@@ -21,19 +23,21 @@ case_1 = OeciCase(
         current_status="CLOSED",
         case_detail_link="alink",
         balance_due_in_cents=0,
+        edit_status=EditStatus.UNCHANGED,
     ),
     (
         OeciCharge(
             ambiguous_charge_id="X0001-1",
-            name="manufacturing",
+            name="petty theft",
             statute="100.000",
-            level="Felony Class B",
+            level="Misdemeanor",
             date=date(2000, 1, 1),
             disposition=Disposition(
                 date=date(2001, 1, 1), ruling="Convicted", status=DispositionStatus.CONVICTED, amended=False,
             ),
             probation_revoked=None,
             balance_due_in_cents=0,
+            edit_status=EditStatus.UNCHANGED,
         ),
         OeciCharge(
             ambiguous_charge_id="X0001-2",
@@ -41,9 +45,12 @@ case_1 = OeciCase(
             statute="200.000",
             level="Felony Class C",
             date=date(2001, 1, 1),
-            disposition=DispositionCreator.empty(),
+            disposition=Disposition(
+                date=date(2001, 1, 1), ruling="Convicted", status=DispositionStatus.CONVICTED, amended=False,
+            ),
             probation_revoked=None,
             balance_due_in_cents=0,
+            edit_status=EditStatus.UNCHANGED,
         ),
     ),
 )
@@ -54,34 +61,37 @@ case_2 = OeciCase(
         case_number="X0002",
         citation_number="X0002",
         location="america",
-        date=date(2001, 1, 1),
+        date=date(1981, 1, 1),
         violation_type="Something Else",
         current_status="CLOSED",
         case_detail_link="alink",
         balance_due_in_cents=0,
+        edit_status=EditStatus.UNCHANGED,
     ),
     (
         OeciCharge(
             ambiguous_charge_id="X0002-1",
-            name="driving",
+            name="something class B",
             statute="100.000",
-            level="Misdemeanor",
-            date=date(2000, 1, 1),
+            level="Felony Class B",
+            date=date(1980, 1, 1),
             disposition=Disposition(
-                date=date(2001, 1, 1), ruling="Convicted", status=DispositionStatus.CONVICTED, amended=False,
+                date=date(1981, 1, 1), ruling="Convicted", status=DispositionStatus.CONVICTED, amended=False,
             ),
             probation_revoked=None,
             balance_due_in_cents=0,
+            edit_status=EditStatus.UNCHANGED,
         ),
         OeciCharge(
             ambiguous_charge_id="X0002-2",
             name="assault 3",
             statute="200.000",
             level="Violation",
-            date=date(2001, 1, 1),
+            date=date(1001, 1, 1),
             disposition=DispositionCreator.empty(),
             probation_revoked=None,
             balance_due_in_cents=0,
+            edit_status=EditStatus.UNCHANGED,
         ),
     ),
 )
@@ -99,7 +109,12 @@ def test_no_op():
     record, questions = RecordCreator.build_record(search("two_cases_two_charges_each"), "username", "password", (), {})
     assert len(record.cases) == 2
     assert len(record.cases[0].charges) == 2
-    assert record.cases[0].charges[1].disposition.status == DispositionStatus.UNKNOWN
+    assert record.cases[1].charges[1].ambiguous_charge_id == "X0002-2"
+    assert record.cases[1].charges[1].disposition.status == DispositionStatus.UNKNOWN
+    assert record.cases[1].summary.edit_status == EditStatus.UNCHANGED
+    assert type(record.cases[1].charges[0].charge_type) == FelonyClassB
+    assert record.cases[1].charges[0].expungement_result.charge_eligibility.status == ChargeEligibilityStatus.INELIGIBLE
+    assert record.cases[1].charges[0].expungement_result.time_eligibility.status == EligibilityStatus.INELIGIBLE
 
 
 def test_edit_some_fields_on_case():
@@ -108,20 +123,37 @@ def test_edit_some_fields_on_case():
         "username",
         "password",
         (),
-        {"X0002": {"action": "update", "summary": {"location": "ocean", "balance_due": "100", "date": "1/1/1001",}}},
+        {
+            "X0002": {
+                "summary": {"edit_status": "UPDATE", "location": "ocean", "balance_due": "100", "date": "1/1/1981",}
+            }
+        },
     )
     assert len(record.cases) == 2
     assert record.cases[0].summary.location == "earth"
+    assert record.cases[0].summary.edit_status == EditStatus.UNCHANGED
     assert record.cases[1].summary.location == "ocean"
     assert record.cases[1].summary.balance_due_in_cents == 10000
-    assert record.cases[1].summary.date == date(1001, 1, 1)
+    assert record.cases[1].summary.date == date(1981, 1, 1)
+    assert record.cases[1].summary.edit_status == EditStatus.UPDATE
 
 
 def test_delete_case():
     record, questions = RecordCreator.build_record(
-        search("single_case_two_charges"), "username", "password", (), {"X0001": {"action": "delete"}},
+        search("two_cases_two_charges_each"),
+        "username",
+        "password",
+        (),
+        {"X0001": {"summary": {"edit_status": "DELETE"}}},
     )
-    assert record == Record((), ())
+
+    assert record.cases[0].summary.case_number == "X0001"
+    assert record.cases[0].summary.edit_status == EditStatus.DELETE
+    assert len(record.cases[0].charges) == 2
+    assert record.cases[0].charges[0].edit_status == EditStatus.DELETE
+    assert record.cases[0].charges[1].edit_status == EditStatus.DELETE
+    assert record.cases[1].summary.case_number == "X0002"
+    assert record.cases[1].summary.edit_status == EditStatus.UNCHANGED
 
 
 def test_add_disposition():
@@ -132,7 +164,7 @@ def test_add_disposition():
         (),
         {
             "X0001": {
-                "action": "update",
+                "summary": {"edit_status": "UPDATE"},
                 "charges": {"X0001-2": {"disposition": {"date": "1/1/2001", "ruling": "Convicted"}}},
             }
         },
@@ -146,7 +178,7 @@ def test_edit_charge_type_of_charge():
         "username",
         "password",
         (),
-        {"X0001": {"action": "update", "charges": {"X0001-2": {"charge_type": "Misdemeanor"}},}},
+        {"X0001": {"summary": {"edit_status": "UPDATE"}, "charges": {"X0001-2": {"charge_type": "Misdemeanor"}},}},
     )
     assert isinstance(record.cases[0].charges[1].charge_type, Misdemeanor)
 
@@ -159,7 +191,7 @@ def test_add_new_charge():
         (),
         {
             "X0001": {
-                "action": "update",
+                "summary": {"edit_status": "UPDATE"},
                 "charges": {
                     "X0001-3": {
                         "charge_type": "Misdemeanor",
@@ -172,3 +204,21 @@ def test_add_new_charge():
     )
     assert isinstance(record.cases[0].charges[2].charge_type, Misdemeanor)
     assert record.cases[0].charges[2].date == date(2001, 1, 1)
+
+
+def test_deleted_charge_does_not_block():
+    record, questions = RecordCreator.build_record(
+        search("two_cases_two_charges_each"),
+        "username",
+        "password",
+        (),
+        {"X0001": {"summary": {"edit_status": "DELETE"},}},
+    )
+    assert record.cases[0].summary.case_number == "X0001"
+    assert record.cases[0].summary.edit_status == EditStatus.DELETE
+    assert record.cases[1].summary.case_number == "X0002"
+    assert record.cases[1].summary.edit_status == EditStatus.UNCHANGED
+    assert (
+        record.cases[1].charges[1].expungement_result.charge_eligibility.status
+        == ChargeEligibilityStatus.NEEDS_MORE_ANALYSIS
+    )

--- a/src/backend/tests/test_edit_results.py
+++ b/src/backend/tests/test_edit_results.py
@@ -323,6 +323,7 @@ def test_deleted_charge_does_not_block():
 
 
 # More thoughts on using / testing Edits:
-# If an ambiguous_charge_id isn't recognized, that automatically creates a new charge and the edit_status is automatically ADD.
-# If a new charge is being added, the charge_type must be provided. Otherwise it will just break. there is no check for this.
-# If an ambiguous_charge_id IS recognized, and the edit_status isn't DELETE, it automatically is set to UPDATED.
+# Edits to a case MUST include "case_number": {"summary":{"edit_status":[something]}}. Without the edit_status it will break.
+# Edits to an existing charge don't need to include edit_status. This allows the frontend to edit the disposition (answering a  DispositionQuestion) without adding the UPDATED badge.
+# If an ambiguous_charge_id isn't recognized, its edit_status must be ADD. Otherwise it will break
+# If a new charge is being added, the charge_type must be provided. Otherwise it will break. there is no check for this.

--- a/src/frontend/src/redux/search/reducer.ts
+++ b/src/frontend/src/redux/search/reducer.ts
@@ -145,12 +145,10 @@ export function searchReducer(
       );
       const edits = JSON.parse(JSON.stringify(state.edits));
       edits[action.case_number] = edits[action.case_number] || {
-        action: "edit",
+        summary: { edit_status: "UPDATE" },
       };
       edits[action.case_number]["charges"] =
         edits[action.case_number]["charges"] || {};
-      edits[action.case_number]["charges"][action.ambiguous_charge_id] =
-        edits[action.case_number]["charges"][action.ambiguous_charge_id] || {};
       edits[action.case_number]["charges"][action.ambiguous_charge_id] = edit;
       return {
         ...state,


### PR DESCRIPTION
The `edits` data object supplied in the request must include the `case.summary.edit_status` field to specify whether the action is an `ADD`, `UPDATE`, or `DELETE`, and the `charge.edit_status` is also used to specify the edits made on charges. 

applying ADD to case will assume the contained charges data are all ADDs.
DELETE on a case will apply a DELETE status to all the charges in the case, and ignore other contents of edits data for that case.
UPDATE on a case can contain edits for the case data, as well as ADD, UPDATE, and DELETE edits on the charges on that case.
 