### PR TITLE
Full frontend functionality for Add/Edit case

### DIFF
--- a/src/backend/expungeservice/record_editor.py
+++ b/src/backend/expungeservice/record_editor.py
@@ -93,17 +93,17 @@ class RecordEditor:
     @staticmethod
     def _add_charge(case_number, ambiguous_charge_id, edit) -> Charge:
         charge_dict = RecordEditor._parse_charge_edits(edit)
-        charge_type_string = charge_dict.pop("charge_type", None)
+        charge_type = RecordEditor._get_charge_type(charge_dict.pop("charge_type", None))
         charge_edits_with_defaults = {
+            "name": "",
             **charge_dict,
-            "charge_type": RecordEditor._get_charge_type(charge_type_string),
+            "charge_type": charge_type,
             "ambiguous_charge_id": ambiguous_charge_id,
             "case_number": case_number,
             "id": f"{ambiguous_charge_id}-0",
-            "name": "N/A",
-            "statute": "N/A",
-            "level": "N/A",
-            "type_name": "N/A",
+            "statute": "",
+            "level": "",
+            "type_name": charge_type.type_name,
             "balance_due_in_cents": 0,
             "edit_status": EditStatus.ADD,
         }
@@ -130,7 +130,10 @@ class RecordEditor:
     @staticmethod
     def _get_charge_type(charge_type: str) -> ChargeType:
         charge_types = get_charge_classes()
-        charge_types_dict = {charge_type.__name__: charge_type() for charge_type in charge_types}
+        charge_types_dict = {
+            **{charge_type.__name__: charge_type() for charge_type in charge_types},
+            **{charge_type.type_name: charge_type() for charge_type in charge_types},
+        }
         return charge_types_dict.get(charge_type, UnclassifiedCharge())
 
     @staticmethod

--- a/src/backend/expungeservice/record_editor.py
+++ b/src/backend/expungeservice/record_editor.py
@@ -23,7 +23,7 @@ class RecordEditor:
         for edit_action_case_number, edit in edits.items():
             if edit["summary"]["edit_status"] == EditStatus.ADD:
                 case = OeciCase.empty(case_number=str(edit["summary"]["case_number"]))
-            elif edit["summary"]["edit_status"] in (EditStatus.UPDATE, EditStatus.DELETE):
+            elif edit["summary"]["edit_status"] in (EditStatus.UPDATE, EditStatus.DELETE, EditStatus.UNCHANGED):
                 case = next(
                     (case for case in search_result_cases if case.summary.case_number == edit_action_case_number)
                 )

--- a/src/backend/expungeservice/record_summarizer.py
+++ b/src/backend/expungeservice/record_summarizer.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 from itertools import groupby
 
-from expungeservice.models.charge import Charge
+from expungeservice.models.charge import Charge, EditStatus
 from expungeservice.models.record import QuestionSummary
 from expungeservice.models.record_summary import RecordSummary, CountyBalance
 from typing import Dict, List, Tuple
@@ -31,7 +31,11 @@ class RecordSummarizer:
             visible_charges = [charge for charge in record.charges if not charge.charge_type.hidden_in_record_summary()]
         eligible_charges_by_date: Dict[str, List[Tuple[str, str]]] = {}
         for label, charges in groupby(sorted(visible_charges, key=group), key=group):
-            charges_tuples = [(charge.ambiguous_charge_id, charge.to_one_line()) for charge in charges]
+            charges_tuples = [
+                (charge.ambiguous_charge_id, charge.to_one_line())
+                for charge in charges
+                if charge.edit_status != EditStatus.DELETE
+            ]
             eligible_charges_by_date[label] = charges_tuples
 
         return RecordSummary(

--- a/src/backend/expungeservice/serializer.py
+++ b/src/backend/expungeservice/serializer.py
@@ -39,7 +39,7 @@ class ExpungeModelEncoder(flask.json.JSONEncoder):
     def case_summary_to_json(self, case):
         return {
             "name": case.name,
-            "birth_year": case.birth_year,
+            "birth_year": case.birth_year if case.birth_year else "",
             "case_number": case.case_number,
             "citation_number": case.citation_number,
             "location": case.location,

--- a/src/frontend/src/components/Appendix/index.tsx
+++ b/src/frontend/src/components/Appendix/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Link } from "react-router-dom";
 
 class Landing extends React.Component {
   render() {

--- a/src/frontend/src/components/Faq/index.tsx
+++ b/src/frontend/src/components/Faq/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Link } from "react-router-dom";
 
 class Faq extends React.Component {
   render() {

--- a/src/frontend/src/components/Header/index.tsx
+++ b/src/frontend/src/components/Header/index.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import Logo from "../Logo";
-import history from "../../service/history";
 
 export default class Header extends React.Component {
   public render() {

--- a/src/frontend/src/components/InvalidInputs/index.tsx
+++ b/src/frontend/src/components/InvalidInputs/index.tsx
@@ -12,7 +12,9 @@ export default class InvalidInputs extends React.Component<Props> {
         {this.props.contents.map((content: JSX.Element, i: number) => {
           return (
             this.props.conditions[i] && (
-              <p className="bg-washed-red mv3 pa3 br3 fw6">{content}</p>
+              <p key={i} className="bg-washed-red mv3 pa3 br3 fw6">
+                {content}{" "}
+              </p>
             )
           );
         })}

--- a/src/frontend/src/components/PrivacyPolicy/index.tsx
+++ b/src/frontend/src/components/PrivacyPolicy/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Link } from "react-router-dom";
 
 class PrivacyPolicy extends React.Component {
   render() {

--- a/src/frontend/src/components/RecordSearch/Record/AddButton.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/AddButton.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+interface Props {
+  onClick: Function;
+  actionName: string;
+  text?: string;
+  ariaControls?: string;
+}
+
+export default class AddButton extends React.Component<Props> {
+  render() {
+    return (
+      <button
+        id={this.props.ariaControls + "-add-button"}
+        aria-expanded="false" // This never needs to be true because the button disappears when clicked.
+        aria-controls={this.props.ariaControls}
+        className="tr mid-gray link hover-blue fw6"
+        onClick={() => {
+          this.props.onClick();
+        }}
+      >
+        <span className="fas fa-plus-circle" aria-hidden="true"></span>
+        <span className="visually-hidden">{this.props.actionName}</span>{" "}
+        {this.props.text || ""}
+      </button>
+    );
+  }
+}

--- a/src/frontend/src/components/RecordSearch/Record/AddButton.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/AddButton.tsx
@@ -4,16 +4,12 @@ interface Props {
   onClick: Function;
   actionName: string;
   text?: string;
-  ariaControls?: string;
 }
 
 export default class AddButton extends React.Component<Props> {
   render() {
     return (
       <button
-        id={this.props.ariaControls + "-add-button"}
-        aria-expanded="false" // This never needs to be true because the button disappears when clicked.
-        aria-controls={this.props.ariaControls}
         className="tr mid-gray link hover-blue fw6"
         onClick={() => {
           this.props.onClick();

--- a/src/frontend/src/components/RecordSearch/Record/Case.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Case.tsx
@@ -1,13 +1,75 @@
 import React from "react";
-import { CaseData } from "./types";
+import { CaseData, ChargeData } from "./types";
 import Charges from "./Charges";
+import Charge from "./Charge";
+import EditCasePanel from "./EditCasePanel";
+import EditButton from "./EditButton";
+import AddButton from "./AddButton";
+import EditedBadge from "./EditedBadge";
 import currencyFormat from "../../../service/currency-format";
+import { undoEditCase } from "../../../redux/search/actions";
+import store from "../../../redux/store";
 
 interface Props {
   case: CaseData;
+  showEditButtons: boolean;
+  editing: boolean;
+  isNewCase: boolean;
+  whenEditing: Function;
+  whenDoneEditing: Function;
+  customElementId?: string;
 }
 
-export default class Cases extends React.Component<Props> {
+interface State {
+  editing: Boolean;
+  addingNewCharge: boolean;
+  nextNewChargeNum: number;
+  //nextBlankCharge?: ChargeData;
+}
+export default class Case extends React.Component<Props, State> {
+  createNextBlankCharge = (nextNum: number) => {
+    return {
+      case_number: this.props.case.case_number,
+      ambiguous_charge_id:
+        this.props.case.case_number + "-X" + ("00" + nextNum).slice(-2),
+      statute: "",
+      expungement_result: null,
+      name: "",
+      type_name: "",
+      date: "",
+      disposition: {
+        status: "",
+        ruling: "",
+        date: "",
+      },
+      probation_revoked: "",
+      edit_status: "ADD",
+    };
+  };
+  state: State = {
+    editing: this.props.editing,
+    addingNewCharge: false,
+    nextNewChargeNum: 1,
+  };
+
+  handleCaseEditSubmit = () => {
+    this.setState({
+      editing: false,
+      nextNewChargeNum: this.state.nextNewChargeNum + 1,
+    });
+    this.props.whenDoneEditing();
+  };
+
+  handleUndoEditClick = () => {
+    if (
+      !(this.props.case.edit_status === "ADD") ||
+      window.confirm("This data will be lost. Remove anyway?")
+    ) {
+      store.dispatch(undoEditCase(this.props.case.case_number));
+      this.props.whenDoneEditing();
+    }
+  };
+
   render() {
     const {
       name,
@@ -18,6 +80,7 @@ export default class Cases extends React.Component<Props> {
       charges,
       location,
       current_status,
+      edit_status,
     } = this.props.case;
     const allIneligible = charges.every(
       (charge) =>
@@ -30,40 +93,75 @@ export default class Cases extends React.Component<Props> {
       "https://publicaccess.courts.oregon.gov/PublicAccessLogin/CaseDetail.aspx?CaseID=";
     const link_id = case_detail_link.substring(case_detail_base.length);
     return (
-      <div id={case_number} className="mb3">
+      <div id={this.props.customElementId || case_number} className="mb3">
         <div className="cf pv2 br3 br--top shadow-case">
-          <div className="fl ph3 pv1">
-            <div className="fw7">Case </div>
-            <a
-              href={prefix + "/api/case_detail_page/" + link_id}
-              target="_blank"
-              className="link bb hover-blue"
-            >
-              {case_number}
-            </a>
-          </div>
-          <div className="fl ph3 pv1">
-            <div className="fw7">Status </div>
-            {current_status}
-          </div>
-          <div className="fl ph3 pv1">
-            <div className="fw7">County </div>
-            {location}
-          </div>
-          <div className="fl ph3 pv1">
-            <div className="fw7">Balance </div>
-            {currencyFormat(balance_due)}
-          </div>
-          <div className="fl ph3 pv1">
-            <div className="fw7">Name </div>
-            {name}
-          </div>
-          <div className="fl ph3 pv1">
-            <div className="fw7">DOB </div>
-            {birth_year}
-          </div>
+          {this.props.editing ? null : (
+            <>
+              <div className="fl ph3 pv1">
+                <div className="fw7">Case </div>
+
+                <a
+                  href={prefix + "/api/case_detail_page/" + link_id}
+                  target="_blank"
+                  className="link bb hover-blue"
+                >
+                  {case_number}
+                </a>
+              </div>
+              <div className="fl ph3 pv1">
+                <div className="fw7">Status </div>
+                {current_status}
+              </div>
+              <div className="fl ph3 pv1">
+                <div className="fw7">County </div>
+                {location}
+              </div>
+              <div className="fl ph3 pv1">
+                <div className="fw7">Balance </div>
+                {currencyFormat(balance_due)}
+              </div>
+              <div className="fl ph3 pv1">
+                <div className="fw7">Name </div>
+                {name}
+              </div>
+              <div className="fl ph3 pv1">
+                <div className="fw7">DOB </div>
+                {birth_year}
+              </div>
+            </>
+          )}
+          {edit_status === "UNCHANGED" || this.props.editing ? null : (
+            <EditedBadge
+              editStatus={edit_status}
+              onClick={this.handleUndoEditClick}
+              showEditButtons={this.props.showEditButtons}
+            />
+          )}
+          {this.props.showEditButtons &&
+            (!this.state.addingNewCharge ? (
+              <div className="fl fr-l ph3 pv3">
+                <EditButton
+                  actionName="Edit Case"
+                  onClick={() => {
+                    this.setState({ editing: true });
+                    this.props.whenEditing();
+                  }}
+                  ariaControls={"case-edit-" + this.props.case.case_number}
+                />
+                <AddButton
+                  actionName="Add Charge"
+                  onClick={() => {
+                    this.props.whenEditing();
+                    this.setState({ addingNewCharge: true });
+                  }}
+                  // ariaControls={this.state.nextBlankCharge.ambiguous_charge_id}
+                  // TODO: the thing this button controls is a charge that doesn't exist yet.
+                />
+              </div>
+            ) : null)}
         </div>
-        {balance_due > 0 && !allIneligible ? (
+
+        {balance_due > 0 && !allIneligible && (
           <div className="bg-washed-red fw6 br3 pv2 ph3 ma2">
             Eligible charges are ineligible until balance is paid
             <a
@@ -73,10 +171,45 @@ export default class Cases extends React.Component<Props> {
               Paying Balances
             </a>
           </div>
-        ) : (
-          ""
         )}
-        <Charges charges={charges} />
+        {this.state.editing && (
+          <EditCasePanel
+            whenDoneEditing={this.handleCaseEditSubmit}
+            case={this.props.case}
+            isNewCase={this.props.isNewCase}
+            editStatus={edit_status}
+          />
+        )}
+        {this.state.addingNewCharge && (
+          <div className="bg-gray-blue-2 shadow br3 overflow-auto mb3">
+            <Charge
+              charge={this.createNextBlankCharge(this.state.nextNewChargeNum)}
+              showEditButtons={this.props.showEditButtons}
+              whenEditing={() => {
+                this.props.whenEditing();
+              }}
+              whenDoneEditing={() => {
+                this.props.whenDoneEditing();
+                this.setState({
+                  addingNewCharge: false,
+                  nextNewChargeNum: this.state.nextNewChargeNum + 1,
+                });
+              }}
+              editing={true}
+              isNewCharge={true}
+            />
+          </div>
+        )}
+        <Charges
+          charges={charges}
+          showEditButtons={this.props.showEditButtons}
+          whenEditing={() => {
+            this.props.whenEditing();
+          }}
+          whenDoneEditing={() => {
+            this.props.whenDoneEditing();
+          }}
+        />
       </div>
     );
   }

--- a/src/frontend/src/components/RecordSearch/Record/Case.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Case.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { CaseData, ChargeData } from "./types";
+import { CaseData } from "./types";
 import Charges from "./Charges";
 import Charge from "./Charge";
 import EditCasePanel from "./EditCasePanel";
@@ -153,8 +153,6 @@ export default class Case extends React.Component<Props, State> {
                     this.props.whenEditing();
                     this.setState({ addingNewCharge: true });
                   }}
-                  // ariaControls={this.state.nextBlankCharge.ambiguous_charge_id}
-                  // TODO: the thing this button controls is a charge that doesn't exist yet.
                 />
               </div>
             ) : null)}

--- a/src/frontend/src/components/RecordSearch/Record/Case.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Case.tsx
@@ -145,7 +145,6 @@ export default class Case extends React.Component<Props, State> {
                     this.props.whenEditing();
                     this.setState({ editing: true });
                   }}
-                  ariaControls={"case-edit-" + this.props.case.case_number}
                 />
                 <AddButton
                   actionName="Add Charge"

--- a/src/frontend/src/components/RecordSearch/Record/Case.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Case.tsx
@@ -24,7 +24,6 @@ interface State {
   editing: Boolean;
   addingNewCharge: boolean;
   nextNewChargeNum: number;
-  //nextBlankCharge?: ChargeData;
 }
 export default class Case extends React.Component<Props, State> {
   createNextBlankCharge = (nextNum: number) => {
@@ -53,11 +52,11 @@ export default class Case extends React.Component<Props, State> {
   };
 
   handleCaseEditSubmit = () => {
+    this.props.whenDoneEditing();
     this.setState({
       editing: false,
       nextNewChargeNum: this.state.nextNewChargeNum + 1,
     });
-    this.props.whenDoneEditing();
   };
 
   handleUndoEditClick = () => {
@@ -143,8 +142,8 @@ export default class Case extends React.Component<Props, State> {
                 <EditButton
                   actionName="Edit Case"
                   onClick={() => {
-                    this.setState({ editing: true });
                     this.props.whenEditing();
+                    this.setState({ editing: true });
                   }}
                   ariaControls={"case-edit-" + this.props.case.case_number}
                 />

--- a/src/frontend/src/components/RecordSearch/Record/Cases.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Cases.tsx
@@ -4,6 +4,9 @@ import { CaseData } from "./types";
 
 interface Props {
   cases: CaseData[];
+  showEditButtons: boolean;
+  whenEditing: Function;
+  whenDoneEditing: Function;
 }
 
 export default class Cases extends React.Component<Props> {
@@ -11,7 +14,18 @@ export default class Cases extends React.Component<Props> {
     const allCases = this.props.cases.map((caseInstance, index) => {
       return (
         <li key={index}>
-          <Case case={caseInstance} />
+          <Case
+            case={caseInstance}
+            editing={false}
+            isNewCase={false}
+            showEditButtons={this.props.showEditButtons}
+            whenEditing={() => {
+              this.props.whenEditing();
+            }}
+            whenDoneEditing={() => {
+              this.props.whenDoneEditing();
+            }}
+          />
         </li>
       );
     });

--- a/src/frontend/src/components/RecordSearch/Record/Charge.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Charge.tsx
@@ -43,7 +43,6 @@ export default class Charge extends React.Component<Props, State> {
   render() {
     const {
       edit_status,
-      case_number,
       ambiguous_charge_id,
       date,
       disposition,
@@ -163,9 +162,10 @@ export default class Charge extends React.Component<Props, State> {
           />
         )}
 
-        {this.props.charge.edit_status === "UNCHANGED" && (
-          <Questions ambiguous_charge_id={ambiguous_charge_id} />
-        )}
+        {!this.state.editing &&
+          this.props.charge.edit_status === "UNCHANGED" && (
+            <Questions ambiguous_charge_id={ambiguous_charge_id} />
+          )}
       </div>
     );
   }

--- a/src/frontend/src/components/RecordSearch/Record/Charge.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Charge.tsx
@@ -162,7 +162,10 @@ export default class Charge extends React.Component<Props, State> {
             }}
           />
         )}
-        <Questions ambiguous_charge_id={ambiguous_charge_id} />
+
+        {this.props.charge.edit_status === "UNCHANGED" && (
+          <Questions ambiguous_charge_id={ambiguous_charge_id} />
+        )}
       </div>
     );
   }

--- a/src/frontend/src/components/RecordSearch/Record/Charge.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Charge.tsx
@@ -112,7 +112,7 @@ export default class Charge extends React.Component<Props, State> {
                 showEditButtons={this.props.showEditButtons}
               />
             )}
-            <div className="dib fr-ns ph3 pv3">
+            <div className="dib fr-ns ph2 pv3">
               {this.props.showEditButtons && (
                 <EditButton
                   actionName="Edit Case"

--- a/src/frontend/src/components/RecordSearch/Record/Charge.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Charge.tsx
@@ -2,16 +2,47 @@ import React from "react";
 import Eligibility from "./Eligibility";
 import TimeEligibility from "./TimeEligibility";
 import TypeEligibility from "./TypeEligibility";
+import EditChargePanel from "./EditChargePanel";
+import EditButton from "./EditButton";
+import EditedBadge from "./EditedBadge";
 import Questions from "./Questions";
 import { ChargeData } from "./types";
+import { undoEditCharge } from "../../../redux/search/actions";
+import store from "../../../redux/store";
 
 interface Props {
   charge: ChargeData;
+  editing: boolean;
+  isNewCharge: boolean;
+  showEditButtons: boolean;
+  whenEditing: Function;
+  whenDoneEditing: Function;
 }
+interface State {
+  editing: Boolean;
+}
+export default class Charge extends React.Component<Props, State> {
+  state: State = {
+    editing: this.props.editing,
+  };
 
-export default class Charge extends React.Component<Props> {
+  handleUndoEditClick = () => {
+    if (
+      !(this.props.charge.edit_status === "ADD") ||
+      window.confirm("This data will be lost. Remove anyway?")
+    ) {
+      store.dispatch(
+        undoEditCharge(
+          this.props.charge.case_number,
+          this.props.charge.ambiguous_charge_id
+        )
+      );
+    }
+  };
+
   render() {
     const {
+      edit_status,
       case_number,
       ambiguous_charge_id,
       date,
@@ -67,28 +98,70 @@ export default class Charge extends React.Component<Props> {
 
     return (
       <div className="br3 ma2 bg-white" id={ambiguous_charge_id}>
-        <Eligibility expungement_result={expungement_result} />
-        <div className="flex-l ph3 pb3">
-          <div className="w-100 w-40-l pr3">
-            {buildRecordTime()}
-            <TypeEligibility
-              type_eligibility={expungement_result.type_eligibility}
-              type_name={type_name}
-            />
-          </div>
-          <div className="w-100 w-60-l pr3">
-            <ul className="list">
-              <li className="mb2">
-                <span className="fw7">Charge: </span>
-                {`${statute}-${name}`}
-              </li>
-              {buildDisposition(disposition)}
-              <li className="mb2">
-                <span className="fw7">Charged: </span> {date}
-              </li>
-            </ul>
-          </div>
-        </div>
+        {this.props.isNewCharge ? null : (
+          <>
+            {edit_status !== "DELETE" && (
+              <Eligibility
+                expungement_result={expungement_result}
+                removed={edit_status === "DELETE"}
+              />
+            )}
+            {edit_status !== "UNCHANGED" && (
+              <EditedBadge
+                editStatus={edit_status}
+                onClick={this.handleUndoEditClick}
+                showEditButtons={this.props.showEditButtons}
+              />
+            )}
+            <div className="dib fr-ns ph3 pv3">
+              {this.props.showEditButtons && (
+                <EditButton
+                  actionName="Edit Case"
+                  onClick={() => {
+                    this.props.whenEditing();
+                    this.setState({ editing: true });
+                  }}
+                  ariaControls={"edit-charge-panel-" + ambiguous_charge_id}
+                />
+              )}
+            </div>
+
+            <div className="flex-l ph3 pb3">
+              <div className="w-100 w-40-l pr3">
+                {buildRecordTime()}
+                <TypeEligibility
+                  type_eligibility={expungement_result.type_eligibility}
+                  type_name={type_name}
+                />
+              </div>
+              <div className="w-100 w-60-l pr3">
+                <ul className="list">
+                  <li className="mb2">
+                    <span className="fw7">Charge: </span>
+                    {`${statute}${statute && "-"}${name}`}
+                  </li>
+                  {buildDisposition(disposition)}
+                  <li className="mb2">
+                    <span className="fw7">Charged: </span> {date}
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </>
+        )}
+        {this.state.editing && (
+          <EditChargePanel
+            charge={this.props.charge}
+            isNewCharge={this.props.isNewCharge}
+            whenDoneEditing={() => {
+              this.setState({ editing: false });
+              this.props.whenDoneEditing();
+            }}
+            handleUndoEditClick={() => {
+              this.handleUndoEditClick();
+            }}
+          />
+        )}
         <Questions ambiguous_charge_id={ambiguous_charge_id} />
       </div>
     );

--- a/src/frontend/src/components/RecordSearch/Record/Charge.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Charge.tsx
@@ -120,7 +120,6 @@ export default class Charge extends React.Component<Props, State> {
                     this.props.whenEditing();
                     this.setState({ editing: true });
                   }}
-                  ariaControls={"edit-charge-panel-" + ambiguous_charge_id}
                 />
               )}
             </div>

--- a/src/frontend/src/components/RecordSearch/Record/Charges.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Charges.tsx
@@ -4,6 +4,9 @@ import { ChargeData } from "./types";
 
 interface Props {
   charges: ChargeData[];
+  showEditButtons: boolean;
+  whenEditing: Function;
+  whenDoneEditing: Function;
 }
 
 export default class Charges extends React.Component<Props> {
@@ -11,7 +14,18 @@ export default class Charges extends React.Component<Props> {
     const charges = this.props.charges.map((charge: ChargeData, i) => {
       return (
         <li key={charge.ambiguous_charge_id}>
-          <Charge charge={charge} />
+          <Charge
+            charge={charge}
+            editing={false}
+            isNewCharge={false}
+            showEditButtons={this.props.showEditButtons}
+            whenEditing={() => {
+              this.props.whenEditing();
+            }}
+            whenDoneEditing={() => {
+              this.props.whenDoneEditing();
+            }}
+          />
         </li>
       );
     });

--- a/src/frontend/src/components/RecordSearch/Record/DateField.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/DateField.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+interface Props {
+  fieldLabel: string;
+  onChange: Function;
+  inputId: string;
+  value: string;
+}
+
+export default class DateField extends React.Component<Props> {
+  handleChange = (e: React.BaseSyntheticEvent) => {
+    this.props.onChange(e.target.value);
+  };
+
+  render() {
+    return (
+      <div>
+        <label className="db fw6 mt3 mb1" htmlFor={this.props.inputId}>
+          {this.props.fieldLabel} <span className="f6 fw4">mm/dd/yyyy</span>
+        </label>
+        <input
+          value={this.props.value}
+          onChange={this.handleChange}
+          className="w5 br2 b--black-20 pa3"
+          id={this.props.inputId}
+          type="text"
+          name="conviction_date"
+        />
+      </div>
+    );
+  }
+}

--- a/src/frontend/src/components/RecordSearch/Record/EditButton.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/EditButton.tsx
@@ -3,7 +3,6 @@ import React from "react";
 interface Props {
   onClick: Function;
   actionName: string;
-  ariaControls: string;
 }
 
 export default class EditButton extends React.Component<Props> {
@@ -11,8 +10,6 @@ export default class EditButton extends React.Component<Props> {
     return (
       <button
         className="mid-gray hover-blue ph2"
-        aria-expanded="false" // This is never true because the button disappears when clicked, unless we create it anyway and just make it visually-hidden.
-        aria-controls={this.props.ariaControls}
         onClick={() => {
           this.props.onClick();
         }}

--- a/src/frontend/src/components/RecordSearch/Record/EditButton.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/EditButton.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+interface Props {
+  onClick: Function;
+  actionName: string;
+  ariaControls: string;
+}
+
+export default class EditButton extends React.Component<Props> {
+  render() {
+    return (
+      <button
+        className="mid-gray hover-blue ph2"
+        aria-expanded="false" // This is never true because the button disappears when clicked, unless we create it anyway and just make it visually-hidden.
+        aria-controls={this.props.ariaControls}
+        onClick={() => {
+          this.props.onClick();
+        }}
+      >
+        <span className="visually-hidden">{this.props.actionName}</span>
+        <span aria-hidden="true" className="fas fa-pen"></span>
+      </button>
+    );
+  }
+}

--- a/src/frontend/src/components/RecordSearch/Record/EditCasePanel.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/EditCasePanel.tsx
@@ -1,0 +1,361 @@
+import React from "react";
+import moment from "moment";
+import { CaseData } from "./types";
+import {
+  editCase,
+  deleteCase,
+  undoEditCase,
+} from "../../../redux/search/actions";
+import store from "../../../redux/store";
+import InvalidInputs from "../../InvalidInputs";
+
+interface Props {
+  whenDoneEditing: Function;
+  case: CaseData;
+  isNewCase: boolean;
+  editStatus: string;
+}
+
+interface State {
+  current_status: string;
+  location: string;
+  balance_due: string;
+  birth_year: string;
+  missingStatus: boolean;
+  missingLocation: boolean;
+  missingBalance: boolean;
+  missingBirthYear: boolean;
+  invalidBirthYear: boolean;
+}
+
+const counties = [
+  "Baker",
+  "Benton",
+  "Clackamas",
+  "Clatsop",
+  "Columbia",
+  "Coos",
+  "Crook",
+  "Curry",
+  "Deschutes",
+  "Douglas",
+  "Gilliam",
+  "Grant",
+  "Harney",
+  "Hood River",
+  "Jackson",
+  "Jefferson",
+  "Josephine",
+  "Klamath",
+  "Lake",
+  "Lane",
+  "Lincoln",
+  "Linn",
+  "Malheur",
+  "Marion",
+  "Morrow",
+  "Multnomah",
+  "Polk",
+  "Sherman",
+  "Tillamook",
+  "Umatilla",
+  "Union",
+  "Wallowa",
+  "Wasco",
+  "Washington",
+  "Wheeler",
+  "Yamhill",
+];
+
+export default class EditCasePanel extends React.Component<Props, State> {
+  state: State = {
+    current_status: this.props.case.current_status,
+    location: this.props.case.location,
+    balance_due: this.props.case.balance_due.toFixed(2),
+    birth_year: this.props.case.birth_year.toString(),
+    missingStatus: false,
+    missingLocation: false,
+    missingBalance: false,
+    missingBirthYear: false,
+    invalidBirthYear: false,
+  };
+
+  anyFieldsChanged = () => {
+    return !(
+      this.props.case.current_status === this.state.current_status &&
+      this.props.case.location === this.state.location &&
+      this.props.case.balance_due.toFixed(2) === this.state.balance_due &&
+      this.props.case.birth_year.toString() === this.state.birth_year
+    );
+  };
+
+  handleEditSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!this.anyFieldsChanged()) {
+      this.props.whenDoneEditing();
+      return;
+    }
+    this.validateForm().then(() => {
+      if (
+        !this.state.missingStatus &&
+        !this.state.missingLocation &&
+        !this.state.missingBalance &&
+        !this.state.missingBirthYear &&
+        !this.state.invalidBirthYear
+      ) {
+        this.dispatchEdit();
+        this.props.whenDoneEditing();
+      }
+    });
+  };
+
+  dispatchEdit = () => {
+    store.dispatch(
+      editCase(
+        this.props.isNewCase || this.props.case.edit_status === "ADD"
+          ? "ADD"
+          : "UPDATE",
+        this.props.case.case_number,
+        this.state.current_status,
+        this.state.location,
+        this.state.balance_due,
+        this.state.birth_year
+      )
+    );
+  };
+
+  dispatchDelete = () => {
+    store.dispatch(deleteCase(this.props.case.case_number));
+  };
+
+  handleRemove = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (this.props.editStatus == "ADD") {
+      if (window.confirm("This data will be lost. Remove anyway?")) {
+        store.dispatch(undoEditCase(this.props.case.case_number));
+        this.props.whenDoneEditing();
+      }
+    } else {
+      this.dispatchDelete();
+      this.props.whenDoneEditing();
+    }
+  };
+
+  handleCancel = (e: React.FormEvent) => {
+    e.preventDefault();
+    this.props.whenDoneEditing();
+  };
+
+  handleChange = (e: React.BaseSyntheticEvent) => {
+    this.setState<any>({
+      [e.target.name]: e.target.value,
+    });
+  };
+
+  balancePattern = new RegExp("[0-9]*[.]?[0-9]?[0-9]?");
+  handleBalanceChange = (e: React.BaseSyntheticEvent) => {
+    const parsed = this.balancePattern.exec(e.target.value);
+    this.setState<any>({
+      balance: parsed ? parsed[0] : "",
+    });
+  };
+
+  birthYearPattern = new RegExp("[0-9][0-9]?[0-9]?[0-9]?");
+  handleBirthYearChange = (e: React.BaseSyntheticEvent) => {
+    const parsed = this.birthYearPattern.exec(e.target.value);
+    this.setState<any>({
+      birth_year: parsed ? parsed[0] : "",
+    });
+  };
+
+  validateForm = () => {
+    return new Promise((resolve) => {
+      this.setState(
+        {
+          missingStatus: this.state.current_status.length === 0,
+          missingLocation: this.state.location === "",
+          missingBalance: this.state.balance_due.length === 0,
+          missingBirthYear:
+            this.state.birth_year.length === 0 || this.state.birth_year == "0",
+          invalidBirthYear:
+            this.state.birth_year !== "" &&
+            this.state.birth_year !== "0" &&
+            !moment(this.state.birth_year, "YYYY", true).isValid(),
+        },
+        resolve
+      );
+    });
+  };
+
+  render() {
+    return (
+      <div
+        data-reach-disclosure-panel=""
+        data-state="open"
+        id={"case-edit-" + this.props.case.case_number}
+        tabIndex={-1}
+      >
+        <form className="pa3">
+          {" "}
+          {/* TODO these were in the styling but the mockup doesn't have a border.  bb bw1 b--black-025 */}
+          <fieldset className="mw6 pa0">
+            <legend className="visually-hidden">Edit Case</legend>
+            <fieldset className="mb3 pa0">
+              <legend className="fw7">Current Status</legend>
+              <div className="radio">
+                <div className="dib">
+                  <input
+                    type="radio"
+                    name="current_status"
+                    id={"case_edit_status_open_" + this.props.case.case_number}
+                    value="Open"
+                    checked={this.state.current_status === "Open"}
+                    onChange={this.handleChange}
+                  />
+                  <label
+                    htmlFor={
+                      "case_edit_status_open_" + this.props.case.case_number
+                    }
+                  >
+                    Open
+                  </label>
+                </div>
+                <div className="dib">
+                  <input
+                    type="radio"
+                    name="current_status"
+                    id={
+                      "case_edit_status_closed_" + this.props.case.case_number
+                    }
+                    value="Closed"
+                    checked={this.state.current_status === "Closed"}
+                    onChange={this.handleChange}
+                  />
+                  <label
+                    htmlFor={
+                      "case_edit_status_closed_" + this.props.case.case_number
+                    }
+                  >
+                    Closed
+                  </label>
+                </div>
+              </div>
+            </fieldset>
+            <div className="mw5 mb3">
+              <label
+                htmlFor={"case_edit_location_" + this.props.case.case_number}
+                className="db mb1 fw7"
+              >
+                County
+              </label>
+              <div className="relative mb3">
+                <select
+                  value={this.state.location}
+                  name="location"
+                  id={"case_edit_location_" + this.props.case.case_number}
+                  className="w-100 pa3 br2 bw1 b--black-20 input-reset bg-white"
+                  onChange={this.handleChange}
+                >
+                  <option value="">---</option>
+                  {counties.map((county, index) => {
+                    return (
+                      <option key={index} value={county}>
+                        {county}
+                      </option>
+                    );
+                  })}
+                </select>
+                <div className="absolute pa3 right-0 top-0 bottom-0 pointer-events-none">
+                  <i aria-hidden="true" className="fas fa-angle-down"></i>
+                </div>
+              </div>
+            </div>
+            <div className="mw5 mb3">
+              <label
+                htmlFor={"case_edit_balance_" + this.props.case.case_number}
+                className="db fw7 mb1"
+              >
+                Balance
+              </label>
+              <div className="relative">
+                <div className="absolute top-0 bottom-0 pl3 flex items-center">
+                  <span>$</span>
+                </div>
+                <input
+                  name="balance"
+                  value={this.state.balance_due}
+                  id={"case_edit_balance_" + this.props.case.case_number}
+                  type="text"
+                  className="w-100 br2 b--black-20 pa3 pl4"
+                  required
+                  aria-invalid="false"
+                  onChange={this.handleBalanceChange}
+                />
+              </div>
+            </div>
+            <div className="mw5 mb4">
+              <label
+                htmlFor={"case_edit_birthyear_" + this.props.case.case_number}
+                className="db fw7 mb1"
+              >
+                Birth Year <span className="normal">yyyy</span>
+              </label>
+              <input
+                name="birth_year"
+                value={
+                  this.props.isNewCase && this.state.birth_year == "0"
+                    ? ""
+                    : this.state.birth_year
+                }
+                id={"case_edit_birthyear_" + this.props.case.case_number}
+                type="text"
+                className="w-100 br2 b--black-20 pa3"
+                required
+                aria-invalid="false"
+                onChange={this.handleBirthYearChange}
+              />
+            </div>
+            <div className="flex items-center mb3">
+              <button
+                className="fw6 br2 bg-blue white bg-animate hover-bg-dark-blue pa3 mr4"
+                onClick={this.handleEditSubmit}
+              >
+                {this.props.isNewCase ? "Create Case" : "Update Case"}
+              </button>
+              {this.props.isNewCase ? null : (
+                <button
+                  className="fw6 blue link hover-red mr4"
+                  onClick={this.handleRemove}
+                >
+                  Remove Case
+                </button>
+              )}
+              <button
+                className="fw6 blue link hover-dark-blue mr4"
+                onClick={this.handleCancel}
+              >
+                Cancel
+              </button>
+            </div>
+            <InvalidInputs
+              conditions={[
+                this.state.missingStatus,
+                this.state.missingLocation,
+                this.state.missingBalance,
+                this.state.missingBirthYear,
+                this.state.invalidBirthYear,
+              ]}
+              contents={[
+                <span>Current Status is required</span>,
+                <span>County is required</span>,
+                <span>Balance is required</span>,
+                <span>Birth Year is required</span>,
+                <span>Birth Year format is invalid</span>,
+              ]}
+            />{" "}
+          </fieldset>
+        </form>
+      </div>
+    );
+  }
+}

--- a/src/frontend/src/components/RecordSearch/Record/EditCasePanel.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/EditCasePanel.tsx
@@ -156,7 +156,7 @@ export default class EditCasePanel extends React.Component<Props, State> {
   handleBalanceChange = (e: React.BaseSyntheticEvent) => {
     const parsed = this.balancePattern.exec(e.target.value);
     this.setState<any>({
-      balance: parsed ? parsed[0] : "",
+      balance_due: parsed ? parsed[0] : "",
     });
   };
 

--- a/src/frontend/src/components/RecordSearch/Record/EditCasePanel.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/EditCasePanel.tsx
@@ -201,7 +201,7 @@ export default class EditCasePanel extends React.Component<Props, State> {
           <fieldset className="mw6 pa0">
             <legend className="visually-hidden">Edit Case</legend>
             <fieldset className="mb3 pa0">
-              <legend className="fw7">Current Status</legend>
+              <legend className="fw6">Current Status</legend>
               <div className="radio">
                 <div className="dib">
                   <input
@@ -244,7 +244,7 @@ export default class EditCasePanel extends React.Component<Props, State> {
             <div className="mw5 mb3">
               <label
                 htmlFor={"case_edit_location_" + this.props.case.case_number}
-                className="db mb1 fw7"
+                className="db mb1 fw6"
               >
                 County
               </label>
@@ -273,7 +273,7 @@ export default class EditCasePanel extends React.Component<Props, State> {
             <div className="mw5 mb3">
               <label
                 htmlFor={"case_edit_balance_" + this.props.case.case_number}
-                className="db fw7 mb1"
+                className="db fw6 mb1"
               >
                 Balance
               </label>
@@ -296,7 +296,7 @@ export default class EditCasePanel extends React.Component<Props, State> {
             <div className="mw5 mb4">
               <label
                 htmlFor={"case_edit_birthyear_" + this.props.case.case_number}
-                className="db fw7 mb1"
+                className="db fw6 mb1"
               >
                 Birth Year <span className="normal">yyyy</span>
               </label>

--- a/src/frontend/src/components/RecordSearch/Record/EditCasePanel.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/EditCasePanel.tsx
@@ -130,7 +130,7 @@ export default class EditCasePanel extends React.Component<Props, State> {
 
   handleRemove = (e: React.FormEvent) => {
     e.preventDefault();
-    if (this.props.editStatus == "ADD") {
+    if (this.props.editStatus === "ADD") {
       if (window.confirm("This data will be lost. Remove anyway?")) {
         store.dispatch(undoEditCase(this.props.case.case_number));
         this.props.whenDoneEditing();
@@ -176,7 +176,7 @@ export default class EditCasePanel extends React.Component<Props, State> {
           missingLocation: this.state.location === "",
           missingBalance: this.state.balance_due.length === 0,
           missingBirthYear:
-            this.state.birth_year.length === 0 || this.state.birth_year == "0",
+            this.state.birth_year.length === 0 || this.state.birth_year === "0",
           invalidBirthYear:
             this.state.birth_year !== "" &&
             this.state.birth_year !== "0" &&
@@ -303,7 +303,7 @@ export default class EditCasePanel extends React.Component<Props, State> {
               <input
                 name="birth_year"
                 value={
-                  this.props.isNewCase && this.state.birth_year == "0"
+                  this.props.isNewCase && this.state.birth_year === "0"
                     ? ""
                     : this.state.birth_year
                 }

--- a/src/frontend/src/components/RecordSearch/Record/EditChargePanel.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/EditChargePanel.tsx
@@ -224,7 +224,7 @@ export default class EditChargePanel extends React.Component<Props, State> {
             <legend className="visually-hidden">Edit Charge</legend>
             {/*<div className="mw7 pa3"> */}
             <fieldset className="mb3 pa0">
-              <legend className="fw7">Disposition</legend>
+              <legend className="fw6">Disposition</legend>
               <div className="radio">
                 {["Convicted", "Dismissed", "Probation Revoked", "Missing"].map(
                   (status: string, index: number) => {
@@ -253,36 +253,40 @@ export default class EditChargePanel extends React.Component<Props, State> {
             </fieldset>
             {(this.state.disposition_status === "Convicted" ||
               this.state.disposition_status === "Probation Revoked") && (
-              <DateField
-                fieldLabel="Conviction Date"
-                onChange={(dateVal: string) => {
-                  this.setState({ disposition_date: dateVal });
-                }}
-                inputId={
-                  "edit-dispo-date-" + this.props.charge.ambiguous_charge_id
-                }
-                value={this.state.disposition_date}
-              />
+              <div className="mb3">
+                <DateField
+                  fieldLabel="Conviction Date"
+                  onChange={(dateVal: string) => {
+                    this.setState({ disposition_date: dateVal });
+                  }}
+                  inputId={
+                    "edit-dispo-date-" + this.props.charge.ambiguous_charge_id
+                  }
+                  value={this.state.disposition_date}
+                />
+              </div>
             )}
             {this.state.disposition_status === "Probation Revoked" && (
-              <DateField
-                fieldLabel="Probation Revoked"
-                onChange={(dateVal: string) => {
-                  this.setState({ probation_revoked_date: dateVal });
-                }}
-                inputId={
-                  "edit-probation-revoked-" +
-                  this.props.charge.ambiguous_charge_id
-                }
-                value={this.state.probation_revoked_date}
-              />
+              <div className="mb3">
+                <DateField
+                  fieldLabel="Probation Revoked"
+                  onChange={(dateVal: string) => {
+                    this.setState({ probation_revoked_date: dateVal });
+                  }}
+                  inputId={
+                    "edit-probation-revoked-" +
+                    this.props.charge.ambiguous_charge_id
+                  }
+                  value={this.state.probation_revoked_date}
+                />
+              </div>
             )}
             <div className="mw6 mb3">
               <label
                 htmlFor={
                   this.props.charge.ambiguous_charge_id + "-select-charge-type"
                 }
-                className="db mb1 fw7"
+                className="db mb1 fw6"
               >
                 Charge Type
               </label>
@@ -323,7 +327,7 @@ export default class EditChargePanel extends React.Component<Props, State> {
               </div>
             </div>
             <div className="mw6 mb3">
-              <label htmlFor="charge-name" className="db mb1 fw7">
+              <label htmlFor="charge-name" className="db mb1 fw6">
                 Charge Name <span className="fw3">(Optional)</span>
               </label>
               <div className="relative mb3">
@@ -339,7 +343,7 @@ export default class EditChargePanel extends React.Component<Props, State> {
               </div>
             </div>
             <div className="mw5 mb4">
-              <label htmlFor="date-charged" className="db fw7 mb1">
+              <label htmlFor="date-charged" className="db fw6 mb1">
                 Date Charged <span className="normal">mm/dd/yyyy</span>
               </label>
               <input

--- a/src/frontend/src/components/RecordSearch/Record/EditChargePanel.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/EditChargePanel.tsx
@@ -111,7 +111,9 @@ export default class EditChargePanel extends React.Component<Props, State> {
   dispatchEdit = () => {
     store.dispatch(
       editCharge(
-        this.props.isNewCharge ? "ADD" : "UPDATE",
+        this.props.isNewCharge || this.props.charge.edit_status === "ADD"
+          ? "ADD"
+          : "UPDATE",
         this.props.charge.case_number,
         this.props.charge.ambiguous_charge_id,
         this.state.date,
@@ -157,7 +159,7 @@ export default class EditChargePanel extends React.Component<Props, State> {
       missingProbationRevoked: false,
       invalidProbationRevoked: false,
       disposition_date:
-        e.target.value === "Dismissed"
+        e.target.value === "Dismissed" || e.target.value === "Convicted"
           ? ""
           : shortToMMDDYYYY(this.props.charge.disposition.date),
       probation_revoked_date: "",

--- a/src/frontend/src/components/RecordSearch/Record/EditChargePanel.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/EditChargePanel.tsx
@@ -1,0 +1,393 @@
+import moment from "moment";
+import React from "react";
+import {
+  ChargeData,
+  CHARGE_TYPES,
+  CHARGE_TYPES_CONVICTED_ONLY,
+  CHARGE_TYPES_DISMISSED_ONLY,
+} from "./types";
+import InvalidInputs from "../../InvalidInputs";
+import { editCharge, deleteCharge } from "../../../redux/search/actions";
+import DateField from "./DateField";
+
+import store from "../../../redux/store";
+
+interface Props {
+  charge: ChargeData;
+  isNewCharge: boolean;
+  whenDoneEditing: Function;
+  handleUndoEditClick: Function;
+}
+
+interface State {
+  edit_status: string;
+  date: string;
+  disposition_status: string;
+  disposition_date: string;
+  probation_revoked_date: string;
+  name: string;
+  type_name: string;
+  missingDisposition: boolean;
+  missingType: boolean;
+  missingDate: boolean;
+  invalidDate: boolean;
+  missingDispositionDate: boolean;
+  invalidDispositionDate: boolean;
+  missingProbationRevoked: boolean;
+  invalidProbationRevoked: boolean;
+}
+
+const shortToMMDDYYYY = (shortDate: string) => {
+  if (!shortDate) return "";
+  const date = new Date(Date.parse(shortDate));
+  return (
+    (date.getMonth() + 1).toString() +
+    "/" +
+    date.getDate().toString() +
+    "/" +
+    date.getFullYear().toString()
+  );
+};
+
+export default class EditChargePanel extends React.Component<Props, State> {
+  state: State = {
+    edit_status: this.props.charge.edit_status,
+    date: shortToMMDDYYYY(this.props.charge.date),
+    disposition_status: this.props.charge.disposition.status,
+    disposition_date: shortToMMDDYYYY(this.props.charge.disposition.date),
+    probation_revoked_date: shortToMMDDYYYY(
+      this.props.charge.probation_revoked
+    ),
+    name: this.props.charge.name,
+    type_name: this.props.charge.type_name,
+    missingDate: false,
+    invalidDate: false,
+    missingDisposition: false,
+    missingType: false,
+    missingDispositionDate: false,
+    invalidDispositionDate: false,
+    missingProbationRevoked: false,
+    invalidProbationRevoked: false,
+  };
+
+  anyFieldsChanged = () => {
+    return !(
+      shortToMMDDYYYY(this.props.charge.date) === this.state.date &&
+      shortToMMDDYYYY(this.props.charge.disposition.date) ===
+        this.state.disposition_date &&
+      shortToMMDDYYYY(this.props.charge.probation_revoked) ===
+        this.state.probation_revoked_date &&
+      this.props.charge.disposition.status === this.state.disposition_status &&
+      this.props.charge.name === this.state.name &&
+      this.props.charge.type_name === this.state.type_name
+    );
+  };
+
+  handleEditSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!this.anyFieldsChanged()) {
+      this.props.whenDoneEditing();
+      return;
+    }
+    this.validateForm().then(() => {
+      if (
+        !this.state.missingDisposition &&
+        !this.state.missingType &&
+        !this.state.missingDate &&
+        !this.state.invalidDate &&
+        !this.state.missingDispositionDate &&
+        !this.state.invalidDispositionDate &&
+        !this.state.missingProbationRevoked &&
+        !this.state.invalidProbationRevoked
+      ) {
+        this.dispatchEdit();
+        this.props.whenDoneEditing();
+      }
+    });
+  };
+
+  dispatchEdit = () => {
+    store.dispatch(
+      editCharge(
+        this.props.isNewCharge ? "ADD" : "UPDATE",
+        this.props.charge.case_number,
+        this.props.charge.ambiguous_charge_id,
+        this.state.date,
+        this.state.disposition_status === "Probation Revoked"
+          ? "Convicted"
+          : this.state.disposition_status,
+        this.state.disposition_date,
+        this.state.probation_revoked_date,
+        this.state.type_name,
+        this.state.name
+      )
+    );
+  };
+
+  dispatchDelete = () => {
+    store.dispatch(
+      deleteCharge(
+        this.props.charge.case_number,
+        this.props.charge.ambiguous_charge_id
+      )
+    );
+  };
+
+  handleRemove = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (this.state.edit_status === "ADD") {
+      this.props.handleUndoEditClick();
+    } else {
+      this.dispatchDelete();
+    }
+    this.props.whenDoneEditing();
+  };
+
+  handleCancel = (e: React.FormEvent) => {
+    e.preventDefault();
+    this.props.whenDoneEditing();
+  };
+
+  handleDispositionStatusChange = (e: React.BaseSyntheticEvent) => {
+    this.setState<any>({
+      [e.target.name]: e.target.value,
+      type_name:
+        (e.target.value === "Dismissed" &&
+          CHARGE_TYPES_CONVICTED_ONLY.includes(this.state.type_name)) ||
+        (e.target.value === "Convicted" &&
+          CHARGE_TYPES_DISMISSED_ONLY.includes(this.state.type_name))
+          ? ""
+          : this.state.type_name,
+    });
+  };
+
+  handleChange = (e: React.BaseSyntheticEvent) => {
+    this.setState<any>({
+      [e.target.name]: e.target.value,
+    });
+  };
+
+  validateForm = () => {
+    return new Promise((resolve) => {
+      this.setState(
+        {
+          missingDisposition: this.state.disposition_status === "",
+          missingType: this.state.type_name === "",
+          missingDate: this.state.date === "",
+          invalidDate:
+            this.state.date !== "" &&
+            !moment(this.state.date, "M/D/YYYY", true).isValid(),
+          missingDispositionDate:
+            (this.state.disposition_status === "Convicted" ||
+              this.state.disposition_status === "Probation Revoked") &&
+            this.state.disposition_date === "",
+          invalidDispositionDate:
+            this.state.disposition_date !== "" &&
+            !moment(this.state.disposition_date, "M/D/YYYY", true).isValid(),
+          missingProbationRevoked:
+            this.state.disposition_status === "Probation Revoked" &&
+            this.state.probation_revoked_date === "",
+          invalidProbationRevoked:
+            this.state.probation_revoked_date !== "" &&
+            !moment(
+              this.state.probation_revoked_date,
+              "M/D/YYYY",
+              true
+            ).isValid(),
+        },
+        resolve
+      );
+    });
+  };
+
+  render() {
+    return (
+      <div
+        id={"edit-charge-panel-" + this.props.charge.ambiguous_charge_id}
+        tabIndex={-1}
+      >
+        <form className="pa3" noValidate>
+          <fieldset className="mw7 pa0">
+            <legend className="visually-hidden">Edit Charge</legend>
+            {/*<div className="mw7 pa3"> */}
+            <fieldset className="mb3 pa0">
+              <legend className="fw7">Disposition</legend>
+              <div className="radio">
+                {["Dismissed", "Convicted", "Probation Revoked", "Missing"].map(
+                  (status: string, index: number) => {
+                    const id =
+                      this.props.charge.ambiguous_charge_id + "-edit-" + status;
+                    return (
+                      <div className="dib" key={index}>
+                        <input
+                          type="radio"
+                          name="disposition_status"
+                          defaultChecked={
+                            status === this.state.disposition_status
+                          }
+                          id={id}
+                          value={status}
+                          onChange={this.handleDispositionStatusChange}
+                        />
+                        <label htmlFor={id}>{status}</label>
+                      </div>
+                    );
+                  }
+                )}
+              </div>
+            </fieldset>
+            {(this.state.disposition_status === "Convicted" ||
+              this.state.disposition_status === "Probation Revoked") && (
+              <DateField
+                fieldLabel="Conviction Date"
+                onChange={(dateVal: string) => {
+                  this.setState({ disposition_date: dateVal });
+                }}
+                inputId={
+                  "edit-dispo-date-" + this.props.charge.ambiguous_charge_id
+                }
+                value={this.state.disposition_date}
+              />
+            )}
+            {this.state.disposition_status === "Probation Revoked" && (
+              <DateField
+                fieldLabel="Probation Revoked"
+                onChange={(dateVal: string) => {
+                  this.setState({ probation_revoked_date: dateVal });
+                }}
+                inputId={
+                  "edit-probation-revoked-" +
+                  this.props.charge.ambiguous_charge_id
+                }
+                value={this.state.probation_revoked_date}
+              />
+            )}
+            <div className="mw6 mb3">
+              <label
+                htmlFor={
+                  this.props.charge.ambiguous_charge_id + "-select-charge-type"
+                }
+                className="db mb1 fw7"
+              >
+                Charge Type
+              </label>
+              <div className="relative mb3">
+                <select
+                  id={
+                    this.props.charge.ambiguous_charge_id +
+                    "-select-charge-type"
+                  }
+                  value={this.state.type_name}
+                  name="type_name"
+                  onChange={this.handleChange}
+                  className="w-100 pa3 br2 bw1 b--black-20 input-reset bg-white"
+                  required
+                  aria-invalid="false"
+                >
+                  <option value="" disabled>
+                    Select...
+                  </option>
+                  {CHARGE_TYPES.map((type_name) => (
+                    <option
+                      value={type_name}
+                      disabled={
+                        (this.state.disposition_status === "Dismissed" &&
+                          CHARGE_TYPES_CONVICTED_ONLY.includes(type_name)) ||
+                        (["Convicted", "Probation Revoked"].includes(
+                          this.state.disposition_status
+                        ) &&
+                          CHARGE_TYPES_DISMISSED_ONLY.includes(type_name))
+                      }
+                    >
+                      {type_name}
+                    </option>
+                  ))}
+                </select>
+                <div className="absolute pa3 right-0 top-0 bottom-0 pointer-events-none">
+                  <i aria-hidden="true" className="fas fa-angle-down"></i>
+                </div>
+              </div>
+            </div>
+            <div className="mw6 mb3">
+              <label htmlFor="charge-name" className="db mb1 fw7">
+                Charge Name <span className="fw3">(Optional)</span>
+              </label>
+              <div className="relative mb3">
+                <input
+                  id="name"
+                  className="w-100 br2 b--black-20 pa3"
+                  value={this.state.name}
+                  name="name"
+                  required
+                  aria-invalid="false"
+                  onChange={this.handleChange}
+                />
+                <div className="absolute pa3 right-0 top-0 bottom-0 pointer-events-none">
+                  <i aria-hidden="true" className="fas fa-angle-down"></i>
+                </div>
+              </div>
+            </div>
+            <div className="mw5 mb4">
+              <label htmlFor="date-charged" className="db fw7 mb1">
+                Date Charged <span className="normal">mm/dd/yyyy</span>
+              </label>
+              <input
+                id="date-charged"
+                name="date"
+                value={this.state.date}
+                onChange={this.handleChange}
+                className="w-100 br2 b--black-20 pa3"
+                required
+                aria-invalid="false"
+              />
+            </div>
+            <div className="flex items-center mb3">
+              <button
+                className="fw6 br2 bg-blue white bg-animate hover-bg-dark-blue pa3 mr4"
+                onClick={this.handleEditSubmit}
+              >
+                {this.props.isNewCharge ? "Add Charge" : "Update Charge"}
+              </button>
+              {this.props.isNewCharge ? null : (
+                <button
+                  className="fw6 blue link hover-red mr4"
+                  onClick={this.handleRemove}
+                >
+                  Remove Charge
+                </button>
+              )}
+              <button
+                className="fw6 blue link hover-dark-blue mr4"
+                onClick={this.handleCancel}
+              >
+                Cancel
+              </button>
+            </div>
+            <InvalidInputs
+              conditions={[
+                this.state.missingType,
+                this.state.missingDate,
+                this.state.invalidDate,
+                this.state.missingDisposition,
+                this.state.missingDispositionDate,
+                this.state.invalidDispositionDate,
+                this.state.missingProbationRevoked,
+                this.state.invalidProbationRevoked,
+              ]}
+              contents={[
+                <span>Charge Type is required</span>,
+                <span>Date Charged is required</span>,
+                <span>Date Charged format is invalid</span>,
+                <span>Disposition is required</span>,
+                <span>Disposition date is required</span>,
+                <span>Disposition date format is invalid</span>,
+                <span>Probation Revoked date is required</span>,
+                <span>Probation Revoked date format is invalid</span>,
+              ]}
+            />{" "}
+          </fieldset>
+        </form>
+      </div>
+    );
+  }
+}

--- a/src/frontend/src/components/RecordSearch/Record/EditChargePanel.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/EditChargePanel.tsx
@@ -38,7 +38,7 @@ interface State {
 }
 
 const shortToMMDDYYYY = (shortDate: string) => {
-  if (!shortDate) return "";
+  if (!shortDate || Date.parse(shortDate) === NaN) return "";
   const date = new Date(Date.parse(shortDate));
   return (
     (date.getMonth() + 1).toString() +

--- a/src/frontend/src/components/RecordSearch/Record/EditChargePanel.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/EditChargePanel.tsx
@@ -59,7 +59,9 @@ export default class EditChargePanel extends React.Component<Props, State> {
       this.props.charge.probation_revoked
     ),
     name: this.props.charge.name,
-    type_name: this.props.charge.type_name,
+    type_name: CHARGE_TYPES.includes(this.props.charge.type_name)
+      ? this.props.charge.type_name
+      : "",
     missingDate: false,
     invalidDate: false,
     missingDisposition: false,
@@ -150,6 +152,15 @@ export default class EditChargePanel extends React.Component<Props, State> {
 
   handleDispositionStatusChange = (e: React.BaseSyntheticEvent) => {
     this.setState<any>({
+      missingDispositionDate: false,
+      invalidDispositionDate: false,
+      missingProbationRevoked: false,
+      invalidProbationRevoked: false,
+      disposition_date:
+        e.target.value === "Dismissed"
+          ? ""
+          : shortToMMDDYYYY(this.props.charge.disposition.date),
+      probation_revoked_date: "",
       [e.target.name]: e.target.value,
       type_name:
         (e.target.value === "Dismissed" &&
@@ -213,7 +224,7 @@ export default class EditChargePanel extends React.Component<Props, State> {
             <fieldset className="mb3 pa0">
               <legend className="fw7">Disposition</legend>
               <div className="radio">
-                {["Dismissed", "Convicted", "Probation Revoked", "Missing"].map(
+                {["Convicted", "Dismissed", "Probation Revoked", "Missing"].map(
                   (status: string, index: number) => {
                     const id =
                       this.props.charge.ambiguous_charge_id + "-edit-" + status;
@@ -229,7 +240,9 @@ export default class EditChargePanel extends React.Component<Props, State> {
                           value={status}
                           onChange={this.handleDispositionStatusChange}
                         />
-                        <label htmlFor={id}>{status}</label>
+                        <label htmlFor={id}>
+                          {status === "Missing" ? "Unknown" : status}
+                        </label>
                       </div>
                     );
                   }
@@ -284,12 +297,11 @@ export default class EditChargePanel extends React.Component<Props, State> {
                   required
                   aria-invalid="false"
                 >
-                  <option value="" disabled>
-                    Select...
-                  </option>
-                  {CHARGE_TYPES.map((type_name) => (
+                  <option value="">Select...</option>
+                  {CHARGE_TYPES.map((type_name, i) => (
                     <option
                       value={type_name}
+                      key={i}
                       disabled={
                         (this.state.disposition_status === "Dismissed" &&
                           CHARGE_TYPES_CONVICTED_ONLY.includes(type_name)) ||
@@ -322,9 +334,6 @@ export default class EditChargePanel extends React.Component<Props, State> {
                   aria-invalid="false"
                   onChange={this.handleChange}
                 />
-                <div className="absolute pa3 right-0 top-0 bottom-0 pointer-events-none">
-                  <i aria-hidden="true" className="fas fa-angle-down"></i>
-                </div>
               </div>
             </div>
             <div className="mw5 mb4">

--- a/src/frontend/src/components/RecordSearch/Record/EditedBadge.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/EditedBadge.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+
+interface Props {
+  editStatus: string;
+  onClick: Function;
+  showEditButtons: boolean;
+}
+
+export default class EditedBadge extends React.Component<Props> {
+  render() {
+    return (
+      <div className="inline-flex bs2-inset-gray bg-white fw6 br3 ma2  ">
+        <span className="mid-gray bs2-r-gray pa2">
+          {this.props.editStatus === "UPDATE"
+            ? "Edited"
+            : this.props.editStatus === "ADD"
+            ? "Manual"
+            : this.props.editStatus === "DELETE"
+            ? "Removed"
+            : null}
+        </span>
+        {this.props.showEditButtons ? (
+          <button
+            className="mid-gray link hover-blue pa2"
+            onClick={() => {
+              this.props.onClick();
+            }}
+          >
+            <span className="visually-hidden">Undo edits</span>
+            <span className="fas fa-undo f6" aria-hidden="true"></span>
+          </button>
+        ) : (
+          <div className="ph3" />
+        )}
+      </div>
+    );
+  }
+}

--- a/src/frontend/src/components/RecordSearch/Record/Eligibility.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Eligibility.tsx
@@ -3,6 +3,7 @@ import { ExpungementResultData } from "./types";
 
 interface Props {
   expungement_result: ExpungementResultData;
+  removed: boolean;
 }
 
 export default class Eligibility extends React.Component<Props> {

--- a/src/frontend/src/components/RecordSearch/Record/Questions.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Questions.tsx
@@ -43,7 +43,7 @@ function Questions(props: Props) {
       return (
         <div className="w-100 bl bw3 b--light-purple pa3 pb1">
           {renderQuestions(question_summary.root, selectFunction)}
-          {props.loading == props.question_summary.ambiguous_charge_id ? (
+          {props.loading === props.question_summary.ambiguous_charge_id ? (
             <div className="radio-spinner" role="status">
               <span className="spinner spinner--sm mr1"></span>
               <span className="f6 fw5">Updating&#8230;</span>
@@ -87,9 +87,11 @@ function Questions(props: Props) {
   ): any {
     return Object.entries(question.options).map(
       ([answer, answerData]: [string, AnswerData]) => {
-        if (question.selection === answer && answerData.question) {
-          return renderQuestions(answerData.question, selectFunction);
-        }
+        return (
+          question.selection === answer &&
+          answerData.question &&
+          renderQuestions(answerData.question, selectFunction)
+        );
       }
     );
   }
@@ -98,17 +100,14 @@ function Questions(props: Props) {
 }
 
 function mapStateToProps(state: AppState, ownProps: Props) {
-  if (
-    state.search.questions &&
-    state.search.questions[ownProps.ambiguous_charge_id]
-  ) {
-    const question_summary =
-      state.search.questions[ownProps.ambiguous_charge_id];
-    return {
-      question_summary: question_summary,
-      loading: state.search.loading,
-    };
-  }
+  const question_summary =
+    (state.search.questions &&
+      state.search.questions[ownProps.ambiguous_charge_id]) ||
+    undefined;
+  return {
+    question_summary: question_summary,
+    loading: state.search.loading,
+  };
 }
 
 export default connect(mapStateToProps, {

--- a/src/frontend/src/components/RecordSearch/Record/Questions.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Questions.tsx
@@ -105,7 +105,7 @@ function mapStateToProps(state: AppState, ownProps: Props) {
       state.search.questions[ownProps.ambiguous_charge_id]) ||
     undefined;
   return {
-    question_summary: question_summary,
+    question_summary,
     loading: state.search.loading,
   };
 }

--- a/src/frontend/src/components/RecordSearch/Record/index.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/index.tsx
@@ -175,6 +175,6 @@ const mapStateToProps = (state: AppState) => {
 };
 
 export default connect(mapStateToProps, {
-  startEditing: startEditing,
-  doneEditing: doneEditing,
+  startEditing,
+  doneEditing,
 })(Record);

--- a/src/frontend/src/components/RecordSearch/Record/index.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/index.tsx
@@ -47,6 +47,7 @@ class Record extends React.Component<Props, State> {
   }
 
   handleAddCaseClick = () => {
+    this.props.startEditing();
     this.setState({
       addingNewCase: true,
     });

--- a/src/frontend/src/components/RecordSearch/Record/index.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/index.tsx
@@ -1,27 +1,31 @@
 import React from "react";
+import { connect } from "react-redux";
 import Cases from "./Cases";
 import Case from "./Case";
 import RecordSummary from "./RecordSummary";
 import { RecordData, CaseData } from "./types";
 import AddButton from "./AddButton";
+import { startEditing, doneEditing } from "../../../redux/search/actions";
+import { AppState } from "../../../redux/store";
 
 interface Props {
   record?: RecordData;
+  editingRecord: boolean;
+  startEditing: Function;
+  doneEditing: Function;
 }
 
 interface State {
   enableEditing: boolean;
-  editingRecord: boolean;
   addingNewCase: boolean;
   blankCase?: CaseData;
   nextNewCaseNum: number;
 }
 
-export default class Record extends React.Component<Props, State> {
+class Record extends React.Component<Props, State> {
   state: State = {
     enableEditing: false,
     addingNewCase: false,
-    editingRecord: false,
     nextNewCaseNum: 1,
   };
 
@@ -45,7 +49,6 @@ export default class Record extends React.Component<Props, State> {
   handleAddCaseClick = () => {
     this.setState({
       addingNewCase: true,
-      editingRecord: true,
     });
   };
 
@@ -101,12 +104,12 @@ export default class Record extends React.Component<Props, State> {
             <div className="bg-gray-blue-2 shadow br3 overflow-auto mb3">
               <Case
                 whenEditing={() => {
-                  this.setState({ editingRecord: true });
+                  this.props.startEditing();
                 }}
                 whenDoneEditing={() => {
+                  this.props.doneEditing();
                   this.setState({
                     addingNewCase: false,
-                    editingRecord: false,
                     nextNewCaseNum: this.state.nextNewCaseNum + 1,
                   });
                 }}
@@ -114,7 +117,7 @@ export default class Record extends React.Component<Props, State> {
                 editing={true}
                 isNewCase={true}
                 showEditButtons={
-                  !this.state.editingRecord && this.state.enableEditing
+                  !this.props.editingRecord && this.state.enableEditing
                 }
                 customElementId="new-case"
               />
@@ -122,7 +125,7 @@ export default class Record extends React.Component<Props, State> {
           )}
           <div className="tr">
             {this.state.enableEditing ? (
-              !this.state.editingRecord && (
+              !this.props.editingRecord && (
                 <>
                   <AddButton
                     onClick={this.handleAddCaseClick}
@@ -149,13 +152,13 @@ export default class Record extends React.Component<Props, State> {
             <Cases
               cases={this.props.record.cases}
               showEditButtons={
-                !this.state.editingRecord && this.state.enableEditing
+                !this.props.editingRecord && this.state.enableEditing
               }
               whenEditing={() => {
-                this.setState({ editingRecord: true });
+                this.props.startEditing();
               }}
               whenDoneEditing={() => {
-                this.setState({ editingRecord: false });
+                this.props.doneEditing();
               }}
             />
           )}
@@ -164,3 +167,14 @@ export default class Record extends React.Component<Props, State> {
     );
   }
 }
+
+const mapStateToProps = (state: AppState) => {
+  return {
+    editingRecord: state.search.editingRecord,
+  };
+};
+
+export default connect(mapStateToProps, {
+  startEditing: startEditing,
+  doneEditing: doneEditing,
+})(Record);

--- a/src/frontend/src/components/RecordSearch/Record/index.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/index.tsx
@@ -1,60 +1,164 @@
 import React from "react";
 import Cases from "./Cases";
+import Case from "./Case";
 import RecordSummary from "./RecordSummary";
-import { RecordData } from "./types";
+import { RecordData, CaseData } from "./types";
+import AddButton from "./AddButton";
 
 interface Props {
-  record: RecordData;
+  record?: RecordData;
 }
 
-export default class Record extends React.Component<Props> {
-  render() {
-    const errors = this.props.record.errors
-      ? this.props.record.errors.map(
-          (errorMessage: string, errorIndex: number) => {
-            const id = "record_error_" + errorIndex;
+interface State {
+  enableEditing: boolean;
+  editingRecord: boolean;
+  addingNewCase: boolean;
+  blankCase?: CaseData;
+  nextNewCaseNum: number;
+}
 
-            const errorMessageArray = errorMessage.split(/(\[.*?\])/g);
-            const errorMessageHTML = errorMessageArray.map(function (element) {
-              if (element.match(/^\[.*\]$/)) {
-                const caseNumber = element.slice(1, -1);
-                return (
-                  <a
-                    className="underline"
-                    href={"#" + caseNumber}
-                    key={caseNumber}
-                  >
-                    {caseNumber}
-                  </a>
-                );
-              } else {
-                return element;
-              }
-            });
-            return (
-              <p
-                role="status"
-                id={id}
-                key={id}
-                className="bg-washed-red mv3 pa3 br3 fw6"
-              >
-                {errorMessageHTML}
-              </p>
-            );
-          }
-        )
-      : null;
+export default class Record extends React.Component<Props, State> {
+  state: State = {
+    enableEditing: false,
+    addingNewCase: false,
+    editingRecord: false,
+    nextNewCaseNum: 1,
+  };
+
+  createNextBlankCase(): CaseData {
+    return {
+      balance_due: 0,
+      birth_year: 0,
+      case_detail_link: "",
+      case_number: "CASE-" + ("000" + this.state.nextNewCaseNum).slice(-4),
+      charges: [],
+      citation_number: "",
+      current_status: "",
+      date: "",
+      location: "",
+      name: "",
+      violation_type: "",
+      edit_status: "ADD",
+    };
+  }
+
+  handleAddCaseClick = () => {
+    this.setState({
+      addingNewCase: true,
+      editingRecord: true,
+    });
+  };
+
+  render() {
+    const errors =
+      this.props.record && this.props.record.errors
+        ? this.props.record.errors.map(
+            (errorMessage: string, errorIndex: number) => {
+              const id = "record_error_" + errorIndex;
+
+              const errorMessageArray = errorMessage.split(/(\[.*?\])/g);
+              const errorMessageHTML = errorMessageArray.map(function (
+                element
+              ) {
+                if (element.match(/^\[.*\]$/)) {
+                  const caseNumber = element.slice(1, -1);
+                  return (
+                    <a
+                      className="underline"
+                      href={"#" + caseNumber}
+                      key={caseNumber}
+                    >
+                      {caseNumber}
+                    </a>
+                  );
+                } else {
+                  return element;
+                }
+              });
+              return (
+                <p
+                  role="status"
+                  id={id}
+                  key={id}
+                  className="bg-washed-red mv3 pa3 br3 fw6"
+                >
+                  {errorMessageHTML}
+                </p>
+              );
+            }
+          )
+        : null;
 
     return (
       <>
         {errors}
         <section>
-          {this.props.record.summary ? (
+          {this.props.record && this.props.record.summary && (
             <RecordSummary summary={this.props.record.summary} />
-          ) : null}
-          {this.props.record.cases ? (
-            <Cases cases={this.props.record.cases} />
-          ) : null}
+          )}
+
+          {this.state.addingNewCase && (
+            <div className="bg-gray-blue-2 shadow br3 overflow-auto mb3">
+              <Case
+                whenEditing={() => {
+                  this.setState({ editingRecord: true });
+                }}
+                whenDoneEditing={() => {
+                  this.setState({
+                    addingNewCase: false,
+                    editingRecord: false,
+                    nextNewCaseNum: this.state.nextNewCaseNum + 1,
+                  });
+                }}
+                case={this.createNextBlankCase()}
+                editing={true}
+                isNewCase={true}
+                showEditButtons={
+                  !this.state.editingRecord && this.state.enableEditing
+                }
+                customElementId="new-case"
+              />
+            </div>
+          )}
+          <div className="tr">
+            {this.state.enableEditing ? (
+              !this.state.editingRecord && (
+                <>
+                  <AddButton
+                    onClick={this.handleAddCaseClick}
+                    actionName={"Add"}
+                    text={"Case"}
+                    ariaControls="new-case"
+                  />
+                  <div className="pb3" />
+                </>
+              )
+            ) : (
+              <button
+                className="inline-flex bs2-inset-gray bg-white fw6 br3 mb2  "
+                onClick={() => {
+                  this.setState({ enableEditing: true });
+                }}
+              >
+                <span className="mid-gray bs2-r-gray pa2">Enable Editing</span>
+              </button>
+            )}
+          </div>
+
+          {this.props.record && this.props.record.cases && (
+            <Cases
+              cases={this.props.record.cases}
+              showEditButtons={
+                !this.state.editingRecord && this.state.enableEditing
+              }
+              whenEditing={() => {
+                this.setState({ editingRecord: true });
+              }}
+              whenDoneEditing={() => {
+                this.setState({ editingRecord: false });
+              }}
+            />
+          )}
         </section>
       </>
     );

--- a/src/frontend/src/components/RecordSearch/Record/index.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/index.tsx
@@ -132,7 +132,6 @@ class Record extends React.Component<Props, State> {
                     onClick={this.handleAddCaseClick}
                     actionName={"Add"}
                     text={"Case"}
-                    ariaControls="new-case"
                   />
                   <div className="pb3" />
                 </>

--- a/src/frontend/src/components/RecordSearch/Record/index.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/index.tsx
@@ -138,12 +138,12 @@ class Record extends React.Component<Props, State> {
               )
             ) : (
               <button
-                className="inline-flex bs2-inset-gray bg-white fw6 br3 mb2  "
+                className="inline-flex bg-white f6 fw5 br2 ba b--black-10 mid-gray link hover-blue pv1 ph2 mb3"
                 onClick={() => {
                   this.setState({ enableEditing: true });
                 }}
               >
-                <span className="mid-gray bs2-r-gray pa2">Enable Editing</span>
+                Enable Editing
               </button>
             )}
           </div>

--- a/src/frontend/src/components/RecordSearch/Record/types.ts
+++ b/src/frontend/src/components/RecordSearch/Record/types.ts
@@ -7,9 +7,12 @@ export interface ChargeData {
   type_name: string;
   date: string;
   disposition: {
+    status: string;
     ruling: string;
     date: string;
   };
+  probation_revoked: string;
+  edit_status: string;
 }
 
 export interface CaseData {
@@ -20,6 +23,7 @@ export interface CaseData {
   charges: ChargeData[];
   citation_number: string;
   current_status: string;
+  edit_status: string;
   date: string;
   location: string;
   name: string;
@@ -92,3 +96,56 @@ export interface AnswerData {
   question?: QuestionData;
   edit?: { [key: string]: string };
 }
+
+export const CHARGE_TYPES = [
+  "Civil Offense",
+  "Criminal Forfeiture",
+  "Dismissed Criminal Charge",
+  "DUII",
+  "Diverted DUII",
+  "FareViolation",
+  "Felony Class A",
+  "Felony Class B",
+  "Felony Class C",
+  "Juvenile",
+  "Marijuana Eligible",
+  "Marijuana Eligible (Below age 21)",
+  "Marijuana Violation",
+  "Marijuana Ineligible",
+  "Misdemeanor",
+  "Parking Ticket",
+  "Person Felony Class B",
+  "Reduced to Violation",
+  "Severe Charge",
+  "Sex Crime",
+  "137.225(6)(f) related sex crime",
+  "137.225(6)(f) related sex crime",
+  "Subsection 6",
+  "Traffic Offense",
+  "Traffic Violation",
+  "Unclassified",
+  "Violation",
+];
+
+export const CHARGE_TYPES_CONVICTED_ONLY = [
+  "Felony Class A",
+  "Felony Class B",
+  "Felony Class C",
+  "DUII",
+  "Marijuana Eligible",
+  "Marijuana Eligible (Below age 21)",
+  "Marijuana Ineligible",
+  "Misdemeanor",
+  "Person Felony Class B",
+  "Severe Charge",
+  "Sex Crime",
+  "137.225(6)(f) related sex crime",
+  "137.225(6)(f) related sex crime",
+  "Subsection 6",
+  "Traffic Offense",
+];
+
+export const CHARGE_TYPES_DISMISSED_ONLY = [
+  "Dismissed Criminal Charge",
+  "Diverted DUII",
+];

--- a/src/frontend/src/components/RecordSearch/index.tsx
+++ b/src/frontend/src/components/RecordSearch/index.tsx
@@ -1,18 +1,19 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { AppState } from "../../redux/store";
-import { RecordData } from "./Record/types";
+import store from "../../redux/store";
+import { RecordData, CaseData } from "./Record/types";
 import { searchRecord, clearRecord } from "../../redux/search/actions";
 import SearchPanel from "./SearchPanel";
 import Record from "./Record";
 import Status from "./Status";
 import { checkOeciRedirect } from "../../service/cookie-service";
 
-type Props = {
+interface Props {
   searchRecord: Function;
   clearRecord: Function;
   record?: RecordData;
-};
+}
 
 class RecordSearch extends Component<Props> {
   componentDidMount() {
@@ -28,13 +29,8 @@ class RecordSearch extends Component<Props> {
       <>
         <main className="mw8 center ph2">
           <SearchPanel searchRecord={this.props.searchRecord} />
-          {this.props.record &&
-          ((this.props.record.cases && this.props.record.cases.length > 0) ||
-            this.props.record.errors) ? (
-            <Record record={this.props.record} />
-          ) : (
-            <Status />
-          )}
+          <Record record={this.props.record} />
+          <Status />
           <div className="bg-white shadow mt4 mb6 pa4 br3">
             <h2 className="fw6 mb3">Assumptions</h2>
             <p className="mb3">

--- a/src/frontend/src/components/RecordSearch/index.tsx
+++ b/src/frontend/src/components/RecordSearch/index.tsx
@@ -1,8 +1,7 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { AppState } from "../../redux/store";
-import store from "../../redux/store";
-import { RecordData, CaseData } from "./Record/types";
+import { RecordData } from "./Record/types";
 import { searchRecord, clearRecord } from "../../redux/search/actions";
 import SearchPanel from "./SearchPanel";
 import Record from "./Record";

--- a/src/frontend/src/redux/search/actions.ts
+++ b/src/frontend/src/redux/search/actions.ts
@@ -18,6 +18,8 @@ import {
   EDIT_CHARGE,
   DELETE_CHARGE,
   UNDO_EDIT_CHARGE,
+  START_EDITING,
+  DONE_EDITING,
 } from "./types";
 import { AliasData } from "../../components/RecordSearch/SearchPanel/types";
 import { RecordData } from "../../components/RecordSearch/Record/types";
@@ -235,5 +237,17 @@ export function undoEditCharge(
       ambiguous_charge_id: ambiguous_charge_id,
     });
     return buildAndSendSearchRequest(dispatch);
+  };
+}
+
+export function startEditing() {
+  return {
+    type: START_EDITING,
+  };
+}
+
+export function doneEditing() {
+  return {
+    type: DONE_EDITING,
   };
 }

--- a/src/frontend/src/redux/search/actions.ts
+++ b/src/frontend/src/redux/search/actions.ts
@@ -155,12 +155,12 @@ export function editCase(
   return (dispatch: Dispatch) => {
     dispatch({
       type: EDIT_CASE,
-      edit_status: edit_status,
-      case_number: case_number,
-      status: status,
-      county: county,
-      balance: balance,
-      birth_year: birth_year,
+      edit_status,
+      case_number,
+      status,
+      county,
+      balance,
+      birth_year,
     });
     return buildAndSendSearchRequest(dispatch);
   };
@@ -170,7 +170,7 @@ export function deleteCase(case_number: string) {
   return (dispatch: Dispatch) => {
     dispatch({
       type: DELETE_CASE,
-      case_number: case_number,
+      case_number,
     });
     return buildAndSendSearchRequest(dispatch);
   };
@@ -180,7 +180,7 @@ export function undoEditCase(case_number: string) {
   return (dispatch: Dispatch) => {
     dispatch({
       type: UNDO_EDIT_CASE,
-      case_number: case_number,
+      case_number,
     });
     return buildAndSendSearchRequest(dispatch);
   };
@@ -200,16 +200,16 @@ export function editCharge(
   return (dispatch: Dispatch) => {
     dispatch({
       type: EDIT_CHARGE,
-      edit_status: edit_status,
-      case_number: case_number,
-      ambiguous_charge_id: ambiguous_charge_id,
-      charge_date: charge_date,
-      ruling: ruling,
+      edit_status,
+      case_number,
+      ambiguous_charge_id,
+      charge_date,
+      ruling,
       disposition_date:
         disposition_date === "" ? charge_date : disposition_date,
-      probation_revoked_date: probation_revoked_date,
-      charge_type: charge_type,
-      charge_name: charge_name,
+      probation_revoked_date,
+      charge_type,
+      charge_name,
     });
     return buildAndSendSearchRequest(dispatch);
   };
@@ -219,8 +219,8 @@ export function deleteCharge(case_number: string, ambiguous_charge_id: string) {
   return (dispatch: Dispatch) => {
     dispatch({
       type: DELETE_CHARGE,
-      case_number: case_number,
-      ambiguous_charge_id: ambiguous_charge_id,
+      case_number,
+      ambiguous_charge_id,
     });
     return buildAndSendSearchRequest(dispatch);
   };
@@ -233,8 +233,8 @@ export function undoEditCharge(
   return (dispatch: Dispatch) => {
     dispatch({
       type: UNDO_EDIT_CHARGE,
-      case_number: case_number,
-      ambiguous_charge_id: ambiguous_charge_id,
+      case_number,
+      ambiguous_charge_id,
     });
     return buildAndSendSearchRequest(dispatch);
   };

--- a/src/frontend/src/redux/search/actions.ts
+++ b/src/frontend/src/redux/search/actions.ts
@@ -12,6 +12,12 @@ import {
   SELECT_ANSWER,
   LOADING_PDF,
   LOADING_PDF_COMPLETE,
+  EDIT_CASE,
+  DELETE_CASE,
+  UNDO_EDIT_CASE,
+  EDIT_CHARGE,
+  DELETE_CHARGE,
+  UNDO_EDIT_CHARGE,
 } from "./types";
 import { AliasData } from "../../components/RecordSearch/SearchPanel/types";
 import { RecordData } from "../../components/RecordSearch/Record/types";
@@ -131,6 +137,102 @@ export function selectAnswer(
       edit: edit,
       date: date,
       probation_revoked_date: probation_revoked_date,
+    });
+    return buildAndSendSearchRequest(dispatch);
+  };
+}
+
+export function editCase(
+  edit_status: string,
+  case_number: string,
+  status: string,
+  county: string,
+  balance: string,
+  birth_year: string
+): any {
+  return (dispatch: Dispatch) => {
+    dispatch({
+      type: EDIT_CASE,
+      edit_status: edit_status,
+      case_number: case_number,
+      status: status,
+      county: county,
+      balance: balance,
+      birth_year: birth_year,
+    });
+    return buildAndSendSearchRequest(dispatch);
+  };
+}
+
+export function deleteCase(case_number: string) {
+  return (dispatch: Dispatch) => {
+    dispatch({
+      type: DELETE_CASE,
+      case_number: case_number,
+    });
+    return buildAndSendSearchRequest(dispatch);
+  };
+}
+
+export function undoEditCase(case_number: string) {
+  return (dispatch: Dispatch) => {
+    dispatch({
+      type: UNDO_EDIT_CASE,
+      case_number: case_number,
+    });
+    return buildAndSendSearchRequest(dispatch);
+  };
+}
+
+export function editCharge(
+  edit_status: string,
+  case_number: string,
+  ambiguous_charge_id: string,
+  charge_date: string,
+  ruling: string,
+  disposition_date: string,
+  probation_revoked_date: string,
+  charge_type: string,
+  charge_name: string
+): any {
+  return (dispatch: Dispatch) => {
+    dispatch({
+      type: EDIT_CHARGE,
+      edit_status: edit_status,
+      case_number: case_number,
+      ambiguous_charge_id: ambiguous_charge_id,
+      charge_date: charge_date,
+      ruling: ruling,
+      disposition_date:
+        disposition_date === "" ? charge_date : disposition_date,
+      probation_revoked_date: probation_revoked_date,
+      charge_type: charge_type,
+      charge_name: charge_name,
+    });
+    return buildAndSendSearchRequest(dispatch);
+  };
+}
+
+export function deleteCharge(case_number: string, ambiguous_charge_id: string) {
+  return (dispatch: Dispatch) => {
+    dispatch({
+      type: DELETE_CHARGE,
+      case_number: case_number,
+      ambiguous_charge_id: ambiguous_charge_id,
+    });
+    return buildAndSendSearchRequest(dispatch);
+  };
+}
+
+export function undoEditCharge(
+  case_number: string,
+  ambiguous_charge_id: string
+) {
+  return (dispatch: Dispatch) => {
+    dispatch({
+      type: UNDO_EDIT_CHARGE,
+      case_number: case_number,
+      ambiguous_charge_id: ambiguous_charge_id,
     });
     return buildAndSendSearchRequest(dispatch);
   };

--- a/src/frontend/src/redux/search/reducer.ts
+++ b/src/frontend/src/redux/search/reducer.ts
@@ -248,7 +248,7 @@ export function searchReducer(
       const filtered_edits = Object.keys(edits)
         .filter((key) => action.case_number !== key)
         .reduce((res: any, key) => ((res[key] = edits[key]), res), {});
-      if (editsFromQuestions) {
+      if (editsFromQuestions && Object.keys(editsFromQuestions).length > 0) {
         filtered_edits[action.case_number] = {
           summary: { edit_status: "UNCHANGED" },
           charges: editsFromQuestions,

--- a/src/frontend/src/redux/search/reducer.ts
+++ b/src/frontend/src/redux/search/reducer.ts
@@ -5,6 +5,12 @@ import {
   SELECT_ANSWER,
   LOADING_PDF,
   LOADING_PDF_COMPLETE,
+  EDIT_CASE,
+  DELETE_CASE,
+  EDIT_CHARGE,
+  DELETE_CHARGE,
+  UNDO_EDIT_CASE,
+  UNDO_EDIT_CHARGE,
   SearchRecordState,
   SearchRecordActionType,
 } from "./types";
@@ -170,6 +176,154 @@ export function searchReducer(
         ...state,
         loadingPdf: false,
       };
+
+    case EDIT_CASE: {
+      const edits = JSON.parse(JSON.stringify(state.edits));
+      if (!edits[action.case_number]) {
+        edits[action.case_number] = {};
+      } // This check lets edits merge and not overwrite each other (e.g. AnswerDisposition vs EditCase)
+      edits[action.case_number]["summary"] = {
+        case_number: action.case_number,
+        current_status: action.status,
+        location: action.county,
+        balance_due: action.balance,
+        birth_year: action.birth_year,
+        edit_status: action.edit_status,
+      };
+      return {
+        ...state,
+        edits: edits,
+        loading: "edit",
+      };
+    }
+
+    case DELETE_CASE: {
+      const edits = JSON.parse(JSON.stringify(state.edits));
+      edits[action.case_number] = { summary: { edit_status: "DELETE" } };
+      return { ...state, edits: edits, loading: "edit" };
+    }
+
+    case UNDO_EDIT_CASE: {
+      const edits = JSON.parse(JSON.stringify(state.edits));
+      const filtered_edits = Object.keys(edits)
+        .filter((key) => action.case_number !== key)
+        .reduce((res: any, key) => ((res[key] = edits[key]), res), {});
+      return { ...state, edits: filtered_edits };
+    }
+
+    case EDIT_CHARGE: {
+      const edits = JSON.parse(JSON.stringify(state.edits));
+      if (!edits[action.case_number]) {
+        edits[action.case_number] = {
+          summary: { edit_status: "UPDATE" },
+        };
+      }
+      if (!edits[action.case_number]["charges"]) {
+        edits[action.case_number]["charges"] = {};
+      }
+      edits[action.case_number]["charges"][action.ambiguous_charge_id] = {
+        edit_status: action.edit_status,
+        date: action.charge_date,
+        disposition: {
+          ruling: action.ruling,
+          date: action.disposition_date,
+        },
+        probation_revoked: action.probation_revoked_date,
+        charge_type: action.charge_type,
+        name: action.charge_name,
+      };
+      return {
+        ...state,
+        edits: edits,
+        loading: "edit",
+      };
+    }
+
+    case DELETE_CHARGE: {
+      const edits = JSON.parse(JSON.stringify(state.edits));
+      if (!edits[action.case_number]) {
+        edits[action.case_number] = { summary: { edit_status: "UPDATE" } };
+      } // This check lets edits merge and not overwrite each other (e.g. AnswerDisposition vs EditCase)
+      //edits[action.case_number]["summary"]["edit_status"] = "UPDATE";
+      if (!edits[action.case_number]["charges"]) {
+        edits[action.case_number]["charges"] = {};
+      }
+      edits[action.case_number]["charges"][action.ambiguous_charge_id] = {
+        edit_status: "DELETE",
+      };
+      return { ...state, edits: edits };
+    }
+
+    case UNDO_EDIT_CHARGE: {
+      {
+        let edits = JSON.parse(JSON.stringify(state.edits));
+        if (edits[action.case_number]["summary"]["edit_status"] == "DELETE") {
+          const ambiguous_charge_ids_on_case =
+            state && state.record && state.record.cases
+              ? state.record.cases
+                  .filter(
+                    (caseData) => caseData.case_number === action.case_number
+                  )[0]
+                  ["charges"].map(
+                    (caseData: any) => caseData.ambiguous_charge_id
+                  )
+              : [];
+          if (ambiguous_charge_ids_on_case.length === 1) {
+            /*Undo only deleted charge on case means undo the deleted case.*/
+            edits = Object.keys(edits)
+              .filter((key) => action.case_number !== key)
+              .reduce((res: any, key) => ((res[key] = edits[key]), res), {});
+            return { ...state, edits: edits };
+          } else {
+            /*Undo deleted charge on a deleted case that has other charges means
+          we must mark the other charges as deleted.*/
+            const delete_charge_edits = ambiguous_charge_ids_on_case
+              .filter((val: string) => val !== action.ambiguous_charge_id)
+              .reduce(
+                (res: any, key: string) => (
+                  (res[key] = { edit_status: "DELETE" }), res
+                ),
+                {}
+              );
+            edits[action.case_number]["summary"]["edit_status"] = "UPDATE";
+            edits[action.case_number]["charges"] = delete_charge_edits;
+            return { ...state, edits: edits };
+          }
+        } else {
+          /* The case edit status is "ADD" or "UPDATE" */
+          /* This charge update gets filtered out; otherwise the edit on that case
+        is unchanged. */
+
+          /* Todo: if the case status is UPDATE,
+          and the undo reverts the last charge edit,
+          and there are no other updates to the case summary, then remove the case edit entry entirely.*/
+          if (
+            Object.keys(edits[action.case_number]["summary"]).length === 1 &&
+            Object.keys(edits[action.case_number]["charges"]).length === 1
+          ) {
+            edits = Object.keys(edits)
+              .filter((key) => action.case_number !== key)
+              .reduce((res: any, key) => ((res[key] = edits[key]), res), {});
+            return { ...state, edits: edits };
+          }
+
+          /* otherwise just remove the charge edit and leave the rest intact.*/
+          const filtered_charge_edits = Object.keys(
+            edits[action.case_number]["charges"]
+          )
+            .filter((key) => key !== action.ambiguous_charge_id)
+            .reduce(
+              (res: any, key) => (
+                (res[key] = edits[action.case_number]["charges"][key]), res
+              ),
+              {}
+            );
+          //edits[action.case_number] ["summary"]["edit_status"] = "UPDATE";
+          edits[action.case_number]["charges"] = filtered_charge_edits;
+          return { ...state, edits: edits };
+        }
+      }
+    }
     default:
       return state;
   }

--- a/src/frontend/src/redux/search/reducer.ts
+++ b/src/frontend/src/redux/search/reducer.ts
@@ -378,7 +378,7 @@ export function searchReducer(
             edits[action.case_number]["charges"] = filtered_charge_edits;
           }
         }
-        return { ...state, edits: edits };
+        return { ...state, edits };
       }
     }
     case START_EDITING: {

--- a/src/frontend/src/redux/search/types.ts
+++ b/src/frontend/src/redux/search/types.ts
@@ -29,6 +29,8 @@ export const UNDO_EDIT_CASE = "UNDO_EDIT_CASE";
 export const EDIT_CHARGE = "EDIT_CHARGE";
 export const DELETE_CHARGE = "DELETE_CHARGE";
 export const UNDO_EDIT_CHARGE = "UNDO_EDIT_CHARGE";
+export const START_EDITING = "START_EDITING";
+export const DONE_EDITING = "DONE_EDITING";
 
 export interface SearchRecordState {
   loading: string;
@@ -37,6 +39,7 @@ export interface SearchRecordState {
   record?: RecordData;
   questions?: QuestionsData;
   edits?: any;
+  editingRecord: boolean;
 }
 
 interface SearchRecordAction {
@@ -107,6 +110,14 @@ interface UndoEditChargeAction {
   ambiguous_charge_id: string;
 }
 
+interface StartEditingAction {
+  type: typeof START_EDITING;
+}
+
+interface DoneEditingAction {
+  type: typeof DONE_EDITING;
+}
+
 export type SearchRecordActionType =
   | SearchRecordAction
   | QuestionsAction
@@ -115,4 +126,6 @@ export type SearchRecordActionType =
   | UndoEditCaseAction
   | EditChargeAction
   | DeleteChargeAction
-  | UndoEditChargeAction;
+  | UndoEditChargeAction
+  | StartEditingAction
+  | DoneEditingAction;

--- a/src/frontend/src/redux/search/types.ts
+++ b/src/frontend/src/redux/search/types.ts
@@ -23,6 +23,12 @@ export const CLEAR_RECORD = "CLEAR_RECORD";
 export const SELECT_ANSWER = "SELECT_ANSWER";
 export const LOADING_PDF = "LOADING_PDF";
 export const LOADING_PDF_COMPLETE = "LOADING_PDF_COMPLETE";
+export const EDIT_CASE = "EDIT_CASE";
+export const DELETE_CASE = "DELETE_CASE";
+export const UNDO_EDIT_CASE = "UNDO_EDIT_CASE";
+export const EDIT_CHARGE = "EDIT_CHARGE";
+export const DELETE_CHARGE = "DELETE_CHARGE";
+export const UNDO_EDIT_CHARGE = "UNDO_EDIT_CHARGE";
 
 export interface SearchRecordState {
   loading: string;
@@ -56,4 +62,57 @@ export interface QuestionsAction {
   probation_revoked_date: string;
 }
 
-export type SearchRecordActionType = SearchRecordAction | QuestionsAction;
+interface EditCaseAction {
+  type: typeof EDIT_CASE;
+  edit_status: string;
+  case_number: string;
+  status: string;
+  county: string;
+  balance: string;
+  birth_year: string;
+}
+
+interface DeleteCaseAction {
+  type: typeof DELETE_CASE;
+  case_number: string;
+}
+
+interface UndoEditCaseAction {
+  type: typeof UNDO_EDIT_CASE;
+  case_number: string;
+}
+
+interface EditChargeAction {
+  type: typeof EDIT_CHARGE;
+  edit_status: string;
+  case_number: string;
+  ambiguous_charge_id: string;
+  charge_date: string;
+  ruling: string;
+  disposition_date: string;
+  probation_revoked_date: string;
+  charge_type: string;
+  charge_name: string;
+}
+
+interface DeleteChargeAction {
+  type: typeof DELETE_CHARGE;
+  case_number: string;
+  ambiguous_charge_id: string;
+}
+
+interface UndoEditChargeAction {
+  type: typeof UNDO_EDIT_CHARGE;
+  case_number: string;
+  ambiguous_charge_id: string;
+}
+
+export type SearchRecordActionType =
+  | SearchRecordAction
+  | QuestionsAction
+  | EditCaseAction
+  | DeleteCaseAction
+  | UndoEditCaseAction
+  | EditChargeAction
+  | DeleteChargeAction
+  | UndoEditChargeAction;

--- a/src/frontend/src/styles/_globals.scss
+++ b/src/frontend/src/styles/_globals.scss
@@ -391,3 +391,10 @@ $lightest-blue2: #e8f2ff;
   position: relative;
   top: 4px;
 }
+
+.bs2-inset-gray {
+  box-shadow: inset 0px 0px 0px 2px #eeeeee;
+}
+.bs2-r-gray {
+  box-shadow: 2px 0px 0px 0px #eeeeee;
+}


### PR DESCRIPTION
Everything works correctly as far as I can tell!
update: located and fixed a few more bugs, detailed in 2nd commit message

I included an "Enable Editing" button, because all the add/edit buttons might unuseful to the user and distracting. 

I'm making this a feature branch in case because there's a fair amount more work to do. Feel free to PR to it, if there's anything bigger than some in-line suggestions.

This is a big feature and my logic doesn't feel amazingly robust, so there's possibly some bugs I missed. I searched pretty hard though. 

Some of the space styling gets a bit hacky like using the occasional empty div e.g. `<div className="pb3"/>` in `Record/index.tsx` line 133. There's probably some cleanup that can happen here.

@hmarcks I'm not really sure about the use of `aria-controls` and `aria-expanded` for the edit and add buttons: when one of the buttons is clicked, it disappears and the edit panel gets rendered. so `aria-controls` is always `false` , and the element that `aria-expanded` could point to never exists at the same time as the button. How should we handle this?

If it's important, I think this could be refactored to use a `Disclosure` as you suggested. I didn't jump at it because I thought it could be a tad complicated to use for both the add and edit actions -- clicking Add Case creates an entire new case element and then also the edit panel within it; whereas Edit just summons the edit panel. It's doable, so it might be worth it.

Comment on backend changes:

Selecting Charge Types by name requires having the full list of types, so I decided to hard-code the list in the frontend. That means we'll have to edit manually as our types change, which is a maintenance hassle. The alternative is to pull the list from the backend. This is something we COULD do, especially as part of the feature in #797 to show a full page of charge types documentation. 

Also I don't think there's a reasonable way to programmatically determine which types can only have one disposition of Convicted/Dismissed, so I hard-coded that info as well.

Comment on redux: It's a mess. The amount of different case-handling is pretty big, and I tried to cover everything I could think of.
Same thing with all the the different possible edit-submit states.

@KentShikama I saw you were doing some `useState()` stuff in the Disposition Questions feature that I didn't really get a handle on, but maybe that's a possble way to clean some stuff up?

