### PR TITLE
icon moves above connecting line

### DIFF
--- a/src/frontend/src/components/RecordSearch/Record/TimeEligibility.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/TimeEligibility.tsx
@@ -13,7 +13,7 @@ export default class TimeEligibility extends React.Component<Props> {
       <div className="relative mb3 connect connect-time">
         <i
           aria-hidden="true"
-          className="absolute fas fa-check-circle green"
+          className="absolute fas fa-check-circle green bg-white z-1"
         ></i>
         <div className="ml3 pl1">
           <span className="fw7">Time</span> Eligible Now


### PR DESCRIPTION
Small bug fix, moved checkmark icon above connecting line:

<img width="368" alt="Screen Shot 2020-07-05 at 12 46 55 PM" src="https://user-images.githubusercontent.com/6887982/86538903-a0db1f00-bebe-11ea-96ef-3c490e937867.png">
