### PR TITLE
Replaced diamond with OR in record_merger and tests.

### DIFF
--- a/src/backend/expungeservice/models/charge_types/duii.py
+++ b/src/backend/expungeservice/models/charge_types/duii.py
@@ -21,7 +21,7 @@ Therefore, to determine whether a dismissal is eligible, ask the client whether 
             raise ValueError("Dismissed criminal charges should have been caught by another class.")
         elif ChargeUtil.convicted(disposition):
             return TypeEligibility(
-                EligibilityStatus.INELIGIBLE, reason="137.225(7)(a) - Traffic offenses are ineligible"
+                EligibilityStatus.INELIGIBLE, reason="Traffic offenses are ineligible under 137.225(7)(a)"
             )
 
 
@@ -31,4 +31,4 @@ class DivertedDuii(ChargeType):
     expungement_rules = "A DUII dismissal resulting from completion of diversion is ineligible under ORS 137.225(8)(b)."
 
     def type_eligibility(self, disposition):
-        return TypeEligibility(EligibilityStatus.INELIGIBLE, reason="137.225(8)(b) - Diverted DUIIs are ineligible",)
+        return TypeEligibility(EligibilityStatus.INELIGIBLE, reason="Ineligible under 137.225(8)(b)",)

--- a/src/backend/expungeservice/models/charge_types/misdemeanor.py
+++ b/src/backend/expungeservice/models/charge_types/misdemeanor.py
@@ -21,5 +21,5 @@ Dismissals for misdemeanors are generally eligible under ORS 137.225(1)(b). Exce
         else:
             return TypeEligibility(
                 EligibilityStatus.ELIGIBLE,
-                reason="Misdemeanors are always eligible under 137.225(5)(b) for convictions, or 137.225(1)(b) for dismissals",
+                reason="Always eligible under 137.225(5)(b) for convictions, or 137.225(1)(b) for dismissals",
             )

--- a/src/backend/expungeservice/record_merger.py
+++ b/src/backend/expungeservice/record_merger.py
@@ -68,7 +68,7 @@ class RecordMerger:
                     time_eligibility=merged_time_eligibility,
                     charge_eligibility=charge_eligibility,
                 )
-                merged_type_name = " ⬥ ".join(
+                merged_type_name = " OR ".join(
                     list(unique_everseen([charge.charge_type.type_name for charge in same_charges]))
                 )
                 merged_charge_type = replace(charge.charge_type, type_name=merged_type_name)
@@ -87,8 +87,11 @@ class RecordMerger:
     @staticmethod
     def merge_type_eligibilities(same_charges: List[Charge]) -> TypeEligibility:
         status = RecordMerger.compute_type_eligibility_status(same_charges)
-        reasons = [charge.type_eligibility.reason for charge in same_charges]
-        reason = " ⬥ ".join(list(unique_everseen(reasons)))
+        reasons = [
+            c.charge_type.type_name + " – " + c.type_eligibility.reason
+            for c in list(unique_everseen(same_charges, lambda c: c.charge_type.type_name))
+        ]
+        reason = " OR ".join(reasons)
         return TypeEligibility(status=status, reason=reason)
 
     @staticmethod
@@ -105,7 +108,7 @@ class RecordMerger:
         if time_eligibilities:
             status = RecordMerger.compute_time_eligibility_status(time_eligibilities)
             reasons = [time_eligibility.reason for time_eligibility in time_eligibilities]
-            reason = " ⬥ ".join(list(unique_everseen(reasons)))
+            reason = " OR ".join(list(unique_everseen(reasons)))
             date_will_be_eligible = time_eligibilities[0].date_will_be_eligible
             if len(set([time_eligibility.date_will_be_eligible for time_eligibility in time_eligibilities])) == 1:
                 unique_date = True

--- a/src/backend/tests/models/charge_types/test_felony_unclassified.py
+++ b/src/backend/tests/models/charge_types/test_felony_unclassified.py
@@ -15,7 +15,7 @@ def test_felony_unclassified_charge():
     assert type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert (
         type_eligibility.reason
-        == "Ineligible by omission from statute ⬥ Convictions that fulfill the conditions of 137.225(5)(a) are eligible ⬥ Eligible under 137.225(5)(b)"
+        == "Felony Class A – Ineligible by omission from statute OR Felony Class B – Convictions that fulfill the conditions of 137.225(5)(a) are eligible OR Felony Class C – Eligible under 137.225(5)(b)"
     )
 
 

--- a/src/backend/tests/models/charge_types/test_manufacture_delivery.py
+++ b/src/backend/tests/models/charge_types/test_manufacture_delivery.py
@@ -12,7 +12,9 @@ def test_manufacture_delivery_dismissed():
     type_eligibility = RecordMerger.merge_type_eligibilities(charges)
 
     assert type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert type_eligibility.reason == "Dismissals are generally eligible under 137.225(1)(b)"
+    assert (
+        type_eligibility.reason == "Dismissed Criminal Charge – Dismissals are generally eligible under 137.225(1)(b)"
+    )
 
 
 def test_manufacture_delivery_missing_disposition():
@@ -24,7 +26,7 @@ def test_manufacture_delivery_missing_disposition():
     assert type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert (
         type_eligibility.reason
-        == "Always eligible under 137.226 (for convictions) or 137.225(1)(b) (for dismissals) ⬥ Disposition not found. Needs further analysis"
+        == "Marijuana Eligible – Always eligible under 137.226 (for convictions) or 137.225(1)(b) (for dismissals) OR Felony Class A – Disposition not found. Needs further analysis"
     )
 
 
@@ -40,7 +42,7 @@ def test_manufacture_delivery_unrecognized_disposition():
     assert type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert (
         type_eligibility.reason
-        == "Always eligible under 137.226 (for convictions) or 137.225(1)(b) (for dismissals) ⬥ Disposition not recognized. Needs further analysis"
+        == "Marijuana Eligible – Always eligible under 137.226 (for convictions) or 137.225(1)(b) (for dismissals) OR Felony Class B – Disposition not recognized. Needs further analysis"
     )
 
 
@@ -51,7 +53,10 @@ def test_manufacture_delivery_manudel():
     type_eligibility = RecordMerger.merge_type_eligibilities(charges)
 
     assert type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert type_eligibility.reason == "Eligible under 137.226 ⬥ Ineligible by omission from statute"
+    assert (
+        type_eligibility.reason
+        == "Marijuana Eligible – Eligible under 137.226 OR Felony Class A – Ineligible by omission from statute"
+    )
 
 
 def test_manufacture_delivery_manudel_felony_unclassified():
@@ -66,7 +71,7 @@ def test_manufacture_delivery_manudel_felony_unclassified():
     assert type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert (
         type_eligibility.reason
-        == "Eligible under 137.226 ⬥ Ineligible by omission from statute ⬥ Convictions that fulfill the conditions of 137.225(5)(a) are eligible ⬥ Eligible under 137.225(5)(b)"
+        == "Marijuana Eligible – Eligible under 137.226 OR Felony Class A – Ineligible by omission from statute OR Felony Class B – Convictions that fulfill the conditions of 137.225(5)(a) are eligible OR Felony Class C – Eligible under 137.225(5)(b)"
     )
 
 
@@ -77,7 +82,7 @@ def test_manufacture_delivery_manudel_felony_c():
     type_eligibility = RecordMerger.merge_type_eligibilities(charges)
 
     assert type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert type_eligibility.reason == "Eligible under 137.225(5)(b)"
+    assert type_eligibility.reason == "Felony Class C – Eligible under 137.225(5)(b)"
 
 
 def test_manufacture_delivery_manufacturing_name():
@@ -92,7 +97,7 @@ def test_manufacture_delivery_manufacturing_name():
     assert type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert (
         type_eligibility.reason
-        == "Eligible under 137.226 ⬥ Ineligible by omission from statute ⬥ Convictions that fulfill the conditions of 137.225(5)(a) are eligible ⬥ Eligible under 137.225(5)(b)"
+        == "Marijuana Eligible – Eligible under 137.226 OR Felony Class A – Ineligible by omission from statute OR Felony Class B – Convictions that fulfill the conditions of 137.225(5)(a) are eligible OR Felony Class C – Eligible under 137.225(5)(b)"
     )
 
 
@@ -108,7 +113,7 @@ def test_manufacture_delivery_2():
     assert type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert (
         type_eligibility.reason
-        == "Ineligible by omission from statute ⬥ Convictions that fulfill the conditions of 137.225(5)(a) are eligible"
+        == "Felony Class A – Ineligible by omission from statute OR Felony Class B – Convictions that fulfill the conditions of 137.225(5)(a) are eligible"
     )
 
 
@@ -124,7 +129,7 @@ def test_manufacture_delivery_heroin():
     assert type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert (
         type_eligibility.reason
-        == "Ineligible by omission from statute ⬥ Convictions that fulfill the conditions of 137.225(5)(a) are eligible"
+        == "Felony Class A – Ineligible by omission from statute OR Felony Class B – Convictions that fulfill the conditions of 137.225(5)(a) are eligible"
     )
 
 
@@ -137,7 +142,7 @@ def test_pcs():
     assert type_eligibility.status is EligibilityStatus.ELIGIBLE
     assert (
         type_eligibility.reason
-        == "Eligible under 137.226 ⬥ Convictions that fulfill the conditions of 137.225(5)(a) are eligible"
+        == "Marijuana Eligible – Eligible under 137.226 OR Felony Class B – Convictions that fulfill the conditions of 137.225(5)(a) are eligible"
     )
 
 
@@ -153,7 +158,7 @@ def test_pcs_heroin():
     assert type_eligibility.status is EligibilityStatus.ELIGIBLE
     assert (
         type_eligibility.reason
-        == "Convictions that fulfill the conditions of 137.225(5)(a) are eligible ⬥ Eligible under 137.225(5)(b)"
+        == "Felony Class B – Convictions that fulfill the conditions of 137.225(5)(a) are eligible OR Felony Class C – Eligible under 137.225(5)(b)"
     )
 
 
@@ -164,4 +169,4 @@ def test_pcs_class_c():
     type_eligibility = RecordMerger.merge_type_eligibilities(charges)
 
     assert type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert type_eligibility.reason == "Eligible under 137.225(5)(b)"
+    assert type_eligibility.reason == "Felony Class C – Eligible under 137.225(5)(b)"

--- a/src/backend/tests/models/charge_types/test_midemeanor.py
+++ b/src/backend/tests/models/charge_types/test_midemeanor.py
@@ -17,7 +17,7 @@ def test_misdemeanor_missing_disposition():
     assert misdemeanor_charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
     assert (
         misdemeanor_charge.type_eligibility.reason
-        == "Misdemeanors are always eligible under 137.225(5)(b) for convictions, or 137.225(1)(b) for dismissals"
+        == "Always eligible under 137.225(5)(b) for convictions, or 137.225(1)(b) for dismissals"
     )
 
 

--- a/src/backend/tests/models/charge_types/test_sex_crimes.py
+++ b/src/backend/tests/models/charge_types/test_sex_crimes.py
@@ -31,5 +31,5 @@ def test_sex_crimes_with_romeo_and_juliet_exception(sex_crimes_statute):
     assert type_eligibility.status is EligibilityStatus.INELIGIBLE
     assert (
         type_eligibility.reason
-        == "Possibly meets requirements under 137.225(6)(f) - Email michael@qiu-qiulaw.com with subject line '6F' for free and confidential further analysis ⬥ Fails to meet requirements under 137.225(6)(f)"
+        == "137.225(6)(f) related sex crime – Possibly meets requirements under 137.225(6)(f) - Email michael@qiu-qiulaw.com with subject line '6F' for free and confidential further analysis"
     )

--- a/src/backend/tests/models/charge_types/test_subsection_6.py
+++ b/src/backend/tests/models/charge_types/test_subsection_6.py
@@ -20,7 +20,9 @@ def test_subsection_6_dismissed():
 
     assert isinstance(charges[0].charge_type, DismissedCharge)
     assert type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert type_eligibility.reason == "Dismissals are generally eligible under 137.225(1)(b)"
+    assert (
+        type_eligibility.reason == "Dismissed Criminal Charge – Dismissals are generally eligible under 137.225(1)(b)"
+    )
 
 
 def test_subsection_6_163165():
@@ -35,7 +37,10 @@ def test_subsection_6_163165():
     assert isinstance(charges[0].charge_type, FelonyClassC)
     assert isinstance(charges[1].charge_type, Subsection6)
     assert type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert type_eligibility.reason == "Eligible under 137.225(5)(b) ⬥ Ineligible under 137.225(6)"
+    assert (
+        type_eligibility.reason
+        == "Felony Class C – Eligible under 137.225(5)(b) OR Subsection 6 – Ineligible under 137.225(6)"
+    )
 
 
 def test_subsection_6_163200():
@@ -50,7 +55,10 @@ def test_subsection_6_163200():
     assert isinstance(charges[0].charge_type, Subsection6)
     assert isinstance(charges[1].charge_type, Misdemeanor)
     assert type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
-    assert type_eligibility.reason == "Ineligible under 137.225(6) ⬥ Eligible under 137.225(5)(b)"
+    assert (
+        type_eligibility.reason
+        == "Subsection 6 – Ineligible under 137.225(6) OR Misdemeanor – Eligible under 137.225(5)(b)"
+    )
 
 
 def test_subsection_6_163575():

--- a/src/backend/tests/models/charge_types/test_type_analyzer_duii.py
+++ b/src/backend/tests/models/charge_types/test_type_analyzer_duii.py
@@ -22,7 +22,7 @@ def test_duii_dismissed():
     assert duii_type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert (
         duii_type_eligibility.reason
-        == "137.225(8)(b) - Diverted DUIIs are ineligible ⬥ Dismissals are generally eligible under 137.225(1)(b)"
+        == "Diverted DUII – Ineligible under 137.225(8)(b) OR Dismissed Criminal Charge – Dismissals are generally eligible under 137.225(1)(b)"
     )
 
 
@@ -33,7 +33,7 @@ def test_duii_diverted():
     assert duii_type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert (
         duii_type_eligibility.reason
-        == "137.225(8)(b) - Diverted DUIIs are ineligible ⬥ Dismissals are generally eligible under 137.225(1)(b)"
+        == "Diverted DUII – Ineligible under 137.225(8)(b) OR Dismissed Criminal Charge – Dismissals are generally eligible under 137.225(1)(b)"
     )
 
 
@@ -42,4 +42,4 @@ def test_duii_convicted():
     duii_type_eligibility = RecordMerger.merge_type_eligibilities(charges)
 
     assert duii_type_eligibility.status is EligibilityStatus.INELIGIBLE
-    assert duii_type_eligibility.reason == "137.225(7)(a) - Traffic offenses are ineligible"
+    assert duii_type_eligibility.reason == "DUII – Traffic offenses are ineligible under 137.225(7)(a)"

--- a/src/frontend/src/components/RecordSearch/Record/TimeEligibility.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/TimeEligibility.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { TimeEligibilityData } from "./types";
+import { newlineOrsInString } from "./util";
 
 interface Props {
   time_eligibility: TimeEligibilityData;
@@ -23,9 +24,12 @@ export default class TimeEligibility extends React.Component<Props> {
 
     const timeLater = (reason: string) => (
       <div className="relative mb3 connect connect-time">
-        <i aria-hidden="true" className="absolute fas fa-clock dark-blue bg-white z-1"></i>
+        <i
+          aria-hidden="true"
+          className="absolute fas fa-clock dark-blue bg-white z-1"
+        ></i>
         <div className="ml3 pl1">
-          <span className="fw7">Time</span> {reason}
+          {newlineOrsInString(<span className="fw7">Time: </span>, reason)}
         </div>
       </div>
     );

--- a/src/frontend/src/components/RecordSearch/Record/TypeEligibility.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/TypeEligibility.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { TypeEligibilityData } from "./types";
+import { newlineOrsInString } from "./util";
 
 interface Props {
   type_eligibility: TypeEligibilityData;
@@ -14,8 +15,7 @@ export default class RecordType extends React.Component<Props> {
       <div className="relative mb3 connect connect-type">
         <i aria-hidden="true" className="absolute fas fa-circle z-1"></i>
         <div className="ml3 pl1">
-          <span className="fw7">Type</span> {this.props.type_name + " "}
-          <div>({reason})</div>
+          {newlineOrsInString(<span className="fw7">Type: </span>, reason)}
         </div>
       </div>
     );
@@ -27,18 +27,19 @@ export default class RecordType extends React.Component<Props> {
           className="absolute fas fa-question-circle purple bg-white z-1"
         ></i>
         <div className="ml3 pl1">
-          <span className="fw7">Type</span> {this.props.type_name + " "}
-          <div>({reason})</div>
+          {newlineOrsInString(<span className="fw7">Type: </span>, reason)}
         </div>
       </div>
     );
 
     const ineligible = (reason: string) => (
       <div className="relative mb3 connect connect-type">
-        <i aria-hidden="true" className="absolute fas fa-times-circle red bg-white z-1"></i>
+        <i
+          aria-hidden="true"
+          className="absolute fas fa-times-circle red bg-white z-1"
+        ></i>
         <div className="ml3 pl1">
-          <span className="fw7">Type</span> {this.props.type_name + " "}
-          <div>({reason})</div>
+          {newlineOrsInString(<span className="fw7">Type: </span>, reason)}
         </div>
       </div>
     );

--- a/src/frontend/src/components/RecordSearch/Record/util.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/util.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+export function newlineOrsInString(
+  leading_label: JSX.Element,
+  eligibilityString: string
+) {
+  const splittedElements = eligibilityString.split("OR");
+
+  let boldSpliced = splittedElements.map((element: string, index: number) => {
+    return (
+      <div className={(index > 0 && "bt ") + "b--light-gray pt1 mt1"}>
+        {index === 0 ? leading_label : <span className="fw7">OR </span>}
+        {element}
+      </div>
+    );
+  });
+  return boldSpliced;
+}


### PR DESCRIPTION
Resolves #1207 

Hmm well one example looks like this, which is pretty cluttered. Maybe make these bold-text? 

![messy_ors](https://user-images.githubusercontent.com/2104990/86836394-4bd01200-c052-11ea-8c63-0f74a9bee96f.png)

vs what we have now:

![with_diamonds](https://user-images.githubusercontent.com/2104990/86836640-a49faa80-c052-11ea-85b5-d2871df9ec67.png)

@KentShikama @hmarcks @michaelzhang43 