### PR TITLE
OECI token expires on closing the browser instead of a time limit.

### DIFF
--- a/src/backend/expungeservice/endpoints/oeci_login.py
+++ b/src/backend/expungeservice/endpoints/oeci_login.py
@@ -40,7 +40,6 @@ class OeciLogin(MethodView):
             secure=os.getenv("TIER") == "production",
             httponly=False,
             samesite="strict",
-            expires=time.time() + 2 * 60 * 60,  # type: ignore # 2 hour lifetime
             value=encrypted_credentials,
         )
         return response, 201


### PR DESCRIPTION
A solution for #1212 

We used to set the cookie time limit to match OECI, to which is about 5 minutes. We extended it to 2 hours, but there's no reason for it not to last for the entire session. The session cookie now expires on closing the browser, with is a predictable behavior. 

Because our search backend creates a new login session with OECI upon every search, there's no risk of the OECI server session expiring.   