### PR TITLE
Tweaks in Extra Info panel

### DIFF
--- a/src/backend/expungeservice/models/charge_types/misdemeanor.py
+++ b/src/backend/expungeservice/models/charge_types/misdemeanor.py
@@ -10,7 +10,6 @@ class Misdemeanor(ChargeType):
     type_name: str = "Misdemeanor"
     expungement_rules: str = """Convictions for misdemeanors are generally eligible under ORS 137.225(5)(b).
 Exceptions include convictions related to sex, child and elder abuse, and driving, including DUII
-
 Dismissals for misdemeanors are generally eligible under ORS 137.225(1)(b). Exceptions include cases dismissed due to successful completion of DUII diversion."""
 
     def type_eligibility(self, disposition):

--- a/src/backend/expungeservice/models/charge_types/parking_ticket.py
+++ b/src/backend/expungeservice/models/charge_types/parking_ticket.py
@@ -14,7 +14,7 @@ class ParkingTicket(ChargeType):
 
     type_name: str = "Parking Ticket"
     expungement_rules: str = (
-        """Parking Tickets are not eligible. ORS 137.225(7)(a) specifically prohibits expungement of convicted traffic offenses. No other section specifically allows for parking offenses to be eligible."""
+        """Parking Tickets are not eligible. ORS 137.225(7)(a) specifically prohibits expungement of convicted traffic offenses. Dismissed parking offenses are not covered under any subsection, and are thus ineligible."""
     )
     blocks_other_charges: bool = False
 

--- a/src/backend/expungeservice/models/charge_types/traffic_offense.py
+++ b/src/backend/expungeservice/models/charge_types/traffic_offense.py
@@ -9,7 +9,9 @@ from expungeservice.models.expungement_result import TypeEligibility, Eligibilit
 class TrafficOffense(ChargeType):
     type_name: str = "Traffic Offense"
     expungement_rules: str = (
-        """A conviction for a State or municipal traffic offense is not eligible for expungement. Common convictions under this category include Driving While Suspended/Revoked, Possession of a Stolen Vehicle, Driving Under the Influence of Intoxicants, and Failure to Perform Duties of a Driver."""
+        """A conviction for a State or municipal traffic offense is not eligible for expungement.
+        Common convictions under this category include Driving While Suspended/Revoked, Possession of a Stolen Vehicle, Driving Under the Influence of Intoxicants, and Failure to Perform Duties of a Driver.
+        A dismissed traffic offense that is of charge level misdemeanor or higher, other than a Diverted DUII, is identified as a Dismissed Criminal Charge, and is thus eligible."""
     )
 
     def type_eligibility(self, disposition):

--- a/src/backend/expungeservice/models/charge_types/traffic_violation.py
+++ b/src/backend/expungeservice/models/charge_types/traffic_violation.py
@@ -11,7 +11,7 @@ class TrafficViolation(ChargeType):
     expungement_rules: str = (
         """Convictions for traffic-related offenses are not eligible for expungement under ORS 137.225(7)(a). This includes Violations, Misdemeanors, and Felonies. Traffic-related charges include Reckless Driving, Driving While Suspended, DUII, Failure to Perform Duties of a Driver, Giving False Information to a Police Officer (when in a car), Fleeing/Attempting to Elude a Police Officer, Possession of a Stolen Vehicle
 Notably, Unauthorized Use of a Vehicle is not considered a traffic offense.
-Dismissed traffic-related Violations are not eligible for expungement
+Dismissed traffic-related Violations are not eligible for expungement under any subsection.
 HOWEVER, dismissed traffic-related Misdemeanors and Felonies, like all dismissed Misdemeanors and Felonies, ARE eligible for expungement."""
     )
     blocks_other_charges: bool = False

--- a/src/frontend/src/components/RecordSearch/Record/Charge.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Charge.tsx
@@ -126,7 +126,7 @@ export default class Charge extends React.Component<Props, State> {
               )}
             </div>
 
-            <div className="flex-l ph3 pb3">
+            <div className="flex-l ph3 pb2">
               <div className="w-100 w-40-l relative pr3">
                 {buildRecordTime()}
                 <TypeEligibility

--- a/src/frontend/src/components/RecordSearch/Record/ExpungementRules.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/ExpungementRules.tsx
@@ -1,42 +1,49 @@
 import React from "react";
-import { ExpungementRulesData } from "./types";
 import {
   Disclosure,
   DisclosureButton,
   DisclosurePanel,
 } from "@reach/disclosure";
+
 interface Props {
-  expungement_rules: ExpungementRulesData;
+  expungement_rules: string;
 }
 
-export default class ExpungementRules extends React.Component<
-  Props,
-  { open: boolean }
-> {
-  constructor(props: any) {
-    super(props);
-    this.state = {
-      open: false,
-    };
-  }
+interface State {
+  open: boolean;
+}
+
+export default class ExpungementRules extends React.Component<Props, State> {
+  state = {
+    open: false,
+  };
+
   render() {
     const toggleOpen = () => {
       this.setState({ open: !this.state.open });
     };
     const rules = this.props.expungement_rules;
     return (
-      <div className="relative mb3  ph3  pb4">
+      <div className="relative ph3  pb4">
         <div className="ml3 pl1">
           <Disclosure open={this.state.open} onChange={() => toggleOpen()}>
             <DisclosureButton>
-              <span className="fw7">More info </span>
+              <span className="">More info </span>
               {this.state.open ? (
                 <span aria-hidden="true" className="fas fa-angle-up"></span>
               ) : (
                 <span aria-hidden="true" className="fas fa-angle-down"></span>
               )}
             </DisclosureButton>
-            <DisclosurePanel className="pt4">{rules + " "}</DisclosurePanel>
+            <DisclosurePanel className="pt4">
+              {rules.split("\n").map((line: string, index: number) => {
+                return (
+                  <div className="mb2" key={index}>
+                    {line}
+                  </div>
+                );
+              })}
+            </DisclosurePanel>
           </Disclosure>
         </div>
       </div>

--- a/src/frontend/src/components/RecordSearch/Record/ExpungementRules.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/ExpungementRules.tsx
@@ -24,21 +24,23 @@ export default class ExpungementRules extends React.Component<Props, State> {
     };
     const rules = this.props.expungement_rules;
     return (
-      <div className="relative ph3  pb4">
-        <div className="ml3 pl1">
+      <div className="bt b--light-gray pt2 mh3 pb2">
+        <div className="">
           <Disclosure open={this.state.open} onChange={() => toggleOpen()}>
             <DisclosureButton>
-              <span className="">More info </span>
-              {this.state.open ? (
-                <span aria-hidden="true" className="fas fa-angle-up"></span>
-              ) : (
-                <span aria-hidden="true" className="fas fa-angle-down"></span>
-              )}
+              <span className="flex items-center tracked-tight fw5 mid-gray link hover-blue pb1">
+                More Info
+                {this.state.open ? (
+                  <span aria-hidden="true" className="fas fa-angle-up pt1 pl1"></span>
+                ) : (
+                  <span aria-hidden="true" className="fas fa-angle-down pt1 pl1"></span>
+                )}
+              </span>
             </DisclosureButton>
-            <DisclosurePanel className="pt4">
+            <DisclosurePanel className="pt2">
               {rules.split("\n").map((line: string, index: number) => {
                 return (
-                  <div className="mb2" key={index}>
+                  <div className="lh-copy mb2" key={index}>
                     {line}
                   </div>
                 );

--- a/src/frontend/src/components/RecordSearch/Record/Questions.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/Questions.tsx
@@ -41,14 +41,16 @@ function Questions(props: Props) {
         props.question_summary.case_number
       );
       return (
-        <div className="w-100 relative bl bw3 b--light-purple pa3 pb1">
-          {renderQuestions(question_summary.root, selectFunction)}
-          {props.loading === props.question_summary.ambiguous_charge_id ? (
-            <div className="radio-spinner" role="status">
-              <span className="spinner spinner--sm mr1"></span>
-              <span className="f6 fw5">Updating&#8230;</span>
-            </div>
-          ) : null}
+        <div className="bt b--light-gray">
+          <div className="w-100 relative bl bw3 b--light-purple pa3 pb1">
+            {renderQuestions(question_summary.root, selectFunction)}
+            {props.loading === props.question_summary.ambiguous_charge_id ? (
+              <div className="radio-spinner" role="status">
+                <span className="spinner spinner--sm mr1"></span>
+                <span className="f6 fw5">Updating&#8230;</span>
+              </div>
+            ) : null}
+          </div>
         </div>
       );
     } else {

--- a/src/frontend/src/components/RecordSearch/Record/types.ts
+++ b/src/frontend/src/components/RecordSearch/Record/types.ts
@@ -3,7 +3,7 @@ export interface ChargeData {
   ambiguous_charge_id: string;
   statute: string;
   expungement_result: any;
-  expungement_rules: any;
+  expungement_rules: string;
   name: string;
   type_name: string;
   date: string;
@@ -72,11 +72,6 @@ export interface TimeEligibilityData {
 export interface ChargeEligibilityData {
   status: string;
   label: string;
-}
-
-export interface ExpungementRulesData {
-  reason: any;
-  open: boolean;
 }
 
 export interface QuestionsData {


### PR DESCRIPTION
I went through the extra rules for each type and decided it's actually worth showing it for every type. Along the way I made these tweaks. 

- Some re-wording of rules
- Simplify frontend types
- Add linebreaks (divs) in rules. 
- More Info button isn't bold text. 
- A little less spacing