### PR TITLE
Generate Forms page documentation

### DIFF
--- a/src/frontend/src/components/App/index.tsx
+++ b/src/frontend/src/components/App/index.tsx
@@ -12,7 +12,7 @@ import Manual from "../Manual";
 import Faq from "../Faq";
 import Appendix from "../Appendix";
 import PrivacyPolicy from "../PrivacyPolicy";
-import UserForm from "../FormFilling";
+import FillForms from "../FillForms";
 import PartnerInterest from "../PartnerInterest";
 
 class App extends React.Component {
@@ -30,7 +30,7 @@ class App extends React.Component {
           <Route component={Faq} path="/faq" />
           <Route component={Appendix} path="/appendix" />
           <Route component={PrivacyPolicy} path="/privacy-policy" />
-          <Route component={UserForm} path="/fill-expungement-forms" />
+          <Route component={FillForms} path="/fill-expungement-forms" />
           <Route component={PartnerInterest} path="/partner-interest" />
           <Route render={this.redirect} />
         </Switch>

--- a/src/frontend/src/components/FillForms/UserDataForm.tsx
+++ b/src/frontend/src/components/FillForms/UserDataForm.tsx
@@ -86,13 +86,13 @@ class UserDataForm extends React.Component<Props, State> {
   public render() {
     return (
       <>
-        <main className="mw6 ph2 center">
-          <section className="cf mt4 mb3 pa3 pa4-l bg-white shadow br3">
-            <h1 className="mb4 f4 fw6">User Information</h1>
+        <main className="mw6">
+          <section className="cf pa3 pa4-ns bg-white shadow br3">
+            <h1 className="f4 fw7 mt0 mb4">User Information</h1>
             <form onSubmit={this.handleSubmit} noValidate={true}>
               <legend className="visually-hidden">User Information</legend>
               <div className="mb4">
-                <label htmlFor="name" className="db mb2 fw6">
+                <label htmlFor="name" className="db mb1 fw6">
                   Full Name
                 </label>
                 <input
@@ -106,7 +106,7 @@ class UserDataForm extends React.Component<Props, State> {
                 />
               </div>
               <div className="mb4">
-                <label htmlFor="dob" className="db mb2 fw6">
+                <label htmlFor="dob" className="db mb1 fw6">
                   Date of Birth
                 </label>
                 <input
@@ -120,7 +120,7 @@ class UserDataForm extends React.Component<Props, State> {
                 />
               </div>
               <div className="mb4">
-                <label htmlFor="mailingAddress" className="db mb2 fw6">
+                <label htmlFor="mailingAddress" className="db mb1 fw6">
                   Mailing Address
                 </label>
                 <input
@@ -134,7 +134,7 @@ class UserDataForm extends React.Component<Props, State> {
                 />
               </div>
               <div className="mb4">
-                <label htmlFor="phoneNumber" className="db mb2 fw6">
+                <label htmlFor="phoneNumber" className="db mb1 fw6">
                   Phone Number
                 </label>
                 <input
@@ -148,7 +148,7 @@ class UserDataForm extends React.Component<Props, State> {
                 />
               </div>
               <div className="mb4">
-                <label htmlFor="city" className="db mb2 fw6">
+                <label htmlFor="city" className="db mb1 fw6">
                   City
                 </label>
                 <input
@@ -162,7 +162,7 @@ class UserDataForm extends React.Component<Props, State> {
                 />
               </div>
               <div className="mb4">
-                <label htmlFor="state" className="db mb2 fw6">
+                <label htmlFor="state" className="db mb1 fw6">
                   State
                 </label>
                 <input
@@ -176,7 +176,7 @@ class UserDataForm extends React.Component<Props, State> {
                 />
               </div>
               <div className="mb4">
-                <label htmlFor="zipCode" className="db mb2 fw6">
+                <label htmlFor="zipCode" className="db mb1 fw6">
                   Zip code
                 </label>
                 <input

--- a/src/frontend/src/components/FillForms/UserDataForm.tsx
+++ b/src/frontend/src/components/FillForms/UserDataForm.tsx
@@ -121,7 +121,7 @@ class UserDataForm extends React.Component<Props, State> {
               </div>
               <div className="mb4">
                 <label htmlFor="mailingAddress" className="db mb1 fw6">
-                  Mailing Address
+                  Mailing Street Address
                 </label>
                 <input
                   id="mailingAddress"
@@ -131,20 +131,6 @@ class UserDataForm extends React.Component<Props, State> {
                   className="w-100 pa3 br2 b--black-20"
                   onChange={this.handleChange}
                   value={this.state.mailingAddress}
-                />
-              </div>
-              <div className="mb4">
-                <label htmlFor="phoneNumber" className="db mb1 fw6">
-                  Phone Number
-                </label>
-                <input
-                  id="phoneNumber"
-                  name="phoneNumber"
-                  type="text"
-                  required={true}
-                  className="w-100 pa3 br2 b--black-20"
-                  onChange={this.handleChange}
-                  value={this.state.phoneNumber}
                 />
               </div>
               <div className="mb4">
@@ -187,6 +173,20 @@ class UserDataForm extends React.Component<Props, State> {
                   className="w-100 pa3 br2 b--black-20"
                   onChange={this.handleChange}
                   value={this.state.zipCode}
+                />
+              </div>
+              <div className="mb4">
+                <label htmlFor="phoneNumber" className="db mb1 fw6">
+                  Phone Number
+                </label>
+                <input
+                  id="phoneNumber"
+                  name="phoneNumber"
+                  type="text"
+                  required={true}
+                  className="w-100 pa3 br2 b--black-20"
+                  onChange={this.handleChange}
+                  value={this.state.phoneNumber}
                 />
               </div>
               <button className="bg-blue white bg-animate hover-bg-dark-blue fw6 db w-100 br2 pv3 ph4 mb4 tc">

--- a/src/frontend/src/components/FillForms/UserDataForm.tsx
+++ b/src/frontend/src/components/FillForms/UserDataForm.tsx
@@ -20,7 +20,7 @@ interface State {
   zipCode: string;
 }
 
-class UserForm extends React.Component<Props, State> {
+class UserDataForm extends React.Component<Props, State> {
   private buildName = () => {
     if (this.props.aliases.length > 0) {
       const firstAlias = this.props.aliases[0];
@@ -205,5 +205,5 @@ const mapStateToProps = (state: AppState) => ({
 });
 
 export default connect(mapStateToProps, { downloadExpungementPacket })(
-  UserForm
+  UserDataForm
 );

--- a/src/frontend/src/components/FillForms/index.tsx
+++ b/src/frontend/src/components/FillForms/index.tsx
@@ -13,23 +13,17 @@ interface State {}
 export default class FillForms extends React.Component<Props, State> {
   public render() {
     return (
-      <main className="flex-l f6 f5-l">
-        <div className="w-50-l pt5 pb5 pb7-l pr3-l">
-          <div className="mw6 center mr0-l ml-auto-l">
-            <section className=" lh-copy mh2 ph5-l">
-              {/*      <main className="center flex-l f6 f5-l pl4">
-          <div className=" center w-50-l pt5 pb5 pb7-l ">
-        <div className="mw6">
-              <section className="lh-copy">
-            */}
-              <h1 className="f2 fw9 mb3 mt4">Generate Expungement Forms</h1>
-
-              <p className="mb2">
+      <main className="mw8 center f6 f5-l ph3 pt4 pb6">
+        <h1 className="f3 f2-l fw9 mb4">Generate Expungement Forms</h1>
+        <div className="flex-l pt2">
+          <div className="w-50-l pr4-l mb4">
+            <section className="mw6 lh-copy">
+              <p className="mb3">
                 This will fill and download the required paperwork forms as PDF
                 files for all cases that have charges eligible for expungement.
               </p>
 
-              <p className="mb2">
+              <p className="mb3">
                 On this page, you may optionally provide the person's name,
                 address, and other information and it will be used to populate
                 the forms. It is not required if you would prefer to fill out
@@ -41,7 +35,7 @@ export default class FillForms extends React.Component<Props, State> {
                 The following required information is obtained from OECI and
                 will be provided in the form:
               </p>
-              <ol className="mb2 pl3">
+              <ol className="pl4 mb3">
                 <li>Case number</li>
                 <li>Names of charges</li>
                 <li>Dates of arrest</li>
@@ -52,16 +46,23 @@ export default class FillForms extends React.Component<Props, State> {
                 The following information might be missing from OECI. If it's
                 available, it will be provided in the form. If it is not present
                 in OECI, some of the information may or may not be required in
-                the application; please consult the manual.
+                the application; please consult the{" "}
+                <a
+                  href="/manual#file"
+                  className="link hover-dark-blue bb"
+                >
+                  Manual
+                </a>
+                .
               </p>
-              <ol className="pl3 mb2">
+              <ol className="pl4 mb3">
                 <li>Arresting Agency</li>
                 <li>DA Number</li>
               </ol>
 
-              <p className="mb2">
+              <p className="mb3">
                 The form that is filled out for each case is selected based on
-                the COUNTY information for that case.
+                the <strong>County</strong> information for that case.
               </p>
 
               <p className="mb2">
@@ -69,7 +70,7 @@ export default class FillForms extends React.Component<Props, State> {
                 expungement. Currently, RecordSponge supports automatic
                 form-filling for the following counties:
               </p>
-              <ol className="mb2 pl3">
+              <ol className="pl4 mb3">
                 <li>Multnomah</li>
                 <li>Jackson</li>
                 <li>Clackamas</li>
@@ -82,28 +83,34 @@ export default class FillForms extends React.Component<Props, State> {
                 <li>Josephine</li>
               </ol>
 
-              <p className="mb2">
+              <p className="mb3">
                 Some other counties also require their own paperwork forms but
                 are not yet supported in our software. This feature will
                 generate the stock expungement forms for any of the counties not
                 listed above.
               </p>
 
-              <p className="mb2">
-                Please read the complete instructions in the manual for filing
-                the required forms for expungement. After downloading the PDFs,
-                review their contents to verify that all the required
-                information is present and correct.
+              <p className="mb3">
+                Please read the complete instructions in the{" "}
+                <a
+                  href="/manual#file"
+                  className="link hover-dark-blue bb"
+                >
+                  Manual
+                </a> 
+                {" "}for filing the required forms for expungement. After 
+                downloading the PDFs, review their contents to verify that all 
+                the required information is present and correct.
               </p>
             </section>
           </div>
-        </div>
 
-        <div className="w-50-l pt4 pt5-l pb5 ph4 ph6-l">
-          <div className="mw6">
-            <section className="lh-copy">
-              <UserDataForm />
-            </section>
+          <div className="w-50-l pl4-l">
+            <div className="mw6">
+              <section className="lh-copy">
+                <UserDataForm />
+              </section>
+            </div>
           </div>
         </div>
       </main>

--- a/src/frontend/src/components/FillForms/index.tsx
+++ b/src/frontend/src/components/FillForms/index.tsx
@@ -3,6 +3,7 @@ import history from "../../service/history";
 import { downloadExpungementPacket } from "../../redux/search/actions";
 import UserDataForm from "./UserDataForm";
 import { connect } from "react-redux";
+import { HashLink as Link } from "react-router-hash-link";
 import { AppState } from "../../redux/store";
 import { AliasData } from "../RecordSearch/SearchPanel/types";
 
@@ -47,12 +48,9 @@ export default class FillForms extends React.Component<Props, State> {
                 available, it will be provided in the form. If it is not present
                 in OECI, some of the information may or may not be required in
                 the application; please consult the{" "}
-                <a
-                  href="/manual#file"
-                  className="link hover-dark-blue bb"
-                >
+                <Link to="/manual#file" className="link hover-dark-blue bb">
                   Manual
-                </a>
+                </Link>
                 .
               </p>
               <ol className="pl4 mb3">
@@ -92,15 +90,12 @@ export default class FillForms extends React.Component<Props, State> {
 
               <p className="mb3">
                 Please read the complete instructions in the{" "}
-                <a
-                  href="/manual#file"
-                  className="link hover-dark-blue bb"
-                >
+                <Link to="/manual#file" className="link hover-dark-blue bb">
                   Manual
-                </a> 
-                {" "}for filing the required forms for expungement. After 
-                downloading the PDFs, review their contents to verify that all 
-                the required information is present and correct.
+                </Link>{" "}
+                for filing the required forms for expungement. After downloading
+                the PDFs, review their contents to verify that all the required
+                information is present and correct.
               </p>
             </section>
           </div>

--- a/src/frontend/src/components/FillForms/index.tsx
+++ b/src/frontend/src/components/FillForms/index.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import history from "../../service/history";
+import { downloadExpungementPacket } from "../../redux/search/actions";
+import UserDataForm from "./UserDataForm";
+import { connect } from "react-redux";
+import { AppState } from "../../redux/store";
+import { AliasData } from "../RecordSearch/SearchPanel/types";
+
+interface Props {}
+
+interface State {}
+
+export default class FillForms extends React.Component<Props, State> {
+  public render() {
+    return (
+      <main className="flex-l f6 f5-l">
+        <div className="w-50-l pt5 pb5 pb7-l pr3-l">
+          <div className="mw6 center mr0-l ml-auto-l">
+            <section className=" lh-copy mh2 ph5-l">
+              {/*      <main className="center flex-l f6 f5-l pl4">
+          <div className=" center w-50-l pt5 pb5 pb7-l ">
+        <div className="mw6">
+              <section className="lh-copy">
+            */}
+              <h1 className="f2 fw9 mb3 mt4">Generate Expungement Forms</h1>
+
+              <p className="mb2">
+                This will fill and download the required pdf paperwork forms for
+                all cases that have charges eligible for expungement.
+              </p>
+
+              <p className="mb2">
+                On this page, you may optionally provide the person's name,
+                address, and other information and it will be used to populate
+                the forms. It is not required if you would prefer to fill out
+                the information later. We do not save any of the information.
+              </p>
+
+              <p className="mb2">
+                The following required information is obtained from OECI and
+                will be provided in the form:
+              </p>
+              <ol className="mb2 pl3">
+                <li>Case number</li>
+                <li>Names of charges</li>
+                <li>Dates of arrest</li>
+                <li>Dates of conviction or dismissal</li>
+              </ol>
+
+              <p className="mb2">
+                The following information might be missing from OECI. If it's
+                available, it will be provided in the form. If it is not present
+                in OECI, some of the information may or may not be required in
+                the application; please consult the manual.
+              </p>
+              <ol className="pl3 mb2">
+                <li>Arresting Agency</li>
+                <li>DA Number</li>
+              </ol>
+
+              <p className="mb2">
+                The form that is filled out for each case is selected based on
+                the COUNTY information for that case.
+              </p>
+
+              <p className="mb2">
+                Many Oregon counties require their own paperwork to file for
+                expungement. Currently, RecordSponge supports automatic
+                form-filling for the following counties:
+              </p>
+              <ol className="mb2 pl3">
+                <li>Multnomah</li>
+                <li>Jackson</li>
+                <li>Clackamas</li>
+                <li>Lane</li>
+                <li>Washington</li>
+                <li>Marion</li>
+                <li>Linn</li>
+                <li>Yamhill</li>
+                <li>Benton</li>
+                <li>Josephine</li>
+              </ol>
+
+              <p className="mb2">
+                Some other counties also require their own paperwork forms but
+                are not yet supported in our software. This Generate Paperwork
+                feature will automatically fill the stock expungement forms for
+                any of the counties not listed above.
+              </p>
+
+              <p className="mb2">
+                Please read the complete instructions in the manual for filing
+                the required forms for expungement. After downloading the pdfs,
+                review their contents to verify that all the required
+                information is present and correct.
+              </p>
+            </section>
+          </div>
+        </div>
+
+        <div className="w-50-l pt4 pt5-l pb5 ph4 ph6-l">
+          <div className="mw6">
+            <section className="lh-copy">
+              <UserDataForm />
+            </section>
+          </div>
+        </div>
+      </main>
+    );
+  }
+}

--- a/src/frontend/src/components/FillForms/index.tsx
+++ b/src/frontend/src/components/FillForms/index.tsx
@@ -25,15 +25,16 @@ export default class FillForms extends React.Component<Props, State> {
               <h1 className="f2 fw9 mb3 mt4">Generate Expungement Forms</h1>
 
               <p className="mb2">
-                This will fill and download the required pdf paperwork forms for
-                all cases that have charges eligible for expungement.
+                This will fill and download the required paperwork forms as PDF
+                files for all cases that have charges eligible for expungement.
               </p>
 
               <p className="mb2">
                 On this page, you may optionally provide the person's name,
                 address, and other information and it will be used to populate
                 the forms. It is not required if you would prefer to fill out
-                the information later. We do not save any of the information.
+                the information later, and we do not save any of this
+                information.
               </p>
 
               <p className="mb2">
@@ -83,14 +84,14 @@ export default class FillForms extends React.Component<Props, State> {
 
               <p className="mb2">
                 Some other counties also require their own paperwork forms but
-                are not yet supported in our software. This Generate Paperwork
-                feature will automatically fill the stock expungement forms for
-                any of the counties not listed above.
+                are not yet supported in our software. This feature will
+                generate the stock expungement forms for any of the counties not
+                listed above.
               </p>
 
               <p className="mb2">
                 Please read the complete instructions in the manual for filing
-                the required forms for expungement. After downloading the pdfs,
+                the required forms for expungement. After downloading the PDFs,
                 review their contents to verify that all the required
                 information is present and correct.
               </p>

--- a/src/frontend/src/components/RecordSearch/Record/RecordSummary/ChargesList.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/RecordSummary/ChargesList.tsx
@@ -32,9 +32,6 @@ export default class ChargesList extends React.Component<Props> {
               <span>
                 {" "}
                 {chargesNames.length > 0 ? `(${chargesNames.length})` : ""}{" "}
-                {eligibilityDate === "Eligible Now" && (
-                  <Link to="/fill-expungement-forms">.</Link>
-                )}
               </span>
             </div>
             <p className="f6 mb2">

--- a/src/frontend/src/components/RecordSearch/Record/RecordSummary/index.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/RecordSummary/index.tsx
@@ -6,6 +6,7 @@ import CountyBalances from "./CountyBalances";
 import { AppState } from "../../../../redux/store";
 import { RecordSummaryData } from "../types";
 import { downloadPdf } from "../../../../redux/search/actions";
+import history from "../../../../service/history";
 
 interface Props {
   downloadPdf: Function;
@@ -13,9 +14,27 @@ interface Props {
   summary: RecordSummaryData;
 }
 
-class RecordSummary extends React.Component<Props> {
+interface State {
+  cantGenerateForms: boolean;
+}
+
+class RecordSummary extends React.Component<Props, State> {
+  state = {
+    cantGenerateForms: false,
+  };
   handleDownloadClick = () => {
     this.props.downloadPdf();
+  };
+
+  handleGenerateFormsClick = () => {
+    if (
+      this.props.summary.eligible_charges_by_date["Eligible Now"] &&
+      this.props.summary.eligible_charges_by_date["Eligible Now"].length > 0
+    ) {
+      history.push("/fill-expungement-forms");
+    } else {
+      this.setState({ cantGenerateForms: true });
+    }
   };
   render() {
     const {
@@ -28,18 +47,38 @@ class RecordSummary extends React.Component<Props> {
 
     return (
       <div className="bg-white shadow br3 mb3 ph3 pb3">
-        <div className="flex justify-between">
-          <h2 className="mv3 f5 fw7">Search Summary</h2>
+        <div className="flex flex-wrap justify-end">
+          <h2 className="mv3 mr-auto f5 fw7">Search Summary</h2>
+          {this.state.cantGenerateForms && (
+            <span className="bg-washed-red mv2 pa1 pt2 br3 fw6">
+              There must be eligible charges to generate paperwork.{" "}
+              <button
+                onClick={() => {
+                  this.setState({ cantGenerateForms: false });
+                }}
+              >
+                <i aria-hidden="true" className="fas fa-times-circle gray"></i>
+              </button>
+            </span>
+          )}
           <button
-            onClick={this.handleDownloadClick}
+            className="ma2 nowrap mid-gray link hover-blue fw6 br3 pv1 ph2"
+            onClick={this.handleGenerateFormsClick}
+          >
+            <i aria-hidden="true" className="fas fa-bolt pr2"></i>Generate
+            Paperwork
+          </button>
+          <button
             className={`ma2 nowrap mid-gray link hover-blue fw6 br3 pv1 ph2${
               this.props.loadingPdf ? " loading-btn" : ""
             }`}
+            onClick={this.handleDownloadClick}
           >
-            <i aria-hidden="true" className="fas fa-download pr2" />
-            Download PDF
+            <i aria-hidden="true" className="fas fa-download pr2"></i>Summary
+            PDF
           </button>
         </div>
+
         <div className="flex-ns flex-wrap">
           <ChargesList
             eligibleChargesByDate={eligible_charges_by_date}

--- a/src/frontend/src/components/RecordSearch/Record/RecordSummary/index.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/RecordSummary/index.tsx
@@ -50,13 +50,14 @@ class RecordSummary extends React.Component<Props, State> {
         <div className="flex flex-wrap justify-end">
           <h2 className="mv3 mr-auto f5 fw7">Search Summary</h2>
           {this.state.cantGenerateForms && (
-            <span className="bg-washed-red mv2 pa1 pt2 br3 fw6">
+            <span className="bg-washed-red mv2 pa2 br3 fw6" role="alert">
               There must be eligible charges to generate paperwork.{" "}
               <button
                 onClick={() => {
                   this.setState({ cantGenerateForms: false });
                 }}
               >
+                <span className="visually-hidden">Close</span>
                 <i aria-hidden="true" className="fas fa-times-circle gray"></i>
               </button>
             </span>

--- a/src/frontend/src/styles/_globals.scss
+++ b/src/frontend/src/styles/_globals.scss
@@ -79,6 +79,11 @@ $washed-red: #f0e0e8;
   background-color: $gray-blue-2;
 }
 
+:focus,
+.link:focus {
+  outline-color: $blue;
+}
+
 .shadow-case {
   box-shadow: 0 -2px 3px 0 rgba(59, 86, 73, 0.1);
 }


### PR DESCRIPTION
Static language to explain the feature. In the future we could generate a dynamic report of what files will be downloaded.

Also add the Generate Forms button. If there are no eligible charges, this in-line error is shown on click. 

![cant_generate_error](https://user-images.githubusercontent.com/2104990/88117482-2114ac00-cb70-11ea-8f6a-8a1913b5b6a8.png)

The page spacing is bad and I couldn't figure out how to do it in columns. @hmarcks Could you give it a redo?
![Screenshot_2020-07-21 RecordSponge Oregon](https://user-images.githubusercontent.com/2104990/88117488-270a8d00-cb70-11ea-9d8a-9fdbbbdc4d61.png)

