### PR TITLE
Balance due in demo, strip spaces from search terms

### DIFF
--- a/src/backend/expungeservice/demo_records.py
+++ b/src/backend/expungeservice/demo_records.py
@@ -23,7 +23,10 @@ class DemoRecords:
             search_results: List[OeciCase] = []
             for alias in aliases:
                 alias_lower = Alias(
-                    alias.first_name.lower(), alias.last_name.lower(), alias.middle_name.lower(), alias.birth_date
+                    alias.first_name.lower().strip(),
+                    alias.last_name.lower().strip(),
+                    alias.middle_name.lower().strip(),
+                    alias.birth_date,
                 )
                 try:
                     alias_search_result = DemoRecords.records.get(alias_lower, [])
@@ -258,6 +261,7 @@ class DemoRecords:
                     data_class=CaseSummary,
                     data={
                         **shared_case_data,
+                        "balance_due_in_cents": 100000,
                         "name": "MULTIPLE CHARGES",
                         "birth_year": 1990,
                         "case_number": "100000",

--- a/src/frontend/src/components/RecordSearch/Demo/DemoInfo.tsx
+++ b/src/frontend/src/components/RecordSearch/Demo/DemoInfo.tsx
@@ -46,6 +46,11 @@ export default class DemoInfo extends React.Component {
               as a conviction. Searching OECI will also reveal traffic
               violations, which are always ineligible.
             </p>
+            <p>
+              This record also includes a case with an outstanding balance due
+              for fines, which is indicated in both the record summary and on
+              the case itself.
+            </p>
           </div>
         ),
       },
@@ -206,7 +211,9 @@ export default class DemoInfo extends React.Component {
           <div>
             {examples.map((examples: any) => (
               <div>
-                <h2 className="fw9 bt b--light-gray pt2 mb3">{examples.name}</h2>
+                <h2 className="fw9 bt b--light-gray pt2 mb3">
+                  {examples.name}
+                </h2>
                 <div className="mw7 mb4">{examples.info}</div>
               </div>
             ))}


### PR DESCRIPTION
Resolves #1365 

And an unrelated tweak to strip spaces from Aliases in demo search (this is how regular search works; apparently handled by OECI). 