### PR TITLE
Exclude removed charges when generating forms.

### DIFF
--- a/src/backend/expungeservice/endpoints/pdf.py
+++ b/src/backend/expungeservice/endpoints/pdf.py
@@ -134,10 +134,9 @@ class FormFilling(MethodView):
 
     @staticmethod
     def _build_pdf_for_case(case, user_information):
+        charges = [c for c in case.charges if c.edit_status != EditStatus.DELETE]
         ineligible_charges_generator, eligible_charges_generator = partition(
-            lambda c: c.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.ELIGIBLE_NOW
-            and c.edit_status != EditStatus.DELETE,
-            case.charges,
+            lambda c: c.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.ELIGIBLE_NOW, charges
         )
         ineligible_charges, eligible_charges = list(ineligible_charges_generator), list(eligible_charges_generator)
         in_part = ", ".join(

--- a/src/backend/expungeservice/endpoints/pdf.py
+++ b/src/backend/expungeservice/endpoints/pdf.py
@@ -7,7 +7,7 @@ from zipfile import ZipFile
 
 from dacite import from_dict
 from expungeservice.expunger import Expunger
-from expungeservice.models.charge import Charge
+from expungeservice.models.charge import Charge, EditStatus
 from expungeservice.models.expungement_result import ChargeEligibilityStatus
 from flask.views import MethodView
 from flask import request, json, make_response, send_file
@@ -135,7 +135,8 @@ class FormFilling(MethodView):
     @staticmethod
     def _build_pdf_for_case(case, user_information):
         ineligible_charges_generator, eligible_charges_generator = partition(
-            lambda c: c.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.ELIGIBLE_NOW,
+            lambda c: c.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.ELIGIBLE_NOW
+            and c.edit_status != EditStatus.DELETE,
             case.charges,
         )
         ineligible_charges, eligible_charges = list(ineligible_charges_generator), list(eligible_charges_generator)

--- a/src/backend/expungeservice/endpoints/pdf.py
+++ b/src/backend/expungeservice/endpoints/pdf.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from os import path
 from pathlib import Path
 from tempfile import mkdtemp
@@ -123,9 +123,12 @@ class FormFilling(MethodView):
         zip_path = path.join(zip_dir, zip_name)
         zipfile = ZipFile(zip_path, "w")
         for case in record_summary.record.cases:
-            pdf = FormFilling._build_pdf_for_case(case, user_information)
+            case_without_deleted_charges = replace(
+                case, charges=[c for c in case.charges if c.edit_status != EditStatus.DELETE]
+            )
+            pdf = FormFilling._build_pdf_for_case(case_without_deleted_charges, user_information)
             if pdf:
-                file_name = f"{case.summary.name}_{case.summary.case_number}.pdf"
+                file_name = f"{case_without_deleted_charges.summary.name}_{case_without_deleted_charges.summary.case_number}.pdf"
                 file_path = path.join(temp_dir, file_name)
                 PdfWriter().write(file_path, pdf)
                 zipfile.write(file_path, file_name)
@@ -134,9 +137,9 @@ class FormFilling(MethodView):
 
     @staticmethod
     def _build_pdf_for_case(case, user_information):
-        charges = [c for c in case.charges if c.edit_status != EditStatus.DELETE]
         ineligible_charges_generator, eligible_charges_generator = partition(
-            lambda c: c.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.ELIGIBLE_NOW, charges
+            lambda c: c.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.ELIGIBLE_NOW,
+            case.charges,
         )
         ineligible_charges, eligible_charges = list(ineligible_charges_generator), list(eligible_charges_generator)
         in_part = ", ".join(


### PR DESCRIPTION
Resolves #1360 

I considered an alternate approach of checking the EditStatus when the charge eligibility gets originally set to `ELIGIBLE_NOW` at 
https://github.com/codeforpdx/recordexpungPDX/blob/d69322e86181ef3c4bbbc3d70e03ddbc2bc63a26/src/backend/expungeservice/record_merger.py#L181

But it feels weirdly out of place to stick Edit functionality info into the merger. Regardless of where we check Edit status, it feels like we're patching it in in an inelegant fashion, so I chose to avoid touching the already-really-complex merger code.