### PR TITLE
Update prod.yml to only trigger on release creation (and not trigger on tag creation)

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -3,9 +3,6 @@ name: deploy to prod
 on:
   release:
     types: [created]
-  push:
-    tags:
-      - v*
 
 # Copied from staging.yml.
 # GitHub does not support sharing steps between workflows yet.


### PR DESCRIPTION
As shown on https://github.com/codeforpdx/recordexpungPDX/actions, the current setup triggers a duplicate action when you do a release on Github (as it creates both a tag and a release by default).