### PR TITLE
#1223: Only create an error message for a missing disposition if the case is closed.

### DIFF
--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -276,7 +276,7 @@ class ErrorChecker:
         for charge in charges:
             if charge.charge_type.blocks_other_charges:
                 case_number = f"[{charge.case(cases).summary.case_number}]"
-                if charge.disposition.status == DispositionStatus.UNKNOWN:
+                if charge.disposition.status == DispositionStatus.UNKNOWN and charge.case(cases).summary.closed():
                     cases_with_missing_disposition.add(case_number)
                 elif charge.disposition.status == DispositionStatus.UNRECOGNIZED:
                     cases_with_unrecognized_disposition.add((case_number, charge.disposition.ruling))


### PR DESCRIPTION
* Only create an error message for a missing disposition if the case is
  closed.

  The "missing disposition" error should only show if the cause of the
  error is for something other than the case being open. If the case is
  open, the disposition is expected to be missing.

* Add `open` method to `Case` class to make certain pieces of logic more
  obvious (removing double negation in `if` statement)