### PR TITLE
#874 Reference Blocking Charge in Eligbility

### DIFF
--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -90,7 +90,7 @@ class Expunger:
                 eligibility_dates.append(
                     (
                         most_recent_blocking_conviction.disposition.date + relativedelta(years=10),
-                        f"OR 137.225(7)(b) – Ten years from most recent {potential}{conviction_string} from case {summary.case_number}.",
+                        f"137.225(7)(b) – Ten years from most recent {potential}{conviction_string} from case {summary.case_number}.",
                     )
                 )
 

--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -90,7 +90,7 @@ class Expunger:
                 eligibility_dates.append(
                     (
                         most_recent_blocking_conviction.disposition.date + relativedelta(years=10),
-                        f"137.225(7)(b) – Ten years from most recent {potential}{conviction_string} from case {summary.case_number}.",
+                        f"137.225(7)(b) – Ten years from most recent {potential}{conviction_string} from case [{summary.case_number}].",
                     )
                 )
 

--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -85,16 +85,12 @@ class Expunger:
 
             if most_recent_blocking_conviction:
                 conviction_string = "other conviction" if charge.convicted() else "conviction"
-                recency = "most recent"
                 summary = most_recent_blocking_conviction.case(cases).summary
-
-                if not summary.closed():
-                    recency += "hypothetical"
-
+                potential = "potential " if not summary.closed() else ""
                 eligibility_dates.append(
                     (
                         most_recent_blocking_conviction.disposition.date + relativedelta(years=10),
-                        f"Ten years from charge in case {summary.case_number} ({recency} {conviction_string}) (137.225(7)(b))",
+                        f"OR 137.225(7)(b) – Ten years from most recent {potential}{conviction_string} from case {summary.case_number}.",
                     )
                 )
 

--- a/src/backend/tests/test_friendly_rule.py
+++ b/src/backend/tests/test_friendly_rule.py
@@ -97,7 +97,7 @@ def test_eligible_mrc_with_violation():
     assert expunger_result[violation.ambiguous_charge_id].date_will_be_eligible == date.today() + relativedelta(years=7)
     assert (
         expunger_result[violation.ambiguous_charge_id].reason
-        == f"OR 137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
+        == f"137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
     )
 
 
@@ -128,7 +128,7 @@ def test_needs_more_analysis_mrc_with_single_arrest():
     assert expunger_result_b[arrest.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
         expunger_result_b[arrest.ambiguous_charge_id].reason
-        == f"OR 137.225(7)(b) – Ten years from most recent conviction from case {case_a.summary.case_number}."
+        == f"137.225(7)(b) – Ten years from most recent conviction from case {case_a.summary.case_number}."
     )
     assert expunger_result_b[arrest.ambiguous_charge_id].date_will_be_eligible == ten_years_from_mrc
 

--- a/src/backend/tests/test_friendly_rule.py
+++ b/src/backend/tests/test_friendly_rule.py
@@ -127,7 +127,8 @@ def test_needs_more_analysis_mrc_with_single_arrest():
 
     assert expunger_result_b[arrest.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
-        expunger_result_b[arrest.ambiguous_charge_id].reason == "Ten years from most recent conviction (137.225(7)(b))"
+        expunger_result_b[arrest.ambiguous_charge_id].reason
+        == f"Ten years from charge in case {eligible_charge.case_number} (most recent conviction) (137.225(7)(b))"
     )
     assert expunger_result_b[arrest.ambiguous_charge_id].date_will_be_eligible == ten_years_from_mrc
 

--- a/src/backend/tests/test_friendly_rule.py
+++ b/src/backend/tests/test_friendly_rule.py
@@ -97,7 +97,7 @@ def test_eligible_mrc_with_violation():
     assert expunger_result[violation.ambiguous_charge_id].date_will_be_eligible == date.today() + relativedelta(years=7)
     assert (
         expunger_result[violation.ambiguous_charge_id].reason
-        == "Ten years from most recent other conviction (137.225(7)(b))"
+        == f"OR 137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
     )
 
 
@@ -128,7 +128,7 @@ def test_needs_more_analysis_mrc_with_single_arrest():
     assert expunger_result_b[arrest.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
         expunger_result_b[arrest.ambiguous_charge_id].reason
-        == f"Ten years from charge in case {eligible_charge.case_number} (most recent conviction) (137.225(7)(b))"
+        == f"OR 137.225(7)(b) – Ten years from most recent conviction from case {case_a.summary.case_number}."
     )
     assert expunger_result_b[arrest.ambiguous_charge_id].date_will_be_eligible == ten_years_from_mrc
 

--- a/src/backend/tests/test_friendly_rule.py
+++ b/src/backend/tests/test_friendly_rule.py
@@ -97,7 +97,7 @@ def test_eligible_mrc_with_violation():
     assert expunger_result[violation.ambiguous_charge_id].date_will_be_eligible == date.today() + relativedelta(years=7)
     assert (
         expunger_result[violation.ambiguous_charge_id].reason
-        == f"137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
+        == f"137.225(7)(b) – Ten years from most recent other conviction from case [{case.summary.case_number}]."
     )
 
 
@@ -128,7 +128,7 @@ def test_needs_more_analysis_mrc_with_single_arrest():
     assert expunger_result_b[arrest.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
         expunger_result_b[arrest.ambiguous_charge_id].reason
-        == f"137.225(7)(b) – Ten years from most recent conviction from case {case_a.summary.case_number}."
+        == f"137.225(7)(b) – Ten years from most recent conviction from case [{case_a.summary.case_number}]."
     )
     assert expunger_result_b[arrest.ambiguous_charge_id].date_will_be_eligible == ten_years_from_mrc
 

--- a/src/backend/tests/test_time_analyzer.py
+++ b/src/backend/tests/test_time_analyzer.py
@@ -45,7 +45,7 @@ class TestSingleChargeDismissals(unittest.TestCase):
         assert expunger_result[three_yr_conviction.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[three_yr_conviction.ambiguous_charge_id].reason
-            == "Ten years from most recent other conviction (137.225(7)(b))"
+            == f"OR 137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
         )
         assert expunger_result[
             three_yr_conviction.ambiguous_charge_id
@@ -76,7 +76,7 @@ class TestSingleChargeDismissals(unittest.TestCase):
         assert expunger_result[arrest.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[arrest.ambiguous_charge_id].reason
-            == "Ten years from most recent conviction (137.225(7)(b))"
+            == f"OR 137.225(7)(b) – Ten years from most recent conviction from case {case.summary.case_number}."
         )
         assert expunger_result[mrc.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
@@ -113,7 +113,7 @@ class TestSingleChargeDismissals(unittest.TestCase):
         assert expunger_result[ten_yr_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[ten_yr_charge.ambiguous_charge_id].reason
-            == f"Ten years from charge in case {ten_yr_charge.case_number} (137.225(7)(b))"
+            == f"OR 137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
         )
         assert (
             expunger_result[ten_yr_charge.ambiguous_charge_id].date_will_be_eligible
@@ -141,7 +141,7 @@ class TestSingleChargeDismissals(unittest.TestCase):
         assert expunger_result[ten_yr_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[ten_yr_charge.ambiguous_charge_id].reason
-            == "Ten years from most recent other conviction (137.225(7)(b))"
+            == f"OR 137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
         )
         assert (
             expunger_result[ten_yr_charge.ambiguous_charge_id].date_will_be_eligible
@@ -280,11 +280,6 @@ class TestDismissalBlock(unittest.TestCase):
 
 
 class TestSecondMRCLogic(unittest.TestCase):
-    def run_expunger(self, mrc, second_mrc):
-        case = CaseFactory.create(charges=tuple([mrc, second_mrc]))
-        record = Record(tuple([case]))
-        return Expunger.run(record)
-
     def test_3_yr_old_conviction_2_yr_old_mrc(self):
         three_years_ago_charge = ChargeFactory.create(
             disposition=DispositionCreator.create(ruling="Convicted", date=Time.THREE_YEARS_AGO)
@@ -293,12 +288,14 @@ class TestSecondMRCLogic(unittest.TestCase):
             disposition=DispositionCreator.create(ruling="Convicted", date=Time.TWO_YEARS_AGO)
         )
 
-        expunger_result = self.run_expunger(two_years_ago_charge, three_years_ago_charge)
+        case = CaseFactory.create(charges=tuple([two_years_ago_charge, three_years_ago_charge]))
+        record = Record(tuple([case]))
+        expunger_result = Expunger.run(record)
 
         assert expunger_result[three_years_ago_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[three_years_ago_charge.ambiguous_charge_id].reason
-            == "Ten years from most recent other conviction (137.225(7)(b))"
+            == f"OR 137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
         )
         assert (
             expunger_result[three_years_ago_charge.ambiguous_charge_id].date_will_be_eligible
@@ -308,7 +305,7 @@ class TestSecondMRCLogic(unittest.TestCase):
         assert expunger_result[two_years_ago_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[two_years_ago_charge.ambiguous_charge_id].reason
-            == "Ten years from most recent other conviction (137.225(7)(b))"
+            == f"OR 137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
         )
         assert (
             expunger_result[two_years_ago_charge.ambiguous_charge_id].date_will_be_eligible
@@ -323,12 +320,14 @@ class TestSecondMRCLogic(unittest.TestCase):
             disposition=DispositionCreator.create(ruling="Convicted", date=Time.FIVE_YEARS_AGO)
         )
 
-        expunger_result = self.run_expunger(five_year_ago_charge, seven_year_ago_charge)
+        case = CaseFactory.create(charges=tuple([five_year_ago_charge, seven_year_ago_charge]))
+        record = Record(tuple([case]))
+        expunger_result = Expunger.run(record)
 
         assert expunger_result[seven_year_ago_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[seven_year_ago_charge.ambiguous_charge_id].reason
-            == "Ten years from most recent other conviction (137.225(7)(b))"
+            == f"OR 137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
         )
         assert (
             expunger_result[seven_year_ago_charge.ambiguous_charge_id].date_will_be_eligible
@@ -338,7 +337,7 @@ class TestSecondMRCLogic(unittest.TestCase):
         assert expunger_result[five_year_ago_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[five_year_ago_charge.ambiguous_charge_id].reason
-            == "Ten years from most recent other conviction (137.225(7)(b))"
+            == f"OR 137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
         )
         assert (
             expunger_result[five_year_ago_charge.ambiguous_charge_id].date_will_be_eligible
@@ -354,7 +353,9 @@ class TestSecondMRCLogic(unittest.TestCase):
         )
         eligibility_date = one_year_old_conviction.disposition.date + Time.THREE_YEARS
 
-        expunger_result = self.run_expunger(one_year_old_conviction, nine_year_old_conviction)
+        case = CaseFactory.create(charges=tuple([one_year_old_conviction, nine_year_old_conviction]))
+        record = Record(tuple([case]))
+        expunger_result = Expunger.run(record)
 
         assert expunger_result[one_year_old_conviction.ambiguous_charge_id].date_will_be_eligible == eligibility_date
 
@@ -557,7 +558,7 @@ def test_3_violations_are_time_restricted():
     assert expunger_result[violation_charge_1.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
         expunger_result[violation_charge_1.ambiguous_charge_id].reason
-        == f"Ten years from charge in case {violation_charge_1.case_number} (most recent other conviction) (137.225(7)(b))"
+        == f"OR 137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
     )
     assert (
         expunger_result[violation_charge_1.ambiguous_charge_id].date_will_be_eligible
@@ -567,7 +568,7 @@ def test_3_violations_are_time_restricted():
     assert expunger_result[violation_charge_2.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
         expunger_result[violation_charge_2.ambiguous_charge_id].reason
-        == f"Ten years from charge in case {violation_charge_1.case_number} (most recent other conviction) (137.225(7)(b))"
+        == f"OR 137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
     )
     assert (
         expunger_result[violation_charge_2.ambiguous_charge_id].date_will_be_eligible
@@ -577,7 +578,7 @@ def test_3_violations_are_time_restricted():
     assert expunger_result[violation_charge_3.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
         expunger_result[violation_charge_3.ambiguous_charge_id].reason
-        == f"Ten years from charge in case {violation_charge_1.case_number} (most recent other conviction) (137.225(7)(b))"
+        == f"OR 137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
     )
     assert (
         expunger_result[violation_charge_3.ambiguous_charge_id].date_will_be_eligible

--- a/src/backend/tests/test_time_analyzer.py
+++ b/src/backend/tests/test_time_analyzer.py
@@ -45,7 +45,7 @@ class TestSingleChargeDismissals(unittest.TestCase):
         assert expunger_result[three_yr_conviction.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[three_yr_conviction.ambiguous_charge_id].reason
-            == f"OR 137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
+            == f"137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
         )
         assert expunger_result[
             three_yr_conviction.ambiguous_charge_id
@@ -76,7 +76,7 @@ class TestSingleChargeDismissals(unittest.TestCase):
         assert expunger_result[arrest.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[arrest.ambiguous_charge_id].reason
-            == f"OR 137.225(7)(b) – Ten years from most recent conviction from case {case.summary.case_number}."
+            == f"137.225(7)(b) – Ten years from most recent conviction from case {case.summary.case_number}."
         )
         assert expunger_result[mrc.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
@@ -113,7 +113,7 @@ class TestSingleChargeDismissals(unittest.TestCase):
         assert expunger_result[ten_yr_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[ten_yr_charge.ambiguous_charge_id].reason
-            == f"OR 137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
+            == f"137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
         )
         assert (
             expunger_result[ten_yr_charge.ambiguous_charge_id].date_will_be_eligible
@@ -141,7 +141,7 @@ class TestSingleChargeDismissals(unittest.TestCase):
         assert expunger_result[ten_yr_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[ten_yr_charge.ambiguous_charge_id].reason
-            == f"OR 137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
+            == f"137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
         )
         assert (
             expunger_result[ten_yr_charge.ambiguous_charge_id].date_will_be_eligible
@@ -295,7 +295,7 @@ class TestSecondMRCLogic(unittest.TestCase):
         assert expunger_result[three_years_ago_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[three_years_ago_charge.ambiguous_charge_id].reason
-            == f"OR 137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
+            == f"137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
         )
         assert (
             expunger_result[three_years_ago_charge.ambiguous_charge_id].date_will_be_eligible
@@ -305,7 +305,7 @@ class TestSecondMRCLogic(unittest.TestCase):
         assert expunger_result[two_years_ago_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[two_years_ago_charge.ambiguous_charge_id].reason
-            == f"OR 137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
+            == f"137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
         )
         assert (
             expunger_result[two_years_ago_charge.ambiguous_charge_id].date_will_be_eligible
@@ -327,7 +327,7 @@ class TestSecondMRCLogic(unittest.TestCase):
         assert expunger_result[seven_year_ago_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[seven_year_ago_charge.ambiguous_charge_id].reason
-            == f"OR 137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
+            == f"137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
         )
         assert (
             expunger_result[seven_year_ago_charge.ambiguous_charge_id].date_will_be_eligible
@@ -337,7 +337,7 @@ class TestSecondMRCLogic(unittest.TestCase):
         assert expunger_result[five_year_ago_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[five_year_ago_charge.ambiguous_charge_id].reason
-            == f"OR 137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
+            == f"137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
         )
         assert (
             expunger_result[five_year_ago_charge.ambiguous_charge_id].date_will_be_eligible
@@ -558,7 +558,7 @@ def test_3_violations_are_time_restricted():
     assert expunger_result[violation_charge_1.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
         expunger_result[violation_charge_1.ambiguous_charge_id].reason
-        == f"OR 137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
+        == f"137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
     )
     assert (
         expunger_result[violation_charge_1.ambiguous_charge_id].date_will_be_eligible
@@ -568,7 +568,7 @@ def test_3_violations_are_time_restricted():
     assert expunger_result[violation_charge_2.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
         expunger_result[violation_charge_2.ambiguous_charge_id].reason
-        == f"OR 137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
+        == f"137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
     )
     assert (
         expunger_result[violation_charge_2.ambiguous_charge_id].date_will_be_eligible
@@ -578,7 +578,7 @@ def test_3_violations_are_time_restricted():
     assert expunger_result[violation_charge_3.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
         expunger_result[violation_charge_3.ambiguous_charge_id].reason
-        == f"OR 137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
+        == f"137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
     )
     assert (
         expunger_result[violation_charge_3.ambiguous_charge_id].date_will_be_eligible

--- a/src/backend/tests/test_time_analyzer.py
+++ b/src/backend/tests/test_time_analyzer.py
@@ -45,7 +45,7 @@ class TestSingleChargeDismissals(unittest.TestCase):
         assert expunger_result[three_yr_conviction.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[three_yr_conviction.ambiguous_charge_id].reason
-            == f"137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
+            == f"137.225(7)(b) – Ten years from most recent other conviction from case [{case.summary.case_number}]."
         )
         assert expunger_result[
             three_yr_conviction.ambiguous_charge_id
@@ -76,7 +76,7 @@ class TestSingleChargeDismissals(unittest.TestCase):
         assert expunger_result[arrest.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[arrest.ambiguous_charge_id].reason
-            == f"137.225(7)(b) – Ten years from most recent conviction from case {case.summary.case_number}."
+            == f"137.225(7)(b) – Ten years from most recent conviction from case [{case.summary.case_number}]."
         )
         assert expunger_result[mrc.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
@@ -113,7 +113,7 @@ class TestSingleChargeDismissals(unittest.TestCase):
         assert expunger_result[ten_yr_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[ten_yr_charge.ambiguous_charge_id].reason
-            == f"137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
+            == f"137.225(7)(b) – Ten years from most recent other conviction from case [{case.summary.case_number}]."
         )
         assert (
             expunger_result[ten_yr_charge.ambiguous_charge_id].date_will_be_eligible
@@ -141,7 +141,7 @@ class TestSingleChargeDismissals(unittest.TestCase):
         assert expunger_result[ten_yr_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[ten_yr_charge.ambiguous_charge_id].reason
-            == f"137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
+            == f"137.225(7)(b) – Ten years from most recent other conviction from case [{case.summary.case_number}]."
         )
         assert (
             expunger_result[ten_yr_charge.ambiguous_charge_id].date_will_be_eligible
@@ -295,7 +295,7 @@ class TestSecondMRCLogic(unittest.TestCase):
         assert expunger_result[three_years_ago_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[three_years_ago_charge.ambiguous_charge_id].reason
-            == f"137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
+            == f"137.225(7)(b) – Ten years from most recent other conviction from case [{case.summary.case_number}]."
         )
         assert (
             expunger_result[three_years_ago_charge.ambiguous_charge_id].date_will_be_eligible
@@ -305,7 +305,7 @@ class TestSecondMRCLogic(unittest.TestCase):
         assert expunger_result[two_years_ago_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[two_years_ago_charge.ambiguous_charge_id].reason
-            == f"137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
+            == f"137.225(7)(b) – Ten years from most recent other conviction from case [{case.summary.case_number}]."
         )
         assert (
             expunger_result[two_years_ago_charge.ambiguous_charge_id].date_will_be_eligible
@@ -327,7 +327,7 @@ class TestSecondMRCLogic(unittest.TestCase):
         assert expunger_result[seven_year_ago_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[seven_year_ago_charge.ambiguous_charge_id].reason
-            == f"137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
+            == f"137.225(7)(b) – Ten years from most recent other conviction from case [{case.summary.case_number}]."
         )
         assert (
             expunger_result[seven_year_ago_charge.ambiguous_charge_id].date_will_be_eligible
@@ -337,7 +337,7 @@ class TestSecondMRCLogic(unittest.TestCase):
         assert expunger_result[five_year_ago_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[five_year_ago_charge.ambiguous_charge_id].reason
-            == f"137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
+            == f"137.225(7)(b) – Ten years from most recent other conviction from case [{case.summary.case_number}]."
         )
         assert (
             expunger_result[five_year_ago_charge.ambiguous_charge_id].date_will_be_eligible
@@ -558,7 +558,7 @@ def test_3_violations_are_time_restricted():
     assert expunger_result[violation_charge_1.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
         expunger_result[violation_charge_1.ambiguous_charge_id].reason
-        == f"137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
+        == f"137.225(7)(b) – Ten years from most recent other conviction from case [{case.summary.case_number}]."
     )
     assert (
         expunger_result[violation_charge_1.ambiguous_charge_id].date_will_be_eligible
@@ -568,7 +568,7 @@ def test_3_violations_are_time_restricted():
     assert expunger_result[violation_charge_2.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
         expunger_result[violation_charge_2.ambiguous_charge_id].reason
-        == f"137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
+        == f"137.225(7)(b) – Ten years from most recent other conviction from case [{case.summary.case_number}]."
     )
     assert (
         expunger_result[violation_charge_2.ambiguous_charge_id].date_will_be_eligible
@@ -578,7 +578,7 @@ def test_3_violations_are_time_restricted():
     assert expunger_result[violation_charge_3.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
         expunger_result[violation_charge_3.ambiguous_charge_id].reason
-        == f"137.225(7)(b) – Ten years from most recent other conviction from case {case.summary.case_number}."
+        == f"137.225(7)(b) – Ten years from most recent other conviction from case [{case.summary.case_number}]."
     )
     assert (
         expunger_result[violation_charge_3.ambiguous_charge_id].date_will_be_eligible

--- a/src/backend/tests/test_time_analyzer.py
+++ b/src/backend/tests/test_time_analyzer.py
@@ -113,7 +113,7 @@ class TestSingleChargeDismissals(unittest.TestCase):
         assert expunger_result[ten_yr_charge.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
         assert (
             expunger_result[ten_yr_charge.ambiguous_charge_id].reason
-            == "Ten years from most recent other conviction (137.225(7)(b))"
+            == f"Ten years from charge in case {ten_yr_charge.case_number} (137.225(7)(b))"
         )
         assert (
             expunger_result[ten_yr_charge.ambiguous_charge_id].date_will_be_eligible
@@ -557,7 +557,7 @@ def test_3_violations_are_time_restricted():
     assert expunger_result[violation_charge_1.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
         expunger_result[violation_charge_1.ambiguous_charge_id].reason
-        == "Ten years from most recent other conviction (137.225(7)(b))"
+        == f"Ten years from charge in case {violation_charge_1.case_number} (most recent other conviction) (137.225(7)(b))"
     )
     assert (
         expunger_result[violation_charge_1.ambiguous_charge_id].date_will_be_eligible
@@ -567,7 +567,7 @@ def test_3_violations_are_time_restricted():
     assert expunger_result[violation_charge_2.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
         expunger_result[violation_charge_2.ambiguous_charge_id].reason
-        == "Ten years from most recent other conviction (137.225(7)(b))"
+        == f"Ten years from charge in case {violation_charge_1.case_number} (most recent other conviction) (137.225(7)(b))"
     )
     assert (
         expunger_result[violation_charge_2.ambiguous_charge_id].date_will_be_eligible
@@ -577,7 +577,7 @@ def test_3_violations_are_time_restricted():
     assert expunger_result[violation_charge_3.ambiguous_charge_id].status is EligibilityStatus.INELIGIBLE
     assert (
         expunger_result[violation_charge_3.ambiguous_charge_id].reason
-        == "Ten years from most recent other conviction (137.225(7)(b))"
+        == f"Ten years from charge in case {violation_charge_1.case_number} (most recent other conviction) (137.225(7)(b))"
     )
     assert (
         expunger_result[violation_charge_3.ambiguous_charge_id].date_will_be_eligible

--- a/src/frontend/src/components/RecordSearch/Record/index.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/index.tsx
@@ -8,6 +8,7 @@ import { RecordData, CaseData } from "./types";
 import AddButton from "./AddButton";
 import { startEditing, doneEditing } from "../../../redux/search/actions";
 import { AppState } from "../../../redux/store";
+import { convertCaseNumberIntoLinks } from "./util";
 
 interface Props {
   record?: RecordData;
@@ -61,26 +62,7 @@ class Record extends React.Component<Props, State> {
         ? this.props.record.errors.map(
             (errorMessage: string, errorIndex: number) => {
               const id = "record_error_" + errorIndex;
-
-              const errorMessageArray = errorMessage.split(/(\[.*?\])/g);
-              const errorMessageHTML = errorMessageArray.map(function (
-                element
-              ) {
-                if (element.match(/^\[.*\]$/)) {
-                  const caseNumber = element.slice(1, -1);
-                  return (
-                    <a
-                      className="underline"
-                      href={"#" + caseNumber}
-                      key={caseNumber}
-                    >
-                      {caseNumber}
-                    </a>
-                  );
-                } else {
-                  return element;
-                }
-              });
+              const errorMessageHTML = convertCaseNumberIntoLinks(errorMessage);
               return (
                 <p
                   role="status"
@@ -156,9 +138,7 @@ class Record extends React.Component<Props, State> {
                     aria-hidden="true"
                     className="fas fa-question-circle link hover-dark-blue gray"
                   ></i>
-                  <span className="visually-hidden">
-                    Editing Help
-                  </span>
+                  <span className="visually-hidden">Editing Help</span>
                 </Link>
               </>
             )}

--- a/src/frontend/src/components/RecordSearch/Record/util.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/util.tsx
@@ -10,9 +10,25 @@ export function newlineOrsInString(
     return (
       <div className={(index > 0 && "bt b--light-gray pt2 mt2") + ""}>
         {index === 0 ? leading_label : <span className="fw7">OR </span>}
-        {element}
+        {convertCaseNumberIntoLinks(element)}
       </div>
     );
   });
   return boldSpliced;
+}
+
+export function convertCaseNumberIntoLinks(eligibilityString: string) {
+  const elements = eligibilityString.split(/(\[.*?\])/g);
+  return elements.map((element: string, index: number) => {
+    if (element.match(/^\[.*\]$/)) {
+      const caseNumber = element.slice(1, -1);
+      return (
+        <a className="underline" href={"#" + caseNumber} key={caseNumber}>
+          {caseNumber}
+        </a>
+      );
+    } else {
+      return element;
+    }
+  });
 }


### PR DESCRIPTION
Reference the blocking charge in time eligibility reason if there is
one.

> When a charge is blocked by some other charge, it may be useful to the
user, and make results more intuitive, if the time reason provides more
than just "blocked by most recent other conviction" and actually names
the blocking conviction that's doing the blocking. Or more specifically,
it should name the case number which is the unique identifier on the
record, rather than just the charge name.

- [ ] Review logic and confirm language is correct in cases where most
  recent blocking charge is:
    - [ ] Open
    - [ ] Closed
- [ ] Update test suite once language and logic is reviewed by team

--- 
After Change:
![image](https://user-images.githubusercontent.com/56364303/89128486-ca319f80-d4aa-11ea-82f1-d12523ca6cd8.png)

Before Change:
![image](https://user-images.githubusercontent.com/56364303/89128506-eaf9f500-d4aa-11ea-9f4b-23f2dba4916d.png)
