### PR TITLE
Add warnings from RecordSponge for form filling

### DIFF
--- a/src/backend/expungeservice/form_filling.py
+++ b/src/backend/expungeservice/form_filling.py
@@ -216,7 +216,6 @@ class FormFilling:
             acc = {**acc, **FormFilling._build_charge(charges, i)}
         return acc
 
-    # TODO: Double check case where disposition date is missing
     @staticmethod
     def _build_charge(charges: List[Charge], i: int) -> Dict[str, str]:
         if len(charges) > (i - 1):

--- a/src/backend/expungeservice/form_filling.py
+++ b/src/backend/expungeservice/form_filling.py
@@ -117,9 +117,7 @@ class FormFilling:
             case.charges,
         )
         ineligible_charges, eligible_charges = list(ineligible_charges_generator), list(eligible_charges_generator)
-        in_part = ", ".join(
-            [charge.ambiguous_charge_id.split("-")[-1] for charge in eligible_charges]
-        )  # TODO: Check if compatible with edit feature
+        in_part = ", ".join([charge.ambiguous_charge_id.split("-")[-1] for charge in eligible_charges])
         case_number_with_comments = (
             f"{case.summary.case_number} (in part - counts {in_part})"
             if ineligible_charges


### PR DESCRIPTION
We add the following warnings for now:

- Warn that a case is attempting to be expunged in part
- Warn that field value may not fit in bounding box

Linking #1336