### PR TITLE
Stop demo when clicking in-page Oeci link.

### DIFF
--- a/src/frontend/src/components/RecordSearch/Demo/DemoInfo.tsx
+++ b/src/frontend/src/components/RecordSearch/Demo/DemoInfo.tsx
@@ -1,7 +1,18 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import { connect } from "react-redux";
+import { stopDemo } from "../../../redux/search/actions";
+import history from "../../../service/history";
+import store from "../../../redux/store";
 
-export default class DemoInfo extends React.Component {
+interface Props {
+  stopDemo: Function;
+}
+class DemoInfo extends React.Component<Props> {
+  toOeci = () => {
+    store.dispatch(this.props.stopDemo());
+    history.push("/oeci");
+  };
   render() {
     const examples = [
       {
@@ -203,9 +214,9 @@ export default class DemoInfo extends React.Component {
 
           <p className="mb4">
             Or,{" "}
-            <Link to="/oeci" className="link bb hover-blue">
+            <button className="link bb hover-blue" onClick={this.toOeci}>
               log in to OECI
-            </Link>
+            </button>
             .
           </p>
           <div>
@@ -223,3 +234,4 @@ export default class DemoInfo extends React.Component {
     );
   }
 }
+export default connect(() => {}, { stopDemo })(DemoInfo);

--- a/src/frontend/src/components/RecordSearch/Demo/index.tsx
+++ b/src/frontend/src/components/RecordSearch/Demo/index.tsx
@@ -12,7 +12,7 @@ class Demo extends React.Component<Props> {
     store.dispatch(this.props.startDemo());
   }
   render() {
-    return <RecordSearch demo={true} />;
+    return <RecordSearch />;
   }
 }
 

--- a/src/frontend/src/components/RecordSearch/index.tsx
+++ b/src/frontend/src/components/RecordSearch/index.tsx
@@ -66,6 +66,7 @@ class RecordSearch extends Component<Props> {
 const mapStateToProps = (state: AppState) => {
   return {
     record: state.search.record,
+    demo: state.search.demo,
   };
 };
 


### PR DESCRIPTION
This keeps the demo active if the user opens the manual then returns to Search.

Closes #1404 