### PR TITLE
Update uwsgi config to reload worker on http timeout

### DIFF
--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -32,4 +32,4 @@ FROM base
 COPY --from=build /src/venvs /src/venvs
 
 EXPOSE 5000
-CMD ["pipenv", "run", "uwsgi", "-b 8192", "--http-timeout", "300", "--py-autoreload", "1", "--http", "0.0.0.0:5000", "--module", "expungeservice.wsgi", "--die-on-term", "--uid", "nobody"]
+CMD ["pipenv", "run", "uwsgi", "-b 8192", "--http-timeout", "300", "--harakiri", "300", "--enable-threads", "--py-autoreload", "1", "--http", "0.0.0.0:5000", "--module", "expungeservice.wsgi", "--die-on-term", "--uid", "nobody"]

--- a/src/ops/docker/expungeservice/Dockerfile
+++ b/src/ops/docker/expungeservice/Dockerfile
@@ -7,4 +7,4 @@ RUN mkdir -p /src/backend/flask_session && chown nobody /src/backend/flask_sessi
 
 COPY frontend /src/frontend
 
-CMD ["pipenv", "run", "uwsgi", "-b 8192", "--http-timeout", "300", "--enable-threads", "--processes", "4", "--threads", "2", "--http", "0.0.0.0:5000", "--module", "expungeservice.wsgi", "--die-on-term", "--uid", "nobody"]
+CMD ["pipenv", "run", "uwsgi", "-b 8192", "--http-timeout", "300", "--harakiri", "300", "--enable-threads", "master", "--processes", "2", "--http", "0.0.0.0:5000", "--module", "expungeservice.wsgi", "--die-on-term", "--uid", "nobody"]


### PR DESCRIPTION
Setting `--http-timeout` doesn't automatically reload the workers that timed out in the background: we need to set `--harakiri` to the same length for that to happen.

Also adjust the process count to 2. I have discovered that uwsgi doesn't automatically route the request for a particular session (or even ip address) to the same worker even if that worker is available. In other words, with multiple processors there is a chance that the request will be routed to the instance of the Flask application that doesn't have the previous in-memory cache. If this becomes an issue, we should switch to using something like redis to guarantee cache integrity across instances or use a process manager to ensure that requests with the same session are always routed to the same instance.