### PR TITLE
Always use case_number_with_comments for case_number

### DIFF
--- a/src/backend/expungeservice/form_filling.py
+++ b/src/backend/expungeservice/form_filling.py
@@ -21,7 +21,7 @@ from pdfrw import PdfReader, PdfWriter, PdfDict, PdfObject
 class FormData:
     case_name: str
     case_number: str
-    case_number_with_comments: str  # For Clackamas and Lincoln county
+    case_number_with_comments: str # For legacy reasons; same as case_number
     da_number: str
     full_name: str
     date_of_birth: str
@@ -177,7 +177,7 @@ class FormFilling:
         form_data_dict = {
             **user_information,
             "case_name": case.summary.name,
-            "case_number": case.summary.case_number,
+            "case_number": case_number_with_comments,
             "case_number_with_comments": case_number_with_comments,
             "da_number": case.summary.district_attorney_number,
             "arresting_agency": "",

--- a/src/backend/tests/pdf/test_markdown_serializer.py
+++ b/src/backend/tests/pdf/test_markdown_serializer.py
@@ -33,14 +33,10 @@ RecordSponge is not your lawyer. The results below should be used as a guide onl
 Below is a summary of your eligibility for expungement based on the assumptions above. 
 If the above assumptions are not true for you and you would like an updated analysis, email roe@qiu-qiulaw.com with your name and date of birth with subject line, “Updated Analysis”.  
 ## Charges Eligible Now  
+ - Possession of Cocaine (CONVICTED) Charged Jun 13, 2009 - $ owed 
  - Possession of Cocaine (DISMISSED) Charged Feb 17, 2009 - $ owed  
   
   
-## Future Eligible Charges  
-The following charges (dismissed and convicted) are eligible at the designated dates. Convictions in the future will set your eligibility dates back until ten years from the date of conviction.  
-### Eligible Nov 9, 2020  
- - Possession of Cocaine (CONVICTED) Charged Jun 13, 2009 - $ owed  
-
   
 """
 


### PR DESCRIPTION
This ensures that the case number field in the expungement PDF forms always have `(in part)` for partial cases regardless of whether each charge is individually listed.