### PR TITLE
Fee written as 0.00 instead of None if there are eligible convictions.

### DIFF
--- a/src/backend/expungeservice/record_summarizer.py
+++ b/src/backend/expungeservice/record_summarizer.py
@@ -94,21 +94,14 @@ class RecordSummarizer:
 
     @staticmethod
     def _build_no_fees_reason(charges):
-        reason = "no eligible cases"  # reason only applies if feeless
+        reason = "None (no eligible cases)"
         if charges:
-            charges_will_be_eligible = [
-                c
-                for c in charges
-                if c.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.WILL_BE_ELIGIBLE
-            ]
             nonconvictions_eligible_now = [
                 c
                 for c in charges
                 if c.expungement_result.charge_eligibility.status == ChargeEligibilityStatus.ELIGIBLE_NOW
                 and c.disposition.status != DispositionStatus.CONVICTED
             ]
-            if charges_will_be_eligible:
-                reason = "no convictions eligible now"
-            elif nonconvictions_eligible_now:
-                reason = "no eligible convictions"
+            if nonconvictions_eligible_now:
+                reason = "$0.00 (no eligible convictions)"
         return reason

--- a/src/backend/tests/models/test_record_summarizer.py
+++ b/src/backend/tests/models/test_record_summarizer.py
@@ -155,4 +155,4 @@ def test_record_summarizer_no_cases():
     assert record_summary.county_fines == []
     assert record_summary.eligible_charges_by_date == {}
     assert record_summary.county_filing_fees == []
-    assert record_summary.no_fees_reason == "no eligible cases"
+    assert record_summary.no_fees_reason == "None (no eligible cases)"

--- a/src/frontend/src/components/RecordSearch/Record/RecordSummary/CountyFilingFees.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/RecordSummary/CountyFilingFees.tsx
@@ -60,7 +60,7 @@ export default class CountyFines extends React.Component<Props> {
             </span>
           </div>
         ) : (
-          <span>{`None (${this.props.no_fees_reason})`}</span>
+          <span>{this.props.no_fees_reason}</span>
         )}
       </div>
     );


### PR DESCRIPTION
Also say "no eligible cases" even if there will be future eligible cases (instead of "no convictions eligible now")

Suggestions from @michaelzhang43 