### PR TITLE
Allow expungement date to be shifted to the future

### DIFF
--- a/src/backend/expungeservice/endpoints/demo.py
+++ b/src/backend/expungeservice/endpoints/demo.py
@@ -22,15 +22,22 @@ class Demo(MethodView):
     def build_response(self):
         request_data = request.get_json()
         Search._validate_request(request_data)
+        today = Search._build_today(request_data.get("today", ""))
         return Demo._build_record_summary(
-            request_data["aliases"], request_data.get("questions"), request_data.get("edits", {})
+            request_data["aliases"], request_data.get("questions"), request_data.get("edits", {}), today
         )
 
     @staticmethod
-    def _build_record_summary(aliases_data, questions_data, edits_data):
+    def _build_record_summary(aliases_data, questions_data, edits_data, today):
         aliases = [from_dict(data_class=Alias, data=alias) for alias in aliases_data]
         record, questions = RecordCreator.build_record(
-            DemoRecords.build_search_results, "username", "password", tuple(aliases), edits_data, Demo.search_cache
+            DemoRecords.build_search_results,
+            "username",
+            "password",
+            tuple(aliases),
+            edits_data,
+            today,
+            Demo.search_cache,
         )
         if questions_data:
             questions = Search._build_questions(questions_data)

--- a/src/backend/expungeservice/expunger.py
+++ b/src/backend/expungeservice/expunger.py
@@ -23,7 +23,7 @@ from expungeservice.models.record import Record
 class Expunger:
     @staticmethod
     @lru_cache(maxsize=32)
-    def run(record: Record) -> Dict[str, TimeEligibility]:
+    def run(record: Record, today: date = date.today()) -> Dict[str, TimeEligibility]:
         """
         Evaluates the expungement eligibility of a record.
         """
@@ -72,7 +72,10 @@ class Expunger:
 
             if charge.disposition.status == DispositionStatus.NO_COMPLAINT:
                 eligibility_dates.append(
-                    (charge.date + relativedelta(years=1), "One year from date of no-complaint arrest (137.225(1)(b))",)
+                    (
+                        charge.date + relativedelta(years=1),
+                        "One year from date of no-complaint arrest (137.225(1)(b))",
+                    )
                 )
 
             if charge.convicted() and charge.probation_revoked:
@@ -124,7 +127,7 @@ class Expunger:
             else:
                 date_will_be_eligible, reason = max(eligibility_dates)
 
-            if date_will_be_eligible and date.today() >= date_will_be_eligible:
+            if date_will_be_eligible and today >= date_will_be_eligible:
                 time_eligibility = TimeEligibility(
                     status=EligibilityStatus.ELIGIBLE,
                     reason="Eligible now",

--- a/src/backend/tests/endpoints/test_search.py
+++ b/src/backend/tests/endpoints/test_search.py
@@ -10,6 +10,7 @@ from tests.factories.crawler_factory import CrawlerFactory
 from expungeservice.record_creator import RecordCreator
 from expungeservice.models.record import Alias
 from expungeservice.endpoints.search import Search
+from expungeservice.util import DateWithFuture as date
 
 
 @pytest.fixture
@@ -130,7 +131,7 @@ def test_search_cache(service, monkeypatch):
         {"first_name": "john", "last_name": "deer", "middle_name": "", "birth_date": ""},
     ]
 
-    Search._build_record_summary("username", "password", test_alias_dictionary, {}, {})
+    Search._build_record_summary("username", "password", test_alias_dictionary, {}, {}, date.today())
     assert Search.search_cache[test_alias]
 
 
@@ -144,6 +145,6 @@ def test_search_cache_error(service, monkeypatch):
         {"first_name": "jane", "last_name": "doe", "middle_name": "q", "birth_date": "June 29th"},
     ]
 
-    Search._build_record_summary("username", "password", test_fail_alias_dictionary, {}, {})
+    Search._build_record_summary("username", "password", test_fail_alias_dictionary, {}, {}, date.today())
 
     assert not Search.search_cache[test_fail_alias]

--- a/src/backend/tests/factories/crawler_factory.py
+++ b/src/backend/tests/factories/crawler_factory.py
@@ -10,7 +10,7 @@ from tests.fixtures.post_login_page import PostLoginPage
 from tests.fixtures.search_page_response import SearchPageResponse
 from tests.fixtures.case_details import CaseDetails
 from tests.fixtures.john_doe import JohnDoe
-from expungeservice.util import LRUCache
+from expungeservice.util import LRUCache, DateWithFuture as date_class
 
 
 class CrawlerFactory:
@@ -39,5 +39,5 @@ class CrawlerFactory:
 
             aliases = (Alias(first_name="John", last_name="Doe", middle_name="", birth_date=""),)
             return RecordCreator.build_record(
-                RecordCreator.build_search_results, "username", "password", aliases, {}, LRUCache(4)
+                RecordCreator.build_search_results, "username", "password", aliases, {}, date_class.today(), LRUCache(4)
             )

--- a/src/backend/tests/test_edit_results.py
+++ b/src/backend/tests/test_edit_results.py
@@ -33,7 +33,10 @@ case_1 = OeciCase(
             level="Misdemeanor",
             date=date(2000, 1, 1),
             disposition=Disposition(
-                date=date(2001, 1, 1), ruling="Convicted", status=DispositionStatus.CONVICTED, amended=False,
+                date=date(2001, 1, 1),
+                ruling="Convicted",
+                status=DispositionStatus.CONVICTED,
+                amended=False,
             ),
             probation_revoked=None,
             balance_due_in_cents=0,
@@ -46,7 +49,10 @@ case_1 = OeciCase(
             level="Felony Class C",
             date=date(2001, 1, 1),
             disposition=Disposition(
-                date=date(2001, 1, 1), ruling="Convicted", status=DispositionStatus.CONVICTED, amended=False,
+                date=date(2001, 1, 1),
+                ruling="Convicted",
+                status=DispositionStatus.CONVICTED,
+                amended=False,
             ),
             probation_revoked=None,
             balance_due_in_cents=0,
@@ -77,7 +83,10 @@ case_2 = OeciCase(
             level="Felony Class B",
             date=date(1980, 1, 1),
             disposition=Disposition(
-                date=date(1981, 1, 1), ruling="Convicted", status=DispositionStatus.CONVICTED, amended=False,
+                date=date(1981, 1, 1),
+                ruling="Convicted",
+                status=DispositionStatus.CONVICTED,
+                amended=False,
             ),
             probation_revoked=None,
             balance_due_in_cents=0,
@@ -108,7 +117,7 @@ def search(mocked_record_name) -> Callable[[Any, Any, Any, Any], Tuple[List[Oeci
 
 def test_no_op():
     record, questions = RecordCreator.build_record(
-        search("two_cases_two_charges_each"), "username", "password", (), {}, LRUCache(4)
+        search("two_cases_two_charges_each"), "username", "password", (), {}, date.today(), LRUCache(4)
     )
     assert len(record.cases) == 2
     assert len(record.cases[0].charges) == 2
@@ -128,9 +137,15 @@ def test_edit_some_fields_on_case():
         (),
         {
             "X0002": {
-                "summary": {"edit_status": "UPDATE", "location": "ocean", "balance_due": "100", "date": "1/1/1981",}
+                "summary": {
+                    "edit_status": "UPDATE",
+                    "location": "ocean",
+                    "balance_due": "100",
+                    "date": "1/1/1981",
+                }
             }
         },
+        date.today(),
         LRUCache(4),
     )
     assert len(record.cases) == 2
@@ -149,6 +164,7 @@ def test_delete_case():
         "password",
         (),
         {"X0001": {"summary": {"edit_status": "DELETE"}}},
+        date.today(),
         LRUCache(4),
     )
 
@@ -186,6 +202,7 @@ def test_add_case():
                 },
             }
         },
+        date.today(),
         LRUCache(4),
     )
     assert len(record.cases) == 2
@@ -233,6 +250,7 @@ def test_update_case_with_add_and_update_and_delete_charges():
                 },
             }
         },
+        date.today(),
         LRUCache(4),
     )
     assert len(record.cases) == 1
@@ -259,6 +277,7 @@ def test_add_disposition():
                 "charges": {"X0001-2": {"disposition": {"date": "1/1/2001", "ruling": "Convicted"}}},
             }
         },
+        date.today(),
         LRUCache(4),
     )
     assert record.cases[0].charges[1].disposition.status == DispositionStatus.CONVICTED
@@ -277,6 +296,7 @@ def test_edit_charge_type_of_charge():
                 "charges": {"X0001-2": {"edit_status": "UPDATE", "charge_type": "Misdemeanor"}},
             }
         },
+        date.today(),
         LRUCache(4),
     )
     assert isinstance(record.cases[0].charges[1].charge_type, Misdemeanor)
@@ -301,6 +321,7 @@ def test_add_new_charge():
                 },
             }
         },
+        date.today(),
         LRUCache(4),
     )
     assert isinstance(record.cases[0].charges[2].charge_type, Misdemeanor)
@@ -309,9 +330,7 @@ def test_add_new_charge():
 
 
 def test_deleted_charge_does_not_block():
-    """
-
-    """
+    """"""
     record, questions = RecordCreator.build_record(
         search("two_cases_two_charges_each"),
         "username",
@@ -329,6 +348,7 @@ def test_deleted_charge_does_not_block():
                 },
             },
         },
+        date.today(),
         LRUCache(4),
     )
     assert record.cases[0].summary.case_number == "X0001"
@@ -346,10 +366,16 @@ def test_deleted_charge_does_not_block():
         (),
         {
             "X0001": {
-                "summary": {"edit_status": "UPDATE",},
-                "charges": {"X0001-1": {"edit_status": "DELETE"}, "X0001-2": {"edit_status": "DELETE"},},
+                "summary": {
+                    "edit_status": "UPDATE",
+                },
+                "charges": {
+                    "X0001-1": {"edit_status": "DELETE"},
+                    "X0001-2": {"edit_status": "DELETE"},
+                },
             }
         },
+        date.today(),
         LRUCache(4),
     )
 

--- a/src/frontend/src/components/RecordSearch/SearchPanel/index.tsx
+++ b/src/frontend/src/components/RecordSearch/SearchPanel/index.tsx
@@ -7,14 +7,17 @@ import Alias from "./Alias";
 import InvalidInputs from "../../InvalidInputs";
 import { searchRecord } from "../../../redux/search/actions";
 import { isValidWildcard } from "./validators";
+import Field from "./Field";
 
 interface Props {
   searchRecord: Function;
   aliases: AliasData[];
+  today: string;
 }
 
 interface State {
   aliases: AliasData[];
+  today: string;
   missingInputs: boolean;
   invalidDate: boolean;
   invalidFirstNameWildcard: boolean;
@@ -24,6 +27,7 @@ interface State {
 class SearchPanel extends React.Component<Props, State> {
   state: State = {
     aliases: this.props.aliases,
+    today: this.props.today || todayToMMDDYYYY(),
     missingInputs: false,
     invalidDate: false,
     invalidFirstNameWildcard: false,
@@ -39,7 +43,7 @@ class SearchPanel extends React.Component<Props, State> {
         !this.state.invalidFirstNameWildcard &&
         !this.state.invalidLastNameWildcard
       ) {
-        this.props.searchRecord(this.state.aliases);
+        this.props.searchRecord(this.state.aliases, this.state.today);
       }
     });
   };
@@ -154,6 +158,20 @@ class SearchPanel extends React.Component<Props, State> {
         <h1 className="visually-hidden">Record Search</h1>
         <section className="cf mt4 mb3 pa4 bg-white shadow br3">
           <form className="mw7 center" onSubmit={this.handleSubmit} noValidate>
+            <div className="flex">
+              <Field
+                coda="mm/dd/yyyy"
+                name="today"
+                label="Expunge Date"
+                content={this.state.today}
+                divMarkup="pl2-r"
+                onChange={(fieldValue: string) => {
+                  this.setState({ today: fieldValue });
+                }}
+                required={true}
+                errorMessage="today_msg"
+              />
+            </div>
             {aliasComponents}
             <div className="flex">
               <button
@@ -199,9 +217,21 @@ class SearchPanel extends React.Component<Props, State> {
   }
 }
 
+const todayToMMDDYYYY = () => {
+  const date = new Date();
+  return (
+    (date.getMonth() + 1).toString() +
+    "/" +
+    date.getDate().toString() +
+    "/" +
+    date.getFullYear().toString()
+  );
+};
+
 const mapStateToProps = (state: AppState) => {
   return {
     aliases: JSON.parse(JSON.stringify(state.search.aliases)),
+    today: JSON.parse(JSON.stringify(state.search.today)),
   };
 };
 

--- a/src/frontend/src/redux/search/actions.ts
+++ b/src/frontend/src/redux/search/actions.ts
@@ -54,6 +54,7 @@ function buildSearchRequest() {
   return {
     demo: store.getState().search.demo,
     aliases: store.getState().search.aliases,
+    today: store.getState().search.today,
     questions: store.getState().search.questions,
     edits: store.getState().search.edits,
   };
@@ -120,10 +121,11 @@ export function downloadPdf() {
   };
 }
 
-export function searchRecord(aliases: AliasData[]): any {
+export function searchRecord(aliases: AliasData[], today: string): any {
   return (dispatch: Dispatch) => {
     dispatch({
       aliases: aliases,
+      today: today,
       type: RECORD_LOADING,
     });
     return buildAndSendSearchRequest(dispatch);

--- a/src/frontend/src/redux/search/reducer.ts
+++ b/src/frontend/src/redux/search/reducer.ts
@@ -37,6 +37,7 @@ const initalState: SearchRecordState = {
       birth_date: "",
     },
   ],
+  today: "",
   edits: {},
   editingRecord: false,
   userInformation: {},
@@ -149,6 +150,7 @@ export function searchReducer(
       return {
         ...state,
         aliases: action.aliases,
+        today: action.today,
         record: {},
         questions: {},
         edits: {},

--- a/src/frontend/src/redux/search/types.ts
+++ b/src/frontend/src/redux/search/types.ts
@@ -42,6 +42,7 @@ export interface SearchRecordState {
   loadingPdf: boolean;
   loadingExpungementPacket: boolean;
   aliases: AliasData[];
+  today: string;
   record?: RecordData;
   questions?: QuestionsData;
   edits?: any;
@@ -59,6 +60,7 @@ interface SearchRecordAction {
     | typeof STOP_DEMO;
 
   aliases: AliasData[];
+  today: string;
   record: RecordData;
   questions: QuestionsData;
   demo: boolean;


### PR DESCRIPTION
Sometimes we want to run our Expunger as if we were running it tomorrow or some arbitrary date in the future. We therefore add a new field internally called "today" to the SearchPanel to be able to change what day "today" is. By default it is the date as of now in PST/PDT. This is a really sweet feature addition from a technical perspective since we only rely on date.today() in one location in expunger.py, so we can do this change in relatively few lines and safely.

Here is a screenshot of the frontend changes:

![Screen Shot 2021-07-03 at 1 02 31 PM](https://user-images.githubusercontent.com/6329898/124342439-f267d800-dbfe-11eb-9947-e88f7c5da939.png)