### PR TITLE
Pass "today" through to the /api/expungement-packet endpoint

### DIFF
--- a/src/frontend/src/redux/search/actions.ts
+++ b/src/frontend/src/redux/search/actions.ts
@@ -291,6 +291,7 @@ export function downloadExpungementPacket(
         aliases: store.getState().search.aliases,
         questions: store.getState().search.questions,
         edits: store.getState().search.edits,
+        today: store.getState().search.today,
         userInformation: store.getState().search.userInformation,
       },
       method: "post",


### PR DESCRIPTION
This allows the PDF form fillings to use the same analysis that is shown on the initial search results summary panel.