### PR TITLE
Auto-add slashes to DOB field and disable inputs that don't look like dates

### DIFF
--- a/src/frontend/src/components/RecordSearch/SearchPanel/Alias.tsx
+++ b/src/frontend/src/components/RecordSearch/SearchPanel/Alias.tsx
@@ -69,7 +69,19 @@ export default class Alias extends React.Component<Props, State> {
           content={this.props.aliasData.birth_date}
           coda="mm/dd/yyyy"
           onChange={(fieldValue: string) => {
-            this.handleFieldChange("birth_date", fieldValue);
+            let newValue = fieldValue;
+            const match1 = new RegExp("^[0-9][0-9](\/[0-9][0-9])?$").exec(fieldValue);
+            const match2 = new RegExp("^[0-9]?([0-9](\/([0-9]([0-9](\/([0-9]([0-9]([0-9][0-9]?)?)?)?)?)?)?)?)?$").exec(fieldValue);
+            if (match1 && match1[0].length===newValue.length) {
+              if (this.props.aliasData.birth_date.slice(-1)=="/") {
+                newValue = fieldValue;
+              } else {
+                newValue = newValue+"/";
+              }
+            } else if (!(match2 && match2[0].length===newValue.length)) {
+              newValue=this.props.aliasData.birth_date;
+            }
+            this.handleFieldChange("birth_date", newValue);
           }}
           required={false}
           errorMessage="dob_msg"


### PR DESCRIPTION
Sarah Kolb asked for this feature. 

I've seen web forms out there that have nice text styling too that makes this feel more intuitive, like with a light-colored suggestion text where the slash "solidifies" at the right time. Other solutions have 3 fields and the cursor moves between them as the user types. Those are probably harder to implement than the solution I did here.

@KentShikama @hmarcks what do you think of putting this change in?