### PR TITLE
Update Summary PDFs to contain balance due

### DIFF
--- a/src/backend/expungeservice/pdf/markdown_serializer.py
+++ b/src/backend/expungeservice/pdf/markdown_serializer.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 
 class MarkdownSerializer:
@@ -55,42 +55,44 @@ If the above assumptions are not true for you and you would like an updated anal
             return ""
 
     @staticmethod
-    def _flatten_charges(case_charges_tuples):
-        charges : List[str]= []
-        if case_charges_tuples:
-            for c in case_charges_tuples:
-                charges += c[1]
-        return charges
+    def _build_listed_charges(eligible_case_charges_tuples: List[Tuple[str, List[Tuple[str, str]]]]) -> str:
+        listed_charges = ""
+        for case_info, charges_info in eligible_case_charges_tuples:
+            if case_info:
+                listed_charges += f" - {case_info} \n"
+                charges = [description for id, description in charges_info]
+                listed_charges += "     - " + " \n     - ".join(charges) + " \n"
+            else:
+                charges = [description for id, description in charges_info]
+                listed_charges += " - " + " \n - ".join(charges) + " \n"
+        return listed_charges
 
     @staticmethod
     def _gen_eligible_charges_block(record):
         eligible_case_charges_tuples = record["summary"]["charges_grouped_by_eligibility_and_case"].get("Eligible Now")
-        eligible_charges = MarkdownSerializer._flatten_charges(eligible_case_charges_tuples)
-        if eligible_charges:
-            charges = [charge_tuple[1] for charge_tuple in eligible_charges]
-            listed_charges = " - " + " \n - ".join(charges)
+        if eligible_case_charges_tuples:
+            listed_charges = MarkdownSerializer._build_listed_charges(eligible_case_charges_tuples)
         else:
             listed_charges = "You are not currently eligible to expunge any charges."
         return "## Charges Eligible Now  \n" + listed_charges + "  \n"
 
     @staticmethod
     def _gen_eligible_charges_if_balance_paid_block(record):
-        eligible_case_charges_tuples = record["summary"]["charges_grouped_by_eligibility_and_case"].get("Eligible Now If Balance Paid")
-        eligible_charges = MarkdownSerializer._flatten_charges(eligible_case_charges_tuples)
-        if eligible_charges:
-            charges = [charge_tuple[1] for charge_tuple in eligible_charges]
-            listed_charges = " - " + " \n - ".join(charges)
+        eligible_case_charges_tuples = record["summary"]["charges_grouped_by_eligibility_and_case"].get(
+            "Eligible Now If Balance Paid"
+        )
+        if eligible_case_charges_tuples:
+            listed_charges = MarkdownSerializer._build_listed_charges(eligible_case_charges_tuples)
             return f"## Charges Eligible Now If Balance Paid  \nThese convictions are eligible as soon as the balance of fines on the case is paid.  \n\n{listed_charges}  \n"
         else:
             return ""
+
     @staticmethod
     def _gen_ineligible_charges_block(record):
         ineligible_case_charges_tuples = record["summary"]["charges_grouped_by_eligibility_and_case"].get("Ineligible")
-        ineligible_charges = MarkdownSerializer._flatten_charges(ineligible_case_charges_tuples)
-        if ineligible_charges:
-            charges = [charge_tuple[1] for charge_tuple in ineligible_charges]
-            charges_string = " - " + "  \n - ".join(charges)
-            return f"## Ineligible Charges  \nThese convictions are not eligible for expungement at any time under the current law.  \n\n{charges_string}  \n"
+        if ineligible_case_charges_tuples:
+            listed_charges = MarkdownSerializer._build_listed_charges(ineligible_case_charges_tuples)
+            return f"## Ineligible Charges  \nThese convictions are not eligible for expungement at any time under the current law.  \n\n{listed_charges}  \n"
         else:
             return ""
 
@@ -105,9 +107,7 @@ If the above assumptions are not true for you and you would like an updated anal
         if future_eligible_charges:
             text_block = "## Future Eligible Charges  \nThe following charges (dismissed and convicted) are eligible at the designated dates. Convictions in the future will set your eligibility dates back until ten years from the date of conviction.  \n"
             for label, section in sorted(future_eligible_charges, key=MarkdownSerializer._sort_future_eligible):
-                flattened_charges = MarkdownSerializer._flatten_charges(section)
-                charges = [charge_tuple[1] for charge_tuple in flattened_charges]
-                listed_charges = " - " + "  \n - ".join(charges)
+                listed_charges = MarkdownSerializer._build_listed_charges(section)
                 text_block += "### " + label + "  \n" + listed_charges + "  \n\n"
             return text_block
         else:
@@ -128,12 +128,12 @@ If the above assumptions are not true for you and you would like an updated anal
 
     @staticmethod
     def _gen_needs_more_analysis_block(record):
-        needs_more_analysis_charges_tuples = record["summary"]["charges_grouped_by_eligibility_and_case"].get("Needs More Analysis")
-        needs_more_analysis_charges = MarkdownSerializer._flatten_charges(needs_more_analysis_charges_tuples)
-        if needs_more_analysis_charges:
-            charges = [charge_tuple[1] for charge_tuple in needs_more_analysis_charges]
+        needs_more_analysis_charges_tuples = record["summary"]["charges_grouped_by_eligibility_and_case"].get(
+            "Needs More Analysis"
+        )
+        if needs_more_analysis_charges_tuples:
             text_block = "## Charges Needing More Analysis  \nAdditionally, you have charges for which the online records do not contain enough information to determine eligibility. If you are curious about the eligibility of these charges, please contact roe@qiu-qiulaw.com.  \n\n"
-            listed_charges = " - " + "  \n - ".join(charges)
+            listed_charges = MarkdownSerializer._build_listed_charges(needs_more_analysis_charges_tuples)
             text_block += listed_charges + "  \n\n"
             return text_block
         else:

--- a/src/backend/tests/models/test_record_summarizer.py
+++ b/src/backend/tests/models/test_record_summarizer.py
@@ -109,30 +109,62 @@ def test_record_summarizer_multiple_cases():
         "Eligible Now If Balance Paid": [
             (
                 "Multnomah 1 – $100.0",
-                [(case_all_eligible.charges[0].ambiguous_charge_id, "Theft of dignity (CONVICTED) Charged Jan 1, 2010")]
+                [
+                    (
+                        case_all_eligible.charges[0].ambiguous_charge_id,
+                        "Theft of dignity (CONVICTED) Charged Jan 1, 2010",
+                    )
+                ],
             ),
-           (
+            (
                 "Clackamas 2 – $200.0",
-                [(case_partially_eligible.charges[0].ambiguous_charge_id, "Theft of services (CONVICTED) Charged Jan 1, 2010")]
+                [
+                    (
+                        case_partially_eligible.charges[0].ambiguous_charge_id,
+                        "Theft of services (CONVICTED) Charged Jan 1, 2010",
+                    )
+                ],
             ),
-           (
+            (
                 "Baker 3 – $300.0",
-                [(case_possibly_eligible.charges[0].ambiguous_charge_id, "Theft of services (CONVICTED) Charged Jan 1, 2010")]
-            )
+                [
+                    (
+                        case_possibly_eligible.charges[0].ambiguous_charge_id,
+                        "Theft of services (CONVICTED) Charged Jan 1, 2010",
+                    )
+                ],
+            ),
         ],
         "Ineligible": [
             (
-                "Clackamas 2 – $200.0",
-                [(case_partially_eligible.charges[1].ambiguous_charge_id, "Theft of services (CONVICTED) Charged Jan 1, 2010")]
+                "",
+                [
+                    (
+                        case_partially_eligible.charges[1].ambiguous_charge_id,
+                        "Theft of services (CONVICTED) Charged Jan 1, 2010",
+                    )
+                ],
             ),
             (
-                "Baker 4 – $400.0",
-                [(case_all_ineligible.charges[0].ambiguous_charge_id, "Theft of services (CONVICTED) Charged Jan 1, 2010")]),
+                "",
+                [
+                    (
+                        case_all_ineligible.charges[0].ambiguous_charge_id,
+                        "Theft of services (CONVICTED) Charged Jan 1, 2010",
+                    )
+                ],
+            ),
             (
                 "",
-                [(case_all_ineligible_2.charges[0].ambiguous_charge_id, "Theft of services (CONVICTED) Charged Jan 1, 2010")])
+                [
+                    (
+                        case_all_ineligible_2.charges[0].ambiguous_charge_id,
+                        "Theft of services (CONVICTED) Charged Jan 1, 2010",
+                    )
+                ],
+            ),
         ],
-}
+    }
 
     assert (
         next(county.total_fines_due for county in record_summary.county_fines if county.county_name == "Multnomah")

--- a/src/backend/tests/pdf/test_markdown_serializer.py
+++ b/src/backend/tests/pdf/test_markdown_serializer.py
@@ -39,8 +39,10 @@ You are not currently eligible to expunge any charges.
 ## Charges Eligible Now If Balance Paid  
 These convictions are eligible as soon as the balance of fines on the case is paid.  
 
- - Possession of Cocaine (CONVICTED) Charged Jun 13, 2009 
- - Possession of Cocaine (DISMISSED) Charged Feb 17, 2009  
+ - Multnomah CASEJD1 – $529.08 
+     - Possession of Cocaine (CONVICTED) Charged Jun 13, 2009 
+     - Possession of Cocaine (DISMISSED) Charged Feb 17, 2009 
+  
  
   
 """
@@ -49,7 +51,10 @@ These convictions are eligible as soon as the balance of fines on the case is pa
 @pytest.fixture
 def example_record():
     return CrawlerFactory.create(
-        record=JohnDoe.SINGLE_CASE_RECORD, cases={"CASEJD1": CaseDetails.CASE_WITH_REVOKED_PROBATION,},
+        record=JohnDoe.SINGLE_CASE_RECORD,
+        cases={
+            "CASEJD1": CaseDetails.CASE_WITH_REVOKED_PROBATION,
+        },
     )
 
 


### PR DESCRIPTION
Based on feedback from @michaelzhang43.

We want to mimic the design of the HTML summary panel as much as possible for the PDF. This includes printing out information about the balances due for each case.

Also suppresses the balance due/case grouping if the charges are Eligible now, Ineligible, etc.

Screenshots examples

<img width="938" alt="Screen Shot 2021-09-18 at 4 09 35 AM" src="https://user-images.githubusercontent.com/6329898/133886777-cdbe2188-0920-4d47-abfa-e5610eaaa90a.png">
<img width="972" alt="Screen Shot 2021-09-18 at 4 10 31 AM" src="https://user-images.githubusercontent.com/6329898/133886800-4542ef0f-ace2-420a-84fa-f34dab8f2d84.png">

