### PR TITLE
Updates analysis stat on landing page

### DIFF
--- a/src/frontend/src/components/App/__snapshots__/App.test.tsx.snap
+++ b/src/frontend/src/components/App/__snapshots__/App.test.tsx.snap
@@ -1596,7 +1596,7 @@ Array [
           <p
             className="tc fw7 white mw7 mh4"
           >
-            Over 5,600 analyses delivered as of January 2022
+            Over 10,000 analyses delivered as of January 2023
           </p>
         </div>
       </div>

--- a/src/frontend/src/components/Landing/index.tsx
+++ b/src/frontend/src/components/Landing/index.tsx
@@ -108,7 +108,7 @@ class Landing extends React.Component {
 
                 <span className="db w4 center bb bw2 b--blue mb3"></span>
                 <p className="tc fw7 white mw7 mh4">
-                  Over 5,600 analyses delivered as of January 2022
+                  Over 10,000 analyses delivered as of January 2023
                 </p>
               </div>
             </div>


### PR DESCRIPTION
 Closes #1641 -  Updates "Over 5,600 analyses delivered as of January 2022" to "Over 10,000 analyses delivered as of January 2023"  