### PR TITLE
Jw/charges summary is ordered

### DIFF
--- a/src/backend/expungeservice/charges_summarizer.py
+++ b/src/backend/expungeservice/charges_summarizer.py
@@ -13,7 +13,7 @@ class ChargesSummarizer:
         visible_charges = [
             charge for charge in record.charges if not charge.charge_type.hidden_in_record_summary(charge.disposition)
         ]
-        eligible_charges_by_date: Dict[str, List[Tuple[str, List[Tuple[str, str]]]]] = {}
+        eligible_charges_by_date: Tuple[str, List[Tuple[str, List[Tuple[str, str]]]]] = []
         sorted_charges = sorted(
             sorted(visible_charges, key=ChargesSummarizer._secondary_sort, reverse=True),
             key=lambda charge: ChargesSummarizer._primary_sort(charge, record),
@@ -32,7 +32,7 @@ class ChargesSummarizer:
                     if case_charge.edit_status != EditStatus.DELETE
                 ]
                 charges_in_section.append((case_info_line, charges_tuples))
-            eligible_charges_by_date[label] = charges_in_section
+            eligible_charges_by_date.append((label, charges_in_section))
         return eligible_charges_by_date
 
     @staticmethod
@@ -52,11 +52,11 @@ class ChargesSummarizer:
                     return 9, "Eligible If Balance Paid on case with Ineligible charge"
 
             if label == "Eligible Now" and future_eligibility_label_on_case:
-                label = "Eligible on case with charge " + future_eligibility_label_on_case
+                label = future_eligibility_label_on_case
                 if no_balance:
-                    return 10, label
+                    return 6, label
                 else:
-                    return 11, label + " If Balance Paid"
+                    return 7, label + " If Balance Paid"
 
             if label == "Needs More Analysis":
                 return 0, label

--- a/src/backend/expungeservice/charges_summarizer.py
+++ b/src/backend/expungeservice/charges_summarizer.py
@@ -13,7 +13,7 @@ class ChargesSummarizer:
         visible_charges = [
             charge for charge in record.charges if not charge.charge_type.hidden_in_record_summary(charge.disposition)
         ]
-        eligible_charges_by_date: Tuple[str, List[Tuple[str, List[Tuple[str, str]]]]] = []
+        eligible_charges_by_date: List[Tuple[str, List[Tuple[str, List[Tuple[str, str]]]]]] = []
         sorted_charges = sorted(
             sorted(visible_charges, key=ChargesSummarizer._secondary_sort, reverse=True),
             key=lambda charge: ChargesSummarizer._primary_sort(charge, record),

--- a/src/backend/expungeservice/models/record_summary.py
+++ b/src/backend/expungeservice/models/record_summary.py
@@ -20,7 +20,7 @@ class CountyFines:
         return round(sum([case_fines.balance for case_fines in self.case_fines]), 2)
 
 
-ChargesForSummaryPanel = Tuple[str, List[Tuple[str, List[Tuple[str, str]]]]]
+ChargesForSummaryPanel = List[Tuple[str, List[Tuple[str, List[Tuple[str, str]]]]]]
 
 
 @dataclass

--- a/src/backend/expungeservice/models/record_summary.py
+++ b/src/backend/expungeservice/models/record_summary.py
@@ -20,7 +20,8 @@ class CountyFines:
         return round(sum([case_fines.balance for case_fines in self.case_fines]), 2)
 
 
-ChargesForSummaryPanel = Dict[str, List[Tuple[str,List[Tuple[str, str]]]]]
+ChargesForSummaryPanel = Tuple[str, List[Tuple[str, List[Tuple[str, str]]]]]
+
 
 @dataclass
 class RecordSummary:

--- a/src/backend/expungeservice/pdf/markdown_serializer.py
+++ b/src/backend/expungeservice/pdf/markdown_serializer.py
@@ -57,7 +57,6 @@ If the above assumptions are not true for you and you would like an updated anal
     @staticmethod
     def _build_listed_charges(eligible_case_charges_tuples: List[Tuple[str, List[Tuple[str, str]]]]) -> str:
         listed_charges = ""
-        print("build...", eligible_case_charges_tuples)
         for case_info, charges_info in eligible_case_charges_tuples:
             if case_info:
                 listed_charges += f" - {case_info} \n"

--- a/src/backend/expungeservice/pdf/markdown_serializer.py
+++ b/src/backend/expungeservice/pdf/markdown_serializer.py
@@ -57,6 +57,7 @@ If the above assumptions are not true for you and you would like an updated anal
     @staticmethod
     def _build_listed_charges(eligible_case_charges_tuples: List[Tuple[str, List[Tuple[str, str]]]]) -> str:
         listed_charges = ""
+        print("build...", eligible_case_charges_tuples)
         for case_info, charges_info in eligible_case_charges_tuples:
             if case_info:
                 listed_charges += f" - {case_info} \n"
@@ -69,29 +70,36 @@ If the above assumptions are not true for you and you would like an updated anal
 
     @staticmethod
     def _gen_eligible_charges_block(record):
-        eligible_case_charges_tuples = record["summary"]["charges_grouped_by_eligibility_and_case"].get("Eligible Now")
-        if eligible_case_charges_tuples:
-            listed_charges = MarkdownSerializer._build_listed_charges(eligible_case_charges_tuples)
+        eligible_case_charges_tuples = [
+            x for x in record["summary"]["charges_grouped_by_eligibility_and_case"] if x[0] == "Eligible Now"
+        ]
+        if len(eligible_case_charges_tuples) > 0:
+            listed_charges = MarkdownSerializer._build_listed_charges(eligible_case_charges_tuples[0][1])
         else:
             listed_charges = "You are not currently eligible to expunge any charges."
         return "## Charges Eligible Now  \n" + listed_charges + "  \n"
 
     @staticmethod
     def _gen_eligible_charges_if_balance_paid_block(record):
-        eligible_case_charges_tuples = record["summary"]["charges_grouped_by_eligibility_and_case"].get(
-            "Eligible Now If Balance Paid"
-        )
-        if eligible_case_charges_tuples:
-            listed_charges = MarkdownSerializer._build_listed_charges(eligible_case_charges_tuples)
+        eligible_case_charges_tuples = [
+            x
+            for x in record["summary"]["charges_grouped_by_eligibility_and_case"]
+            if x[0] == "Eligible Now If Balance Paid"
+        ]
+
+        if len(eligible_case_charges_tuples) > 0:
+            listed_charges = MarkdownSerializer._build_listed_charges(eligible_case_charges_tuples[0][1])
             return f"## Charges Eligible Now If Balance Paid  \nThese convictions are eligible as soon as the balance of fines on the case is paid.  \n\n{listed_charges}  \n"
         else:
             return ""
 
     @staticmethod
     def _gen_ineligible_charges_block(record):
-        ineligible_case_charges_tuples = record["summary"]["charges_grouped_by_eligibility_and_case"].get("Ineligible")
-        if ineligible_case_charges_tuples:
-            listed_charges = MarkdownSerializer._build_listed_charges(ineligible_case_charges_tuples)
+        ineligible_case_charges_tuples = [
+            x for x in record["summary"]["charges_grouped_by_eligibility_and_case"] if x[0] == "Ineligible"
+        ]
+        if len(ineligible_case_charges_tuples) > 0:
+            listed_charges = MarkdownSerializer._build_listed_charges(ineligible_case_charges_tuples[0][1])
             return f"## Ineligible Charges  \nThese convictions are not eligible for expungement at any time under the current law.  \n\n{listed_charges}  \n"
         else:
             return ""
@@ -100,8 +108,8 @@ If the above assumptions are not true for you and you would like an updated anal
     def _gen_future_eligible_block(record):
         eligible_charges_by_date = record["summary"]["charges_grouped_by_eligibility_and_case"]
         future_eligible_charges = [
-            (key, eligible_charges_by_date[key])
-            for key in eligible_charges_by_date.keys()
+            (key, eligible_charges_for_date)
+            for key, eligible_charges_for_date in eligible_charges_by_date
             if key not in ["Eligible Now", "Ineligible", "Needs More Analysis", "Eligible Now If Balance Paid"]
         ]
         if future_eligible_charges:
@@ -128,12 +136,12 @@ If the above assumptions are not true for you and you would like an updated anal
 
     @staticmethod
     def _gen_needs_more_analysis_block(record):
-        needs_more_analysis_charges_tuples = record["summary"]["charges_grouped_by_eligibility_and_case"].get(
-            "Needs More Analysis"
-        )
-        if needs_more_analysis_charges_tuples:
+        needs_more_analysis_charges_tuples = [
+            x for x in record["summary"]["charges_grouped_by_eligibility_and_case"] if x[0] == "Needs More Analysis"
+        ]
+        if len(needs_more_analysis_charges_tuples) > 0:
             text_block = "## Charges Needing More Analysis  \nAdditionally, you have charges for which the online records do not contain enough information to determine eligibility. If you are curious about the eligibility of these charges, please contact roe@qiu-qiulaw.com.  \n\n"
-            listed_charges = MarkdownSerializer._build_listed_charges(needs_more_analysis_charges_tuples)
+            listed_charges = MarkdownSerializer._build_listed_charges(needs_more_analysis_charges_tuples[0][1])
             text_block += listed_charges + "  \n\n"
             return text_block
         else:

--- a/src/backend/expungeservice/serializer.py
+++ b/src/backend/expungeservice/serializer.py
@@ -7,7 +7,7 @@ from expungeservice.models.record_summary import RecordSummary, CountyFines
 
 class ExpungeModelEncoder(flask.json.JSONEncoder):
     def record_summary_to_json(self, record_summary):
-        return {
+        record_summary = {
             **self.record_to_json(record_summary.record),
             **{
                 "summary": {
@@ -20,6 +20,7 @@ class ExpungeModelEncoder(flask.json.JSONEncoder):
                 "questions": record_summary.questions,
             },
         }
+        return record_summary
 
     def record_to_json(self, record):
         return {

--- a/src/backend/tests/models/test_record_summarizer.py
+++ b/src/backend/tests/models/test_record_summarizer.py
@@ -105,68 +105,77 @@ def test_record_summarizer_multiple_cases():
     assert record_summary.total_fines_due == 1000.00
     assert record_summary.total_cases == 5
     assert record_summary.total_charges == 6
-    assert record_summary.charges_grouped_by_eligibility_and_case == {
-        "Eligible Now If Balance Paid": [
-            (
-                "Multnomah 1 – $100.0",
-                [
-                    (
-                        case_all_eligible.charges[0].ambiguous_charge_id,
-                        "Theft of dignity (CONVICTED) Charged Jan 1, 2010",
-                    )
-                ],
-            ),
-            (
-                "Baker 3 – $300.0",
-                [
-                    (
-                        case_possibly_eligible.charges[0].ambiguous_charge_id,
-                        "Theft of services (CONVICTED) Charged Jan 1, 2010",
-                    )
-                ],
-            ),
-        ],
-        "Eligible If Balance Paid on case with Ineligible charge": [
-          (
-                "Clackamas 2 – $200.0",
-                [
-                    (
-                        case_partially_eligible.charges[0].ambiguous_charge_id,
-                        "Theft of services (CONVICTED) Charged Jan 1, 2010",
-                    )
-                ],
-            ),
-        ],
-        "Ineligible": [
-            (
-                "",
-                [
-                    (
-                        case_partially_eligible.charges[1].ambiguous_charge_id,
-                        "Theft of services (CONVICTED) Charged Jan 1, 2010",
-                    )
-                ],
-            ),
-            (
-                "",
-                [
-                    (
-                        case_all_ineligible.charges[0].ambiguous_charge_id,
-                        "Theft of services (CONVICTED) Charged Jan 1, 2010",
-                    )
-                ],
-            ),
-            (
-                "",
-                [
-                    (
-                        case_all_ineligible_2.charges[0].ambiguous_charge_id,
-                        "Theft of services (CONVICTED) Charged Jan 1, 2010",
-                    )
-                ],
-            ),
-        ],
-    }
+    assert record_summary.charges_grouped_by_eligibility_and_case == [
+        (
+            "Ineligible",
+            [
+                (
+                    "",
+                    [
+                        (
+                            case_partially_eligible.charges[1].ambiguous_charge_id,
+                            "Theft of services (CONVICTED) Charged Jan 1, 2010",
+                        )
+                    ],
+                ),
+                (
+                    "",
+                    [
+                        (
+                            case_all_ineligible.charges[0].ambiguous_charge_id,
+                            "Theft of services (CONVICTED) Charged Jan 1, 2010",
+                        )
+                    ],
+                ),
+                (
+                    "",
+                    [
+                        (
+                            case_all_ineligible_2.charges[0].ambiguous_charge_id,
+                            "Theft of services (CONVICTED) Charged Jan 1, 2010",
+                        )
+                    ],
+                ),
+            ],
+        ),
+        (
+            "Eligible Now If Balance Paid",
+            [
+                (
+                    "Multnomah 1 – $100.0",
+                    [
+                        (
+                            case_all_eligible.charges[0].ambiguous_charge_id,
+                            "Theft of dignity (CONVICTED) Charged Jan 1, 2010",
+                        )
+                    ],
+                ),
+                (
+                    "Baker 3 – $300.0",
+                    [
+                        (
+                            case_possibly_eligible.charges[0].ambiguous_charge_id,
+                            "Theft of services (CONVICTED) Charged Jan 1, 2010",
+                        )
+                    ],
+                ),
+            ],
+        ),
+        (
+            "Eligible If Balance Paid on case with Ineligible charge",
+            [
+                (
+                    "Clackamas 2 – $200.0",
+                    [
+                        (
+                            case_partially_eligible.charges[0].ambiguous_charge_id,
+                            "Theft of services (CONVICTED) Charged Jan 1, 2010",
+                        )
+                    ],
+                ),
+            ],
+        ),
+    ]
 
     assert (
         next(county.total_fines_due for county in record_summary.county_fines if county.county_name == "Multnomah")
@@ -189,4 +198,4 @@ def test_record_summarizer_no_cases():
     assert record_summary.total_cases == 0
     assert record_summary.total_charges == 0
     assert record_summary.county_fines == []
-    assert record_summary.charges_grouped_by_eligibility_and_case == {}
+    assert record_summary.charges_grouped_by_eligibility_and_case == []

--- a/src/frontend/src/components/RecordSearch/Record/RecordSummary/ChargesList.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/RecordSummary/ChargesList.tsx
@@ -18,7 +18,7 @@ interface EligibilityGroupProps {
 }
 
 interface ChargeListProps {
-  chargesGroupedByEligibilityAndCase: { [label: string]: any[] };
+  chargesGroupedByEligibilityAndCase: [string, any[]][];
   totalCharges: number;
 }
 
@@ -101,7 +101,7 @@ export default function ChargesList({
         <p className="f6 fw5 pt1">Excludes traffic violations</p>
       </h3>
 
-      {Object.entries(chargesGroupedByEligibilityAndCase).map(
+      {chargesGroupedByEligibilityAndCase.map(
         ([eligibility, headerAndCharges]) => {
           return (
             <EligibilityGroup

--- a/src/frontend/src/components/RecordSearch/Record/RecordSummary/index.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/RecordSummary/index.tsx
@@ -29,7 +29,9 @@ export default function RecordSummary() {
   } = summary;
 
   const handleGenerateFormsClick = () => {
-    if (groupedCharges["Eligible Now"]?.length > 0) {
+    if (
+      groupedCharges?.filter((x) => x[0] === "Eligible Now")[0][1]?.length > 0
+    ) {
       history.push("/fill-expungement-forms");
     } else {
       setCanGenerateForms(false);

--- a/src/frontend/src/components/RecordSearch/Record/types.ts
+++ b/src/frontend/src/components/RecordSearch/Record/types.ts
@@ -57,7 +57,7 @@ export interface RecordData {
 
 export interface RecordSummaryData {
   total_charges: number;
-  charges_grouped_by_eligibility_and_case: { [label: string]: any[] };
+  charges_grouped_by_eligibility_and_case: [string, any[]][];
   county_fines: CountyFinesData[];
   total_fines_due: number;
   total_cases: number;

--- a/src/frontend/src/test/data/blankResponse.ts
+++ b/src/frontend/src/test/data/blankResponse.ts
@@ -7,7 +7,7 @@ const blankResponse: SearchResponse = {
     questions: {},
     summary: {
       total_charges: 0,
-      charges_grouped_by_eligibility_and_case: { "Eligible Now": [] },
+      charges_grouped_by_eligibility_and_case: [["Eligible Now", []]],
       county_fines: [],
       total_fines_due: 0,
       total_cases: 0,

--- a/src/frontend/src/test/data/commonResponse.ts
+++ b/src/frontend/src/test/data/commonResponse.ts
@@ -327,59 +327,69 @@ const commonResponse: SearchResponse = {
       },
     },
     summary: {
-      charges_grouped_by_eligibility_and_case: {
-        "Eligible Jan 21, 2026": [
+      charges_grouped_by_eligibility_and_case: [
+        [
+          "Eligible Jan 21, 2026",
           [
-            "",
             [
+              "",
               [
-                "100000-1",
-                "Aggravated Theft in the First Degree (CONVICTED) Charged Sep 9, 2016",
+                [
+                  "100000-1",
+                  "Aggravated Theft in the First Degree (CONVICTED) Charged Sep 9, 2016",
+                ],
               ],
             ],
           ],
         ],
-        "Eligible Now": [
+        [
+          "Eligible Now",
           [
-            "",
             [
+              "",
               [
-                "200000-1",
-                "Obstruction of search warrant (DISMISSED) Charged Sep 9, 2019",
+                [
+                  "200000-1",
+                  "Obstruction of search warrant (DISMISSED) Charged Sep 9, 2019",
+                ],
               ],
             ],
-          ],
-          [
-            "",
             [
+              "",
               [
-                "110000-1",
-                "Theft in the Second Degree (CONVICTED) Charged May 26, 2015",
+                [
+                  "110000-1",
+                  "Theft in the Second Degree (CONVICTED) Charged May 26, 2015",
+                ],
               ],
             ],
-          ],
-          [
-            "",
             [
+              "",
               [
-                "120000-1",
-                "Poss under oz Marijuana (CONVICTED) Charged May 26, 2014",
-              ],
-            ],
-          ],
-        ],
-        "Needs More Analysis": [
-          [
-            "",
-            [
-              [
-                "210000-1",
-                "Poss Controlled Sub (CONVICTED) Charged Nov 16, 2018",
+                [
+                  "120000-1",
+                  "Poss under oz Marijuana (CONVICTED) Charged May 26, 2014",
+                ],
               ],
             ],
           ],
         ],
-      },
+
+        [
+          "Needs More Analysis",
+          [
+            [
+              "",
+              [
+                [
+                  "210000-1",
+                  "Poss Controlled Sub (CONVICTED) Charged Nov 16, 2018",
+                ],
+              ],
+            ],
+          ],
+        ],
+      ],
       county_fines: [
         { case_fines: [], county_name: "Baker", total_fines_due: 0 },
         { case_fines: [], county_name: "Benton", total_fines_due: 0 },

--- a/src/frontend/src/test/data/complexResponse.ts
+++ b/src/frontend/src/test/data/complexResponse.ts
@@ -1934,251 +1934,272 @@ const complexResponse: SearchResponse = {
     errors: [],
     summary: {
       total_charges: 41,
-      charges_grouped_by_eligibility_and_case: {
-        "Needs More Analysis": [
+      charges_grouped_by_eligibility_and_case: [
+        [
+          "Needs More Analysis",
           [
-            "",
             [
+              "",
               [
-                "996271-1",
-                "Attempt to Commit a Class C/Unclassified Felony (CONVICTED) Charged Jan 29, 2014",
-              ],
-              [
-                "996271-2",
-                "Attempt to Commit a Class C/Unclassified Felony (CONVICTED) Charged Jan 29, 2014",
+                [
+                  "996271-1",
+                  "Attempt to Commit a Class C/Unclassified Felony (CONVICTED) Charged Jan 29, 2014",
+                ],
+                [
+                  "996271-2",
+                  "Attempt to Commit a Class C/Unclassified Felony (CONVICTED) Charged Jan 29, 2014",
+                ],
               ],
             ],
-          ],
-          [
-            "",
             [
+              "",
               [
-                "9999323-9",
-                "Attempt to Commit a Class C/Unclassified Felony (CONVICTED) Charged Jan 23, 1996",
-              ],
-            ],
-          ],
-        ],
-        Ineligible: [
-          [
-            "",
-            [
-              [
-                "99AV3457-1",
-                "A traffic charge (CONVICTED) Charged Jan 11, 2019",
-              ],
-            ],
-          ],
-          [
-            "",
-            [
-              [
-                "99DF09900-1",
-                "A traffic charge (CONVICTED) Charged Jan 1, 2019",
-              ],
-            ],
-          ],
-          ["", [["999933-1", "ABC/Felony (CONVICTED) Charged Jan 27, 1996"]]],
-          ["", [["999252-D-1", "SUII (CONVICTED) Charged Jan 10, 1995"]]],
-          [
-            "",
-            [
-              [
-                "XX99972-D-1",
-                "ABC/Misdemeanor (CONVICTED) Charged Jan 30, 1989",
-              ],
-            ],
-          ],
-          ["", [["XX99057-X-1", "SUII (CONVICTED) Charged Jan 14, 1988"]]],
-        ],
-        "Eligible Now": [
-          [
-            "",
-            [
-              [
-                "9910A9-1",
-                "Attempt to Commit a Class B Felony (DISMISSED) Charged Jan 11, 2002",
-              ],
-              [
-                "9910A9-2",
-                "Attempt to Commit a Class B Felony (DISMISSED) Charged Jan 11, 2002",
-              ],
-              [
-                "9910A9-6",
-                "Resisting An Orange (DISMISSED) Charged Jan 11, 2002",
-              ],
-            ],
-          ],
-          [
-            "",
-            [
-              ["9960799-1", "Frowning (DISMISSED) Charged Jan 1, 2000"],
-              ["9960799-2", "Skipping Rope (DISMISSED) Charged Jan 1, 2000"],
-            ],
-          ],
-          [
-            "",
-            [
-              [
-                "9950699A-1",
-                "Contempt of Court - Punitive (CONVICTED) Charged Jan 1, 1998",
-              ],
-              [
-                "9950699A-2",
-                "Contempt of Court - Punitive (DISMISSED) Charged Jan 11, 1998",
-              ],
-            ],
-          ],
-          [
-            "",
-            [
-              [
-                "99506871AA-1",
-                "Contempt of Court (DISMISSED) Charged Jan 23, 1998",
-              ],
-            ],
-          ],
-          ["", [["999345-2", "Frowning (DISMISSED) Charged Jan 5, 1998"]]],
-          [
-            "",
-            [
-              [
-                "9999323-1",
-                "Illegal stuff in the First Degree (DISMISSED) Charged Jan 23, 1996",
-              ],
-              [
-                "9999323-2",
-                "Something else illegal in the First Degree (DISMISSED) Charged Jan 23, 1996",
-              ],
-              [
-                "9999323-3",
-                "Something else illegal in the First Degree (DISMISSED) Charged Jan 23, 1996",
-              ],
-              [
-                "9999323-4",
-                "Something illegal (DISMISSED) Charged Jan 23, 1996",
-              ],
-              [
-                "9999323-5",
-                "Something illegal in the Second Degree (DISMISSED) Charged Jan 23, 1996",
-              ],
-              [
-                "9999323-6",
-                "Something illegal in the Second Degree (DISMISSED) Charged Jan 23, 1996",
-              ],
-              [
-                "9999323-7",
-                "Something illegal in the Second Degree (DISMISSED) Charged Jan 23, 1996",
-              ],
-              [
-                "9999323-8",
-                "Something illegal in the Second Degree (DISMISSED) Charged Jan 23, 1996",
-              ],
-            ],
-          ],
-          [
-            "",
-            [
-              [
-                "9999323D-D-1",
-                "Illegal stuff in the First Degree (DISMISSED) Charged Jan 23, 1996",
-              ],
-              [
-                "9999323D-D-2",
-                "Something else illegal in the First Degree (DISMISSED) Charged Jan 23, 1996",
-              ],
-              [
-                "9999323D-D-3",
-                "Something illegal (DISMISSED) Charged Jan 23, 1996",
-              ],
-              [
-                "9999323D-D-4",
-                "Something illegal in the Second Degree (DISMISSED) Charged Jan 23, 1996",
-              ],
-            ],
-          ],
-          [
-            "",
-            [["999933D-D-1", "ABC/Felony (DISMISSED) Charged Jan 27, 1996"]],
-          ],
-          [
-            "",
-            [
-              [
-                "999620-X-1",
-                "Discarding Hot Dogs w/in 100 Yards of State Waters (CONVICTED) Charged Jan 22, 1991",
+                [
+                  "9999323-9",
+                  "Attempt to Commit a Class C/Unclassified Felony (CONVICTED) Charged Jan 23, 1996",
+                ],
               ],
             ],
           ],
         ],
-        "Eligible Now If Balance Paid": [
+        [
+          "Ineligible",
           [
-            "Washington 99AV3457 \u2013 $100",
             [
+              "",
               [
-                "99AV3457-2",
-                "Reckless Diving (DISMISSED) Charged Jan 11, 2019",
-              ],
-              [
-                "99AV3457-3",
-                "Failure to Perform Duties of Golfer-Property Damage (DISMISSED) Charged Jan 11, 2019",
+                [
+                  "99AV3457-1",
+                  "A traffic charge (CONVICTED) Charged Jan 11, 2019",
+                ],
               ],
             ],
-          ],
-          [
-            "Washington 99DF09900 \u2013 $100",
             [
+              "",
               [
-                "99DF09900-2",
-                "Resisting An Orange (DISMISSED) Charged Jan 1, 2019",
+                [
+                  "99DF09900-1",
+                  "A traffic charge (CONVICTED) Charged Jan 1, 2019",
+                ],
+              ],
+            ],
+            ["", [["999933-1", "ABC/Felony (CONVICTED) Charged Jan 27, 1996"]]],
+            ["", [["999252-D-1", "SUII (CONVICTED) Charged Jan 10, 1995"]]],
+            [
+              "",
+              [
+                [
+                  "XX99972-D-1",
+                  "ABC/Misdemeanor (CONVICTED) Charged Jan 30, 1989",
+                ],
+              ],
+            ],
+            ["", [["XX99057-X-1", "SUII (CONVICTED) Charged Jan 14, 1988"]]],
+          ],
+        ],
+        [
+          "Eligible Now",
+          [
+            [
+              "",
+              [
+                [
+                  "9910A9-1",
+                  "Attempt to Commit a Class B Felony (DISMISSED) Charged Jan 11, 2002",
+                ],
+                [
+                  "9910A9-2",
+                  "Attempt to Commit a Class B Felony (DISMISSED) Charged Jan 11, 2002",
+                ],
+                [
+                  "9910A9-6",
+                  "Resisting An Orange (DISMISSED) Charged Jan 11, 2002",
+                ],
+              ],
+            ],
+            [
+              "",
+              [
+                ["9960799-1", "Frowning (DISMISSED) Charged Jan 1, 2000"],
+                ["9960799-2", "Skipping Rope (DISMISSED) Charged Jan 1, 2000"],
+              ],
+            ],
+            [
+              "",
+              [
+                [
+                  "9950699A-1",
+                  "Contempt of Court - Punitive (CONVICTED) Charged Jan 1, 1998",
+                ],
+                [
+                  "9950699A-2",
+                  "Contempt of Court - Punitive (DISMISSED) Charged Jan 11, 1998",
+                ],
+              ],
+            ],
+            [
+              "",
+              [
+                [
+                  "99506871AA-1",
+                  "Contempt of Court (DISMISSED) Charged Jan 23, 1998",
+                ],
+              ],
+            ],
+            ["", [["999345-2", "Frowning (DISMISSED) Charged Jan 5, 1998"]]],
+            [
+              "",
+              [
+                [
+                  "9999323-1",
+                  "Illegal stuff in the First Degree (DISMISSED) Charged Jan 23, 1996",
+                ],
+                [
+                  "9999323-2",
+                  "Something else illegal in the First Degree (DISMISSED) Charged Jan 23, 1996",
+                ],
+                [
+                  "9999323-3",
+                  "Something else illegal in the First Degree (DISMISSED) Charged Jan 23, 1996",
+                ],
+                [
+                  "9999323-4",
+                  "Something illegal (DISMISSED) Charged Jan 23, 1996",
+                ],
+                [
+                  "9999323-5",
+                  "Something illegal in the Second Degree (DISMISSED) Charged Jan 23, 1996",
+                ],
+                [
+                  "9999323-6",
+                  "Something illegal in the Second Degree (DISMISSED) Charged Jan 23, 1996",
+                ],
+                [
+                  "9999323-7",
+                  "Something illegal in the Second Degree (DISMISSED) Charged Jan 23, 1996",
+                ],
+                [
+                  "9999323-8",
+                  "Something illegal in the Second Degree (DISMISSED) Charged Jan 23, 1996",
+                ],
+              ],
+            ],
+            [
+              "",
+              [
+                [
+                  "9999323D-D-1",
+                  "Illegal stuff in the First Degree (DISMISSED) Charged Jan 23, 1996",
+                ],
+                [
+                  "9999323D-D-2",
+                  "Something else illegal in the First Degree (DISMISSED) Charged Jan 23, 1996",
+                ],
+                [
+                  "9999323D-D-3",
+                  "Something illegal (DISMISSED) Charged Jan 23, 1996",
+                ],
+                [
+                  "9999323D-D-4",
+                  "Something illegal in the Second Degree (DISMISSED) Charged Jan 23, 1996",
+                ],
+              ],
+            ],
+            [
+              "",
+              [["999933D-D-1", "ABC/Felony (DISMISSED) Charged Jan 27, 1996"]],
+            ],
+            [
+              "",
+              [
+                [
+                  "999620-X-1",
+                  "Discarding Hot Dogs w/in 100 Yards of State Waters (CONVICTED) Charged Jan 22, 1991",
+                ],
               ],
             ],
           ],
         ],
-        "Eligible Jan 30, 2025": [
+        [
+          "Eligible Now If Balance Paid",
           [
-            "",
             [
-              ["9910A9-4", "Frowning (CONVICTED) Charged Jan 11, 2002"],
+              "Washington 99AV3457 \u2013 $100",
               [
-                "9910A9-5",
-                "Resisting An Orange (CONVICTED) Charged Jan 11, 2002",
+                [
+                  "99AV3457-2",
+                  "Reckless Diving (DISMISSED) Charged Jan 11, 2019",
+                ],
+                [
+                  "99AV3457-3",
+                  "Failure to Perform Duties of Golfer-Property Damage (DISMISSED) Charged Jan 11, 2019",
+                ],
               ],
             ],
-          ],
-          [
-            "",
             [
+              "Washington 99DF09900 \u2013 $100",
               [
-                "999345-1",
-                "Derping in the Fourth Degree (CONVICTED) Charged Jan 5, 1998",
-              ],
-            ],
-          ],
-        ],
-        "Eligible Jan 11, 2027": [
-          [
-            "",
-            [
-              [
-                "9910A9-3",
-                "Derping in the Fourth Degree (CONVICTED) Charged Jan 11, 2002",
+                [
+                  "99DF09900-2",
+                  "Resisting An Orange (DISMISSED) Charged Jan 1, 2019",
+                ],
               ],
             ],
           ],
         ],
-        "Eligible Jan 30, 2025 If Balance Paid": [
+        [
+          "Eligible Jan 30, 2025",
           [
-            "Washington 999388 \u2013 $1400.6",
             [
+              "",
               [
-                "999388-1",
-                "Improper Use of an Emergency Kazoo System (CONVICTED) Charged Jan 20, 2012",
+                ["9910A9-4", "Frowning (CONVICTED) Charged Jan 11, 2002"],
+                [
+                  "9910A9-5",
+                  "Resisting An Orange (CONVICTED) Charged Jan 11, 2002",
+                ],
+              ],
+            ],
+            [
+              "",
+              [
+                [
+                  "999345-1",
+                  "Derping in the Fourth Degree (CONVICTED) Charged Jan 5, 1998",
+                ],
               ],
             ],
           ],
         ],
-      },
+        [
+          "Eligible Jan 11, 2027",
+          [
+            [
+              "",
+              [
+                [
+                  "9910A9-3",
+                  "Derping in the Fourth Degree (CONVICTED) Charged Jan 11, 2002",
+                ],
+              ],
+            ],
+          ],
+        ],
+        [
+          "Eligible Jan 30, 2025 If Balance Paid",
+          [
+            [
+              "Washington 999388 \u2013 $1400.6",
+              [
+                [
+                  "999388-1",
+                  "Improper Use of an Emergency Kazoo System (CONVICTED) Charged Jan 20, 2012",
+                ],
+              ],
+            ],
+          ],
+        ],
+      ],
       total_cases: 18,
       county_fines: [
         {

--- a/src/frontend/src/test/data/errorResponse.ts
+++ b/src/frontend/src/test/data/errorResponse.ts
@@ -7,7 +7,7 @@ const errorResponse: SearchResponse = {
     questions: {},
     summary: {
       total_charges: 0,
-      charges_grouped_by_eligibility_and_case: { "Eligible Now": [] },
+      charges_grouped_by_eligibility_and_case: [["Eligible Now", []]],
       county_fines: [],
       total_fines_due: 0,
       total_cases: 0,

--- a/src/frontend/src/test/data/multipleResponse.ts
+++ b/src/frontend/src/test/data/multipleResponse.ts
@@ -273,34 +273,40 @@ const multipleResponse: SearchResponse = {
     errors: [],
     questions: {},
     summary: {
-      charges_grouped_by_eligibility_and_case: {
-        "Eligible Now": [
+      charges_grouped_by_eligibility_and_case: [
+        [
+          "Eligible Now",
           [
-            "",
             [
+              "",
               [
-                "110000-1",
-                "Theft in the Third Degree (DISMISSED) Charged Jan 21, 2022",
+                [
+                  "110000-1",
+                  "Theft in the Third Degree (DISMISSED) Charged Jan 21, 2022",
+                ],
               ],
             ],
           ],
         ],
-        "Eligible Now If Balance Paid": [
+        [
+          "Eligible Now If Balance Paid",
           [
-            "Baker 100000 \u2013 $1000.0",
             [
+              "Baker 100000 \u2013 $1000.0",
               [
-                "100000-1",
-                "Disorderly Conduct in the First Degree (CONVICTED) Charged Jan 21, 2019",
-              ],
-              [
-                "100000-2",
-                "Disorderly Conduct in the Second Degree (DISMISSED) Charged Jan 21, 2019",
+                [
+                  "100000-1",
+                  "Disorderly Conduct in the First Degree (CONVICTED) Charged Jan 21, 2019",
+                ],
+                [
+                  "100000-2",
+                  "Disorderly Conduct in the Second Degree (DISMISSED) Charged Jan 21, 2019",
+                ],
               ],
             ],
           ],
         ],
-      },
+      ],
       county_fines: [
         {
           case_fines: [{ balance: 1000.0, case_number: "100000" }],


### PR DESCRIPTION
additional requests on #1656 

This changes the data type of sections returned by the summarizer so that it retains the order we build it in.