### PR TITLE
Fixes for Eligible charge on case with ineligible charge

### DIFF
--- a/src/frontend/src/components/RecordSearch/Record/RecordSummary/ChargesList.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/RecordSummary/ChargesList.tsx
@@ -26,7 +26,7 @@ function getEligibilityColor(eligibility: string) {
     {
       "Eligible Now": "green",
       Ineligible: "red",
-      "Eligible on case with Ineligible charge": "red",
+      "Eligible on case with Ineligible charge": "green",
       "Needs More Analysis": "purple",
     }[eligibility] ?? "dark-blue"
   );

--- a/src/frontend/src/components/RecordSearch/Record/RecordSummary/index.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/RecordSummary/index.tsx
@@ -30,7 +30,7 @@ export default function RecordSummary() {
 
   const handleGenerateFormsClick = () => {
     if (
-      groupedCharges?.filter((x) => x[0] === "Eligible Now")[0][1]?.length > 0
+      groupedCharges?.filter((x) => x[0] === "Eligible Now" || x[0] === "Eligible on case with Ineligible charge")[0][1]?.length > 0
     ) {
       history.push("/fill-expungement-forms");
     } else {


### PR DESCRIPTION
A few change requests from users:

1. Paperwork should be generated if this is the only type of eligible charge
2. The header for this type in the summary should be green
