### PR TITLE
Workaround for retry failure

### DIFF
--- a/src/backend/expungeservice/crawler/crawler.py
+++ b/src/backend/expungeservice/crawler/crawler.py
@@ -47,7 +47,8 @@ class Crawler:
     @staticmethod
     def fetch_link(link: str, session: Session = None):
         if session:
-            response = session.get(link)
+            headers = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:90.0) Gecko/20100101 Firefox/90.0"}
+            response = session.get(link, headers=headers)
             Crawler.cached_links[link] = response
             return response
         else:


### PR DESCRIPTION
```
HTTPSConnectionPool(host='publicaccess.courts.oregon.gov', port=443): Max retries exceeded with url: /PublicAccessLogin/CaseDetail.aspx?CaseID=... (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7fdabbbb3d50>: Failed to establish a new connection: Errno -3 Try again'))
```