### PR TITLE
Ask if violations are traffic related

### DIFF
--- a/src/backend/expungeservice/charge_classifier.py
+++ b/src/backend/expungeservice/charge_classifier.py
@@ -108,9 +108,13 @@ class ChargeClassifier:
     def _violation(level, name):
         if "violation" in level:
             if "reduced" in name or "treated as" in name:
-                return AmbiguousChargeTypeWithQuestion([ReducedToViolation()])
+                question_string = "For Multnomah County only: Was the underlying charge traffic-related?"
+                options = {"Yes": TrafficViolation(), "No (or not Multnomah County)": ReducedToViolation()}
+                return ChargeClassifier._build_ambiguous_charge_type_with_question(question_string, options)
             else:
-                return AmbiguousChargeTypeWithQuestion([Violation()])
+                question_string = "For Multnomah County only: Was the underlying charge traffic-related?"
+                options = {"Yes": TrafficViolation(), "No (or not Multnomah County)": Violation()}
+                return ChargeClassifier._build_ambiguous_charge_type_with_question(question_string, options)
 
     @staticmethod
     def _drug_crime(

--- a/src/backend/expungeservice/charge_creator.py
+++ b/src/backend/expungeservice/charge_creator.py
@@ -19,8 +19,9 @@ class ChargeCreator:
         section = ChargeCreator._set_section(statute)
         birth_year = kwargs.get("birth_year")
         disposition = kwargs["disposition"]
+        location = kwargs["location"]
         ambiguous_charge_type_with_questions = ChargeClassifier(
-            violation_type, name, statute, level, section, birth_year, disposition
+            violation_type, name, statute, level, section, birth_year, disposition, location
         ).classify()
         kwargs["statute"] = statute
         kwargs["ambiguous_charge_id"] = ambiguous_charge_id

--- a/src/backend/expungeservice/demo_records.py
+++ b/src/backend/expungeservice/demo_records.py
@@ -551,4 +551,36 @@ class DemoRecords:
                 ),
             ),
         ],
+        Alias("single", "violation", "", ""): [
+            OeciCase(
+                summary=from_dict(
+                    data_class=CaseSummary,
+                    data={
+                        **shared_case_data,
+                        "current_status": "Closed",
+                        "name": "John Notaperson",
+                        "case_number": "123456",
+                        "violation_type": "Offense Violation",
+                        "balance_due_in_cents": 0,
+                    },
+                ),
+                charges=(
+                    from_dict(
+                        data_class=OeciCharge,
+                        data={
+                            **shared_charge_data,
+                            "ambiguous_charge_id": "123456-1",
+                            "name": "Assaulting a Public Safety Officer",
+                            "statute": "163.208",
+                            "level": "Violation",
+                            "date": date_class.today() - relativedelta(years=2),
+                            "disposition": DispositionCreator.create(
+                                date=date_class.today() - relativedelta(years=1, months=9), ruling="Convicted"
+                            ),
+                            "balance_due_in_cents": 50000,
+                        },
+                    ),
+                ),
+            ),
+        ],
     }

--- a/src/backend/expungeservice/demo_records.py
+++ b/src/backend/expungeservice/demo_records.py
@@ -570,7 +570,38 @@ class DemoRecords:
                         data={
                             **shared_charge_data,
                             "ambiguous_charge_id": "123456-1",
-                            "name": "Assaulting a Public Safety Officer",
+                            "name": "Something minor",
+                            "statute": "163.208",
+                            "level": "Violation",
+                            "date": date_class.today() - relativedelta(years=2),
+                            "disposition": DispositionCreator.create(
+                                date=date_class.today() - relativedelta(years=1, months=9), ruling="Convicted"
+                            ),
+                            "balance_due_in_cents": 50000,
+                        },
+                    ),
+                ),
+            ),
+            OeciCase(
+                summary=from_dict(
+                    data_class=CaseSummary,
+                    data={
+                        **shared_case_data,
+                        "current_status": "Closed",
+                        "name": "John Notaperson",
+                        "case_number": "1234567",
+                        "violation_type": "Offense Violation",
+                        "balance_due_in_cents": 0,
+                        "location":"Benton"
+                    },
+                ),
+                charges=(
+                    from_dict(
+                        data_class=OeciCharge,
+                        data={
+                            **shared_charge_data,
+                            "ambiguous_charge_id": "1234567-1",
+                            "name": "Something minor",
                             "statute": "163.208",
                             "level": "Violation",
                             "date": date_class.today() - relativedelta(years=2),

--- a/src/backend/expungeservice/record_creator.py
+++ b/src/backend/expungeservice/record_creator.py
@@ -170,6 +170,7 @@ class RecordCreator:
                 "balance_due_in_cents": oeci_charge.balance_due_in_cents,
                 "case_number": oeci_case.summary.case_number,
                 "violation_type": oeci_case.summary.violation_type,
+                "location": oeci_case.summary.location,
                 "birth_year": oeci_case.summary.birth_year,
                 "edit_status": EditStatus(oeci_charge.edit_status),
             }

--- a/src/backend/tests/factories/charge_factory.py
+++ b/src/backend/tests/factories/charge_factory.py
@@ -18,8 +18,9 @@ class ChargeFactory:
         date: date_class = None,
         disposition: Disposition = DispositionCreator.empty(),
         violation_type="Offense Misdemeanor",
+        location="Benton"
     ) -> Charge:
-        charges = cls._build_ambiguous_charge(case_number, date, disposition, level, name, statute, violation_type)
+        charges = cls._build_ambiguous_charge(case_number, date, disposition, level, name, statute, violation_type, location)
         assert len(charges) == 1
         return charges[0]
 
@@ -33,11 +34,12 @@ class ChargeFactory:
         date: date_class = None,
         disposition: Disposition = DispositionCreator.empty(),
         violation_type="Offense Misdemeanor",
+        location="Benton"
     ) -> AmbiguousCharge:
-        return cls._build_ambiguous_charge(case_number, date, disposition, level, name, statute, violation_type)
+        return cls._build_ambiguous_charge(case_number, date, disposition, level, name, statute, violation_type, location)
 
     @classmethod
-    def _build_ambiguous_charge(cls, case_number, date, disposition, level, name, statute, violation_type):
+    def _build_ambiguous_charge(cls, case_number, date, disposition, level, name, statute, violation_type, location):
         cls.charge_count += 1
         if disposition.status != DispositionStatus.UNKNOWN and not date:
             updated_date = disposition.date
@@ -53,6 +55,7 @@ class ChargeFactory:
             "date": updated_date,
             "disposition": disposition,
             "violation_type": violation_type,
+            "location": location,
             "balance_due_in_cents": 0,
             "edit_status": EditStatus.UNCHANGED,
         }
@@ -68,6 +71,7 @@ class ChargeFactory:
         level="Misdemeanor Class A",
         date=date_class(1901, 1, 1),
         violation_type="Offense Misdemeanor",
+        location="Benton"
     ) -> Charge:
         cls.charge_count += 1
         disposition = DispositionCreator.create(date=date_class.today(), ruling="Dismissed")
@@ -79,6 +83,7 @@ class ChargeFactory:
             "date": date,
             "disposition": disposition,
             "violation_type": violation_type,
+            "location": location,
             "balance_due_in_cents": 0,
             "edit_status": EditStatus.UNCHANGED,
         }

--- a/src/backend/tests/models/charge_types/test_reduced_to_violation.py
+++ b/src/backend/tests/models/charge_types/test_reduced_to_violation.py
@@ -1,17 +1,19 @@
 from expungeservice.models.expungement_result import EligibilityStatus
 from expungeservice.models.charge_types.reduced_to_violation import ReducedToViolation
+from expungeservice.models.charge_types.traffic_violation import TrafficViolation
+from expungeservice.record_merger import RecordMerger
 
 from tests.factories.charge_factory import ChargeFactory
 from tests.models.test_charge import Dispositions
 
 
 def test_reduced_to_violation_convicted():
-    charge = ChargeFactory.create(
+    charge = ChargeFactory.create_ambiguous_charge(
         name="Theft in the Second Degree (Reduced - DA Elected)",
         statute="164045",
         level="Violation Class A",
         disposition=Dispositions.CONVICTED,
-    )
+    )[1]
 
     assert isinstance(charge.charge_type, ReducedToViolation)
     assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
@@ -19,32 +21,40 @@ def test_reduced_to_violation_convicted():
 
 
 def test_reduced_to_violation_dismissed():
-    charge = ChargeFactory.create(
+    charges = ChargeFactory.create_ambiguous_charge(
         name="Misdemeanor Treated as a Violation",
         statute="161.566(1)",
         level="Violation Class A",
         disposition=Dispositions.DISMISSED,
     )
 
-    assert isinstance(charge.charge_type, ReducedToViolation)
-    assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert charge.type_eligibility.reason == "Dismissed criminal charge eligible under 137.225(1)(b)"
+    type_eligibility = RecordMerger.merge_type_eligibilities(charges)
+
+    assert type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert (
+        type_eligibility.reason
+        == "Traffic Violation – Dismissed violations are eligible under 137.225(1)(b) but administrative reasons may make this difficult to expunge. OR Reduced to Violation – Dismissed criminal charge eligible under 137.225(1)(b)"
+    )
+    assert isinstance(charges[0].charge_type, TrafficViolation)
+    assert isinstance(charges[1].charge_type, ReducedToViolation)
 
 
 def test_reduced_to_violation_unrecognized_disposition():
-    charge = ChargeFactory.create(
+    charges = ChargeFactory.create_ambiguous_charge(
         name="Theft in the Second Degree (Reduced - DA Elected)",
         statute="164045",
         level="Violation Class A",
         disposition=Dispositions.UNRECOGNIZED_DISPOSITION,
     )
+    type_eligibility = RecordMerger.merge_type_eligibilities(charges)
 
-    assert isinstance(charge.charge_type, ReducedToViolation)
-    assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
     assert (
-        charge.type_eligibility.reason
-        == "Reduced Violations are always eligible under 137.225(5)(d) for convictions, or 137.225(1)(b) for dismissals"
+        type_eligibility.reason
+        == "Traffic Violation – Always ineligible under 137.225(7)(a) (for convictions) or by omission from statute (for dismissals) OR Reduced to Violation – Reduced Violations are always eligible under 137.225(5)(d) for convictions, or 137.225(1)(b) for dismissals"
     )
+    assert isinstance(charges[0].charge_type, TrafficViolation)
+    assert isinstance(charges[1].charge_type, ReducedToViolation)
 
 
 def test_reduced_violation_ineligible_under_other_criterion():

--- a/src/backend/tests/models/charge_types/test_reduced_to_violation.py
+++ b/src/backend/tests/models/charge_types/test_reduced_to_violation.py
@@ -8,12 +8,12 @@ from tests.models.test_charge import Dispositions
 
 
 def test_reduced_to_violation_convicted():
-    charge = ChargeFactory.create_ambiguous_charge(
+    charge = ChargeFactory.create(
         name="Theft in the Second Degree (Reduced - DA Elected)",
         statute="164045",
         level="Violation Class A",
         disposition=Dispositions.CONVICTED,
-    )[1]
+    )
 
     assert isinstance(charge.charge_type, ReducedToViolation)
     assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
@@ -21,11 +21,39 @@ def test_reduced_to_violation_convicted():
 
 
 def test_reduced_to_violation_dismissed():
+    charge = ChargeFactory.create(
+        name="Misdemeanor Treated as a Violation",
+        statute="161.566(1)",
+        level="Violation Class A",
+        disposition=Dispositions.DISMISSED,
+    )
+
+    assert isinstance(charge.charge_type, ReducedToViolation)
+    assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert charge.type_eligibility.reason == "Dismissed criminal charge eligible under 137.225(1)(b)"
+
+
+def test_reduced_to_violation_multnomah_convicted():
+    charge = ChargeFactory.create_ambiguous_charge(
+        name="Theft in the Second Degree (Reduced - DA Elected)",
+        statute="164045",
+        level="Violation Class A",
+        disposition=Dispositions.CONVICTED,
+        location="Multnomah"
+    )[1]
+
+    assert isinstance(charge.charge_type, ReducedToViolation)
+    assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert charge.type_eligibility.reason == "Eligible under 137.225(5)(d)"
+
+
+def test_reduced_to_violation_multnomah_dismissed():
     charges = ChargeFactory.create_ambiguous_charge(
         name="Misdemeanor Treated as a Violation",
         statute="161.566(1)",
         level="Violation Class A",
         disposition=Dispositions.DISMISSED,
+        location="Multnomah"
     )
 
     type_eligibility = RecordMerger.merge_type_eligibilities(charges)
@@ -39,12 +67,14 @@ def test_reduced_to_violation_dismissed():
     assert isinstance(charges[1].charge_type, ReducedToViolation)
 
 
-def test_reduced_to_violation_unrecognized_disposition():
+def test_reduced_to_violation_multnomah_unrecognized_disposition():
     charges = ChargeFactory.create_ambiguous_charge(
         name="Theft in the Second Degree (Reduced - DA Elected)",
         statute="164045",
         level="Violation Class A",
         disposition=Dispositions.UNRECOGNIZED_DISPOSITION,
+        location="Multnomah"
+
     )
     type_eligibility = RecordMerger.merge_type_eligibilities(charges)
 

--- a/src/backend/tests/models/charge_types/test_violation.py
+++ b/src/backend/tests/models/charge_types/test_violation.py
@@ -6,10 +6,28 @@ from expungeservice.models.charge_types.traffic_violation import TrafficViolatio
 from tests.factories.charge_factory import ChargeFactory
 from tests.models.test_charge import Dispositions
 
-
 def test_violation_convicted():
-    charges = ChargeFactory.create_ambiguous_charge(
+    charge = ChargeFactory.create(
         name="Viol Treatment", statute="1615662", level="Violation Unclassified", disposition=Dispositions.CONVICTED
+    )
+
+    assert isinstance(charge.charge_type, Violation)
+    assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert charge.type_eligibility.reason == "Eligible under 137.225(5)(c)"
+
+
+def test_violation_dismissed():
+    charge = ChargeFactory.create(
+        name="Viol Treatment", statute="1615662", level="Violation Unclassified", disposition=Dispositions.DISMISSED
+    )
+
+    assert isinstance(charge.charge_type, Violation)
+    assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
+    assert charge.type_eligibility.reason == "Eligible under 137.225(1)(b)"
+    
+def test_violation_multnomah_convicted():
+    charges = ChargeFactory.create_ambiguous_charge(
+        name="Viol Treatment", statute="1615662", level="Violation Unclassified", disposition=Dispositions.CONVICTED, location="Multnomah"
     )
     type_eligibility = RecordMerger.merge_type_eligibilities(charges)
 
@@ -22,9 +40,9 @@ def test_violation_convicted():
     assert isinstance(charges[1].charge_type, Violation)
 
 
-def test_violation_dismissed():
+def test_violation_multnomah_dismissed():
     charges = ChargeFactory.create_ambiguous_charge(
-        name="Viol Treatment", statute="1615662", level="Violation Unclassified", disposition=Dispositions.DISMISSED
+        name="Viol Treatment", statute="1615662", level="Violation Unclassified", disposition=Dispositions.DISMISSED, location="Multnomah"
     )
     type_eligibility = RecordMerger.merge_type_eligibilities(charges)
 

--- a/src/backend/tests/models/charge_types/test_violation.py
+++ b/src/backend/tests/models/charge_types/test_violation.py
@@ -1,25 +1,37 @@
 from expungeservice.models.expungement_result import EligibilityStatus
 from expungeservice.models.charge_types.violation import Violation
+from expungeservice.record_merger import RecordMerger
+from expungeservice.models.charge_types.traffic_violation import TrafficViolation
 
 from tests.factories.charge_factory import ChargeFactory
 from tests.models.test_charge import Dispositions
 
 
 def test_violation_convicted():
-    charge = ChargeFactory.create(
+    charges = ChargeFactory.create_ambiguous_charge(
         name="Viol Treatment", statute="1615662", level="Violation Unclassified", disposition=Dispositions.CONVICTED
     )
+    type_eligibility = RecordMerger.merge_type_eligibilities(charges)
 
-    assert isinstance(charge.charge_type, Violation)
-    assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert charge.type_eligibility.reason == "Eligible under 137.225(5)(c)"
+    assert type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert (
+        type_eligibility.reason
+        == "Traffic Violation – Ineligible under 137.225(7)(a) OR Violation – Eligible under 137.225(5)(c)"
+    )
+    assert isinstance(charges[0].charge_type, TrafficViolation)
+    assert isinstance(charges[1].charge_type, Violation)
 
 
 def test_violation_dismissed():
-    charge = ChargeFactory.create(
+    charges = ChargeFactory.create_ambiguous_charge(
         name="Viol Treatment", statute="1615662", level="Violation Unclassified", disposition=Dispositions.DISMISSED
     )
+    type_eligibility = RecordMerger.merge_type_eligibilities(charges)
 
-    assert isinstance(charge.charge_type, Violation)
-    assert charge.type_eligibility.status is EligibilityStatus.ELIGIBLE
-    assert charge.type_eligibility.reason == "Eligible under 137.225(1)(b)"
+    assert type_eligibility.status is EligibilityStatus.NEEDS_MORE_ANALYSIS
+    assert (
+        type_eligibility.reason
+        == "Traffic Violation – Dismissed violations are eligible under 137.225(1)(b) but administrative reasons may make this difficult to expunge. OR Violation – Eligible under 137.225(1)(b)"
+    )
+    assert isinstance(charges[0].charge_type, TrafficViolation)
+    assert isinstance(charges[1].charge_type, Violation)

--- a/src/backend/tests/test_time_analyzer.py
+++ b/src/backend/tests/test_time_analyzer.py
@@ -29,17 +29,17 @@ class TestSingleChargeDismissals(unittest.TestCase):
             disposition=DispositionCreator.create(ruling="Dismissed", date=Time.THREE_YEARS_AGO),
         )
 
-        violation = ChargeFactory.create_ambiguous_charge(
+        violation = ChargeFactory.create(
             level="Violation",
             case_number="1",
             disposition=DispositionCreator.create(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO),
-        )[1]
+        )
 
-        violation_2 = ChargeFactory.create_ambiguous_charge(
+        violation_2 = ChargeFactory.create(
             level="Violation",
             case_number="1",
             disposition=DispositionCreator.create(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO),
-        )[1]
+        )
         case = CaseFactory.create(charges=tuple([three_yr_conviction, arrest, violation, violation_2]))
         record = Record(tuple([case]))
         expunger_result = Expunger.run(record)
@@ -472,11 +472,11 @@ def test_doubly_eligible_b_felony_gets_normal_eligibility_rule():
 
 def test_single_violation_is_time_restricted():
     # A single violation doesn't block other records, but it is still subject to the 3 year rule.
-    violation_charge = ChargeFactory.create_ambiguous_charge(
+    violation_charge = ChargeFactory.create(
         level="Class A Violation",
         date=Time.TEN_YEARS_AGO,
         disposition=DispositionCreator.create(ruling="Convicted", date=Time.LESS_THAN_ONE_YEAR_AGO),
-    )[1]
+    )
 
     case = CaseFactory.create(charges=tuple([violation_charge]))
     expunger_result = Expunger.run(Record(tuple([case])))
@@ -492,16 +492,16 @@ def test_single_violation_is_time_restricted():
 
 
 def test_2_violations_are_time_restricted():
-    violation_charge_1 = ChargeFactory.create_ambiguous_charge(
+    violation_charge_1 = ChargeFactory.create(
         level="Class A Violation",
         date=Time.THREE_YEARS_AGO,
         disposition=DispositionCreator.create(ruling="Convicted", date=Time.THREE_YEARS_AGO),
-    )[1]
-    violation_charge_2 = ChargeFactory.create_ambiguous_charge(
+    )
+    violation_charge_2 = ChargeFactory.create(
         level="Class A Violation",
         date=Time.TWO_YEARS_AGO,
         disposition=DispositionCreator.create(ruling="Convicted", date=Time.TWO_YEARS_AGO),
-    )[1]
+    )
 
     case = CaseFactory.create(charges=tuple([violation_charge_1, violation_charge_2]))
     expunger_result = Expunger.run(Record(tuple([case])))
@@ -521,21 +521,21 @@ def test_2_violations_are_time_restricted():
     )
 
 def test_3_violations_are_time_restricted():
-    violation_charge_1 = ChargeFactory.create_ambiguous_charge(
+    violation_charge_1 = ChargeFactory.create(
         level="Class A Violation",
         date=Time.TWO_YEARS_AGO,
         disposition=DispositionCreator.create(ruling="Convicted", date=Time.LESS_THAN_TWO_YEARS_AGO),
-    )[1]
-    violation_charge_2 = ChargeFactory.create_ambiguous_charge(
+    )
+    violation_charge_2 = ChargeFactory.create(
         level="Class A Violation",
         date=Time.ONE_YEAR_AGO,
         disposition=DispositionCreator.create(ruling="Convicted", date=Time.LESS_THAN_ONE_YEAR_AGO),
-    )[1]
-    violation_charge_3 = ChargeFactory.create_ambiguous_charge(
+    )
+    violation_charge_3 = ChargeFactory.create(
         level="Class A Violation",
         date=Time.YESTERDAY,
         disposition=DispositionCreator.create(ruling="Convicted", date=Time.YESTERDAY),
-    )[1]
+    )
 
     case = CaseFactory.create(charges=tuple([violation_charge_3, violation_charge_2, violation_charge_1]))
     expunger_result = Expunger.run(Record(tuple([case])))
@@ -573,11 +573,11 @@ def test_nonblocking_charge_is_not_skipped_and_does_not_block():
         level="N/A", statute="1.000", disposition=DispositionCreator.create(ruling="Convicted", date=Time.ONE_YEAR_AGO)
     )
 
-    violation_charge = ChargeFactory.create_ambiguous_charge(
+    violation_charge = ChargeFactory.create(
         level="Class A Violation",
         date=Time.TEN_YEARS_AGO,
         disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO),
-    )[1]
+    )
 
     case = CaseFactory.create(charges=tuple([civil_offense, violation_charge]))
     expunger_result = Expunger.run(Record(tuple([case])))

--- a/src/backend/tests/test_time_analyzer.py
+++ b/src/backend/tests/test_time_analyzer.py
@@ -29,17 +29,17 @@ class TestSingleChargeDismissals(unittest.TestCase):
             disposition=DispositionCreator.create(ruling="Dismissed", date=Time.THREE_YEARS_AGO),
         )
 
-        violation = ChargeFactory.create(
+        violation = ChargeFactory.create_ambiguous_charge(
             level="Violation",
             case_number="1",
             disposition=DispositionCreator.create(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO),
-        )
+        )[1]
 
-        violation_2 = ChargeFactory.create(
+        violation_2 = ChargeFactory.create_ambiguous_charge(
             level="Violation",
             case_number="1",
             disposition=DispositionCreator.create(ruling="Convicted", date=Time.LESS_THAN_THREE_YEARS_AGO),
-        )
+        )[1]
         case = CaseFactory.create(charges=tuple([three_yr_conviction, arrest, violation, violation_2]))
         record = Record(tuple([case]))
         expunger_result = Expunger.run(record)
@@ -472,11 +472,11 @@ def test_doubly_eligible_b_felony_gets_normal_eligibility_rule():
 
 def test_single_violation_is_time_restricted():
     # A single violation doesn't block other records, but it is still subject to the 3 year rule.
-    violation_charge = ChargeFactory.create(
+    violation_charge = ChargeFactory.create_ambiguous_charge(
         level="Class A Violation",
         date=Time.TEN_YEARS_AGO,
         disposition=DispositionCreator.create(ruling="Convicted", date=Time.LESS_THAN_ONE_YEAR_AGO),
-    )
+    )[1]
 
     case = CaseFactory.create(charges=tuple([violation_charge]))
     expunger_result = Expunger.run(Record(tuple([case])))
@@ -492,16 +492,16 @@ def test_single_violation_is_time_restricted():
 
 
 def test_2_violations_are_time_restricted():
-    violation_charge_1 = ChargeFactory.create(
+    violation_charge_1 = ChargeFactory.create_ambiguous_charge(
         level="Class A Violation",
         date=Time.THREE_YEARS_AGO,
         disposition=DispositionCreator.create(ruling="Convicted", date=Time.THREE_YEARS_AGO),
-    )
-    violation_charge_2 = ChargeFactory.create(
+    )[1]
+    violation_charge_2 = ChargeFactory.create_ambiguous_charge(
         level="Class A Violation",
         date=Time.TWO_YEARS_AGO,
         disposition=DispositionCreator.create(ruling="Convicted", date=Time.TWO_YEARS_AGO),
-    )
+    )[1]
 
     case = CaseFactory.create(charges=tuple([violation_charge_1, violation_charge_2]))
     expunger_result = Expunger.run(Record(tuple([case])))
@@ -521,21 +521,21 @@ def test_2_violations_are_time_restricted():
     )
 
 def test_3_violations_are_time_restricted():
-    violation_charge_1 = ChargeFactory.create(
+    violation_charge_1 = ChargeFactory.create_ambiguous_charge(
         level="Class A Violation",
         date=Time.TWO_YEARS_AGO,
         disposition=DispositionCreator.create(ruling="Convicted", date=Time.LESS_THAN_TWO_YEARS_AGO),
-    )
-    violation_charge_2 = ChargeFactory.create(
+    )[1]
+    violation_charge_2 = ChargeFactory.create_ambiguous_charge(
         level="Class A Violation",
         date=Time.ONE_YEAR_AGO,
         disposition=DispositionCreator.create(ruling="Convicted", date=Time.LESS_THAN_ONE_YEAR_AGO),
-    )
-    violation_charge_3 = ChargeFactory.create(
+    )[1]
+    violation_charge_3 = ChargeFactory.create_ambiguous_charge(
         level="Class A Violation",
         date=Time.YESTERDAY,
         disposition=DispositionCreator.create(ruling="Convicted", date=Time.YESTERDAY),
-    )
+    )[1]
 
     case = CaseFactory.create(charges=tuple([violation_charge_3, violation_charge_2, violation_charge_1]))
     expunger_result = Expunger.run(Record(tuple([case])))
@@ -573,11 +573,11 @@ def test_nonblocking_charge_is_not_skipped_and_does_not_block():
         level="N/A", statute="1.000", disposition=DispositionCreator.create(ruling="Convicted", date=Time.ONE_YEAR_AGO)
     )
 
-    violation_charge = ChargeFactory.create(
+    violation_charge = ChargeFactory.create_ambiguous_charge(
         level="Class A Violation",
         date=Time.TEN_YEARS_AGO,
         disposition=DispositionCreator.create(ruling="Convicted", date=Time.TEN_YEARS_AGO),
-    )
+    )[1]
 
     case = CaseFactory.create(charges=tuple([civil_offense, violation_charge]))
     expunger_result = Expunger.run(Record(tuple([case])))


### PR DESCRIPTION
This was a request from Michael and team. In multnomah county they need to identify Violations and Reduced to Violations as possibly traffic-related even if OECI doesn't reflect them as such.

In my first commit I tried to avoid a major change to the classifier by making the question specify the county, but I discovered this looks bad:

<img width="1032" alt="Screenshot 2023-10-27 at 2 18 21 PM" src="https://github.com/codeforpdx/recordexpungPDX/assets/2104990/3251211a-8021-4a01-bedc-b4443c4200ee">

So in my second commit I add the location argument to the charge creator and classifier. Now the charge is NMA only in Multnomah County:



<img width="1053" alt="Screenshot 2023-10-27 at 2 39 51 PM" src="https://github.com/codeforpdx/recordexpungPDX/assets/2104990/50cff918-cf1f-4d72-bb41-bc4d92ed0b7e">
