### PR TITLE
Match header change to properly detect partially eligible case

### DIFF
--- a/src/frontend/src/components/RecordSearch/Record/RecordSummary/index.tsx
+++ b/src/frontend/src/components/RecordSearch/Record/RecordSummary/index.tsx
@@ -34,7 +34,7 @@ export default function RecordSummary() {
       (x) => x[0] === "Eligible Now"
     );
     const chargesEligibleOnIneligible = groupedCharges?.filter(
-      (x) => x[0] === "Eligible on case with Ineligible charge"
+      (x) => x[0] === "Eligible Now on case with Ineligible charge"
     );
     if (
       (chargesEligibleNow[0] && chargesEligibleNow[0][1].length > 0) ||


### PR DESCRIPTION
This fixes a bug that was introduced in #1712 , because the frontend wasn't updated to check the new header name for partially eligible cases. The bug was that a record with no fully eligible cases but with a partially eligible case could not generate paperwork.

